### PR TITLE
Use release tag name instead of name in log messages

### DIFF
--- a/checks/signed_releases.go
+++ b/checks/signed_releases.go
@@ -45,7 +45,7 @@ func SignedReleases(c checker.Checker) checker.CheckResult {
 		if len(assets) == 0 {
 			continue
 		}
-		c.Logf("release found: %s", r.GetName())
+		c.Logf("release found: %s", r.GetTagName())
 		totalReleases++
 		signed := false
 		for _, asset := range assets {
@@ -62,7 +62,7 @@ func SignedReleases(c checker.Checker) checker.CheckResult {
 			}
 		}
 		if !signed {
-			c.Logf("!! release %s has no signed artifacts", r.GetName())
+			c.Logf("!! release %s has no signed artifacts", r.GetTagName())
 		}
 		if totalReleases > releaseLookBack {
 			break


### PR DESCRIPTION
Use the release TagName instead of Name when reporting found releases.
An example of the problem using Name:
```
$ go run . --repo=github.com/magefile/mage --show-details --checks=Signed-Releases
Starting [Signed-Releases]
Finished [Signed-Releases]

RESULTS
-------
Signed-Releases: Fail 10
    release found: Colors, working directory, some better errors
    !! release Colors, working directory, some better errors has no signed artifacts
    release found: Modules and go1.13 Fixes
    !! release Modules and go1.13 Fixes has no signed artifacts
    release found: v1.8.0 - Papercuts and Bug Fixes
    !! release v1.8.0 - Papercuts and Bug Fixes has no signed artifacts
    release found: v1.7.1
    !! release v1.7.1 has no signed artifacts
    release found: v1.7.0 Mage Imports
    !! release v1.7.0 Mage Imports has no signed artifacts
    release found: v1.6.2 Bug Fixes
    !! release v1.6.2 Bug Fixes has no signed artifacts
    found signed artifacts for 0 out of 6 releases
```

With this commit:

```
Signed-Releases: Fail 10
    release found: v1.10.0
    !! release v1.10.0 has no signed artifacts
    release found: v1.9.0
    !! release v1.9.0 has no signed artifacts
    release found: v1.8.0
    !! release v1.8.0 has no signed artifacts
    release found: v1.7.1
    !! release v1.7.1 has no signed artifacts
    release found: v1.7.0
    !! release v1.7.0 has no signed artifacts
    release found: v1.6.2
    !! release v1.6.2 has no signed artifacts
    found signed artifacts for 0 out of 6 releases
```