### PR TITLE
feature - CODEOWNERS for GitHub branch protection feature

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+@inferno-chromium @dlorenc @kimsterv @naveensrinivasan


### PR DESCRIPTION
Included the codeowners for enabling branch protection "Require review from Code Owners"

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>