### PR TITLE
Feature - signing releases

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -20,6 +20,13 @@ jobs:
         with:
           go-version: 1.15
       -
+        name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@v3
+        with:
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          passphrase: ${{ secrets.PASSPHRASE }}
+      -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2
         with:
@@ -27,3 +34,4 @@ jobs:
           args: release --rm-dist
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,28 @@
-checksum:
+before:
+  hooks:
+    # You may remove this if you don't use go modules.
+    - go mod download
+builds:
+  - env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - windows
+      - darwin
+# List of combinations of GOOS + GOARCH + GOARM to ignore.
+    # Default is empty.
+    ignore:
+      - goos: darwin
+        goarch: 386
+      - goos: darwin
+        goarch: arm64
+archives:
+  - replacements:
+      linux: Linux
+      386: i386
+      amd64: x86_64
 
+checksum:
   # Algorithm to be used.
   # Accepted options are sha256, sha512, sha1, crc32, md5, sha224 and sha384.
   # Default is sha256.
@@ -8,3 +31,6 @@ changelog:
   # Set it to true if you wish to skip the changelog generation.
   # This may result in an empty release notes on GitHub/GitLab/Gitea.
   skip: true
+signs:
+  - artifacts: checksum
+    args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes/features)
Used it against the fork.
```
./scorecard --repo=https://github.com/naveensrinivasan/scorecard  --checks Signed-Releases --show-details
Starting [Signed-Releases]
Finished [Signed-Releases]

RESULTS
-------
Signed-Releases: Fail 8
    release found: v1.1.4
    signed release artifact found: scorecard_1.1.4_checksums.txt.sig, url: https://api.github.com/repos/naveensrinivasan/scorecard/releases/assets/32224145
    release found: v1.1.2
    !! release v1.1.2 has no signed artifacts
    release found: v1.1.1
    !! release v1.1.1 has no signed artifacts
    release found: v1.4
    !! release v1.4 has no signed artifacts
    found signed artifacts for 1 out of 4 releases
 ```


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature signed releases for Scorecard


* **What is the current behavior?** (You can also link to an open issue here)
The release isn't signed.


* **What is the new behavior (if this is a feature change)?**
The releases would be signed.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None


* **Other information**:
The GPG key and passphrase for signing the artifacts have already been created in GitHub.

https://github.com/naveensrinivasan/scorecard/releases/tag/v1.1.4
