### PR TITLE
Improve code review check to account for diff author-committer usecase.

### DIFF
--- a/checks/code_review.go
+++ b/checks/code_review.go
@@ -76,11 +76,11 @@ func GithubCodeReview(c checker.Checker) checker.CheckResult {
 		// time on clicking the approve button.
 		if !foundApprovedReview {
 			commit, _, err := c.Client.Repositories.GetCommit(c.Ctx, c.Owner, c.Repo, pr.GetMergeCommitSHA())
-			if err != nil {
+			if err == nil {
 				commitAuthor := commit.GetAuthor().GetLogin()
 				commitCommitter := commit.GetCommitter().GetLogin()
 				if commitAuthor != "" && commitCommitter != "" && commitAuthor != commitCommitter {
-					c.Logf("found different author and committer for pr: %d", pr.GetNumber())
+					c.Logf("found pr with committer different than author: %d", pr.GetNumber())
 					totalReviewed++
 				}
 			}

--- a/checks/code_review.go
+++ b/checks/code_review.go
@@ -55,17 +55,37 @@ func GithubCodeReview(c checker.Checker) checker.CheckResult {
 			continue
 		}
 		totalMerged++
-		// Merged PR!
+
+		// check if the PR is approved by a reviewer
+		foundApprovedReview := false
 		reviews, _, err := c.Client.PullRequests.ListReviews(c.Ctx, c.Owner, c.Repo, pr.GetNumber(), &github.ListOptions{})
 		if err != nil {
 			continue
 		}
 		for _, r := range reviews {
 			if r.GetState() == "APPROVED" {
+				c.Logf("found review approved pr: %d", pr.GetNumber())
 				totalReviewed++
+				foundApprovedReview = true
 				break
 			}
 		}
+
+		// check if the PR is committed by someone other than author. this is kind
+		// of equivalent to a review and is done several times on small prs to save
+		// time on clicking the approve button.
+		if !foundApprovedReview {
+			commit, _, err := c.Client.Repositories.GetCommit(c.Ctx, c.Owner, c.Repo, pr.GetMergeCommitSHA())
+			if err != nil {
+				commitAuthor := commit.GetAuthor().GetLogin()
+				commitCommitter := commit.GetCommitter().GetLogin()
+				if commitAuthor != "" && commitCommitter != "" && commitAuthor != commitCommitter {
+					c.Logf("found different author and committer for pr: %d", pr.GetNumber())
+					totalReviewed++
+				}
+			}
+		}
+
 	}
 
 	if totalReviewed > 0 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,6 +113,7 @@ type checkResult struct {
 	CheckName  string
 	Pass       bool
 	Confidence int
+	Details    []string
 }
 
 type record struct {
@@ -127,11 +128,17 @@ func outputJSON(results []pkg.Result) {
 		Repo: repo.String(),
 		Date: d.Format("2006-01-02"),
 	}
+
 	for _, r := range results {
+		var details []string
+		if showDetails {
+			details = r.Cr.Details
+		}
 		or.Checks = append(or.Checks, checkResult{
 			CheckName:  r.Name,
 			Pass:       r.Cr.Pass,
 			Confidence: r.Cr.Confidence,
+			Details:    details,
 		})
 	}
 	output, err := json.Marshal(or)


### PR DESCRIPTION
See
```
$ go run . --repo=https://github.com/protocolbuffers/protobuf --show-details --checks=Code-Review
Starting [Code-Review]
Finished [Code-Review]

RESULTS
-------
Code-Review: Pass 9
    found different author and committer for pr: 8053
    found different author and committer for pr: 8052
    found review approved pr: 8048
    found review approved pr: 8045
    found different author and committer for pr: 8043
    found review approved pr: 8035
    found review approved pr: 8032
    found review approved pr: 8030
    found review approved pr: 8029
    found review approved pr: 8028
    found review approved pr: 8026
    found review approved pr: 8025
    found review approved pr: 8024
    found review approved pr: 8023
    found review approved pr: 8022
    found different author and committer for pr: 8014
    found different author and committer for pr: 8013
    found review approved pr: 8011
    found review approved pr: 8010
    found review approved pr: 8006
    found review approved pr: 8005
    found different author and committer for pr: 8003
    found review approved pr: 8000
    found different author and committer for pr: 7997
    github code reviews found
```