### PR TITLE
feature - Included the e2e into the PR workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,14 @@ jobs:
         run: make fmt
       - name: go mod tidy
         run: make tidy
-      - name: Run tests
+      - name: Run unit tests
         run: make test
       - name: Build
         run: make build
+      - name: Run e2e
+        env:  
+          GITHUB_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
+        run: |
+          go get github.com/onsi/ginkgo/ginkgo@v1.14.2
+          go mod download
+          make e2e

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,7 +23,7 @@ jobs:
         run: make build
       - name: Run e2e
         env:  
-          GITHUB_AUTH_TOKEN: ${{ secrets.GIT_AUTH_TOKEN }}
+          GITHUB_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
         run: |
           go get github.com/onsi/ginkgo/ginkgo@v1.14.2
           go mod download

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,14 @@ Following the targets that can be used to test your changes locally.
 | make all   | Runs go test,golangci lint checks, fmt, go mod tidy | yes                  |
 | make build | Runs go build                                       | yes                  |
 
+## Permission for GitHub personal access tokens
+
+The personal access tokens need scopes that are required are
+
+- `repo:status` - Access commit status
+- `repo_deployment` - Access deployment status
+- `public_repo` - Access public repositories
+
 ## Where the CI Tests are configured
 
 1. See the [action files](.github/workflows) to check its tests, and the scripts used on it.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,7 @@ Following the targets that can be used to test your changes locally.
 
 ## Permission for GitHub personal access tokens
 
-The personal access tokens need scopes that are required are
+The personal access token need the following scopes:
 
 - `repo:status` - Access commit status
 - `repo_deployment` - Access deployment status

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -33,7 +33,7 @@ func TestE2e(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	//making sure the GITHUB_AUTH_TOKEN is set prior to running e2e tests
+	// making sure the GITHUB_AUTH_TOKEN is set prior to running e2e tests
 	token, contains := os.LookupEnv("GITHUB_AUTH_TOKEN")
 
 	Expect(contains).ShouldNot(BeFalse(),

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"os"
 	"testing"
 
 	"github.com/google/go-github/v32/github"
@@ -32,6 +33,13 @@ func TestE2e(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
+	//making sure the GITHUB_AUTH_TOKEN is set prior to running e2e tests
+	token, contains := os.LookupEnv("GITHUB_AUTH_TOKEN")
+
+	Expect(contains).ShouldNot(BeFalse(),
+		"GITHUB_AUTH_TOKEN env variable is not set.The GITHUB_AUTH_TOKEN env variable has to be set to run e2e test.")
+	Expect(len(token)).ShouldNot(BeZero(), "Length of the GITHUB_AUTH_TOKEN env variable is zero.")
+
 	ctx := context.TODO()
 
 	logLevel := zap.LevelFlag("verbosity", zap.InfoLevel, "override the default log level")


### PR DESCRIPTION
- Validated the presence of the GITHU_AUTH_TOKEN variable presence before running the e2e.
- Update the contributing doc with scopes of the personal access token.
- Updated the workflow to include the e2e tests.

### Secret 
A secret name `GIT_AUTH_TOKEN` has to be created with Personal access token to run `e2e` before merging this PR.