### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ The program only requires one argument to run, the name of the repo:
 
 ```shell
 $ go build
-$ ./scorecard --repo=github.com/kubernetes/kubernetes
+$ ./scorecard --repo=https://github.com/kubernetes/kubernetes
 Starting [Active]
 Starting [CI-Tests]
 Starting [CII-Best-Practices]


### PR DESCRIPTION
The getting started readme example was:

> ./scorecard --repo=github.com/kubernetes/kubernetes

Which results in:
`Error: invalid argument "github.com/kubernetes/kubernetes" for "--repo" flag: unsupported host:`

So it has been corrected to include the scheme:
```
./scorecard --repo=https://github.com/kubernetes/kubernetes
```