### PR TITLE
Feat - implemented goreleaser for releases

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -1,0 +1,29 @@
+name: goreleaser
+
+on:
+  push:
+    tags:
+      - "*" # triggers only if push new tag version, like `0.8.4` or else
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      -
+        name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.15
+      -
+        name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v2
+        with:
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Implemented [goreleaser](https://github.com/goreleaser/goreleaser-action) for releasing the code to Github. The release would happen only for `tag` pushes

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>

The release would be automated and would be something like this. 
![image](https://user-images.githubusercontent.com/172697/103488093-0067a800-4dd8-11eb-8560-52748ba26f1c.png)

https://github.com/naveensrinivasan/scorecard/releases/tag/v1.4