### PR TITLE
Fix - dependabot githubactions location

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,6 @@ updates:
     interval: daily
   open-pull-requests-limit: 10
 - package-ecosystem: "github-actions"
-  directory: ".github/workflows"
+  directory: "/"
   schedule:
       interval: "daily"


### PR DESCRIPTION
The third time is a charm.

Fixes the path of the actions.

```
Dependabot couldn't find a .yml.

Dependabot requires a .yml to evaluate your Github_actions dependencies. It had expected to find one at the path: /.github/workflows/.github/workflows/<anything>.yml.

If this isn't a Github_actions project, you may wish to disable updates for it in the .github/dependabot.yml config file in this repo.
```