### PR TITLE
Feature - Include metadata in the results

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,10 +61,10 @@ ci-e2e:  ## Runs ci e2e tests
 ci-e2e: build check-env
 	$(call ndef, GITHUB_AUTH_TOKEN)
 	mkdir -p bin
-	./scorecard --repo=https://github.com/ossf/scorecard --show-details --format json > ./bin/results.json
+	./scorecard --repo=https://github.com/ossf/scorecard --format json --metadata=openssf > ./bin/results.json
 	ginkgo -p  -v -cover  ./...
 	mkdir -p cache
-	USE_DISK_CACHE=1 DISK_CACHE_PATH="./cache" ./scorecard --repo=https://github.com/ossf/scorecard --show-details --format json > ./bin/results.json
+	USE_DISK_CACHE=1 DISK_CACHE_PATH="./cache" ./scorecard --repo=https://github.com/ossf/scorecard --show-details --metadata=openssf  --format json > ./bin/results.json
 	ginkgo -p  -v -cover  ./...
 
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -39,7 +39,8 @@ import (
 var (
 	repo        pkg.RepoURL
 	checksToRun []string
-	// This one has to use goflag instead of pflag because it's defined by zap
+	metaData    []string
+	// This one has to use goflag instead of pflag because it's defined by zap.
 	logLevel    = zap.LevelFlag("verbosity", zap.InfoLevel, "override the default log level")
 	format      string
 	npm         string
@@ -149,16 +150,18 @@ type npmSearchResults struct {
 }
 
 type record struct {
-	Repo   string
-	Date   string
-	Checks []checkResult
+	Repo     string
+	Date     string
+	Checks   []checkResult
+	MetaData []string
 }
 
 func outputJSON(results []pkg.Result) {
 	d := time.Now()
 	or := record{
-		Repo: repo.String(),
-		Date: d.Format("2006-01-02"),
+		Repo:     repo.String(),
+		Date:     d.Format("2006-01-02"),
+		MetaData: metaData,
 	}
 
 	for _, r := range results {
@@ -255,6 +258,8 @@ func init() {
 	rootCmd.Flags().Var(&repo, "repo", "repository to check")
 	rootCmd.Flags().StringVar(&npm, "npm", "", "npm package to check. If the npm package has a GitHub repository")
 	rootCmd.Flags().StringVar(&format, "format", formatDefault, "output format. allowed values are [default, csv, json]")
+	rootCmd.Flags().StringSliceVar(
+		&metaData, "metadata", []string{}, "metadata for the project.It can be multiple separated by commas")
 
 	rootCmd.Flags().BoolVar(&showDetails, "show-details", false, "show extra details about each check")
 	checkNames := []string{}

--- a/e2e/executable_test.go
+++ b/e2e/executable_test.go
@@ -17,19 +17,23 @@ type scorecard struct {
 		Confidence int      `json:"Confidence"`
 		Details    []string `json:"Details"`
 	} `json:"Checks"`
+	MetaData []string `json:"MetaData"`
 }
 
 var _ = Describe("E2E TEST:executable", func() {
 	Context("E2E TEST:Validating executable test", func() {
 		It("Should return valid test results for scorecard", func() {
 
-			file, _ := ioutil.ReadFile("../bin/results.json")
+			file, err := ioutil.ReadFile("../bin/results.json")
+
+			Expect(err).Should(BeNil())
 
 			data := scorecard{}
 
-			err := json.Unmarshal([]byte(file), &data)
+			err = json.Unmarshal(file, &data)
 
-			Expect(err).Should(BeNil())
+			Expect(len(data.MetaData)).ShouldNot(BeZero())
+			Expect(data.MetaData[0]).Should(BeEquivalentTo("openssf"))
 
 			for _, c := range data.Checks {
 				switch c.CheckName {

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -31,8 +31,9 @@ import (
 )
 
 type Result struct {
-	Cr   checker.CheckResult
-	Name string
+	Cr       checker.CheckResult
+	Name     string
+	MetaData []string
 }
 
 type RepoURL struct {


### PR DESCRIPTION


* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Does not include metadata for scan


* **What is the new behavior (if this is a feature change)?**
Included metadata that can be passed an argument to the command line. The same metadata will be returned with the `json` results.

### How is the metadata useful?
The scorecard cron jobs would be scanning 1000's of repositories and would store the results in a format that would make it easier for the end-users to consume(CDN, API, Big Query). It would easier to filter based on this metadata.

For example, The envoy team dependencies are scanned right now as part of the cron. With this metadata, the team can get all its results filtered by using the metadata as their criteria.

`❯ ./scorecard --repo=https://github.com/ossf/scorecard --format json --metadata=envoy,foo,bar | jq`

```json

{
  "Repo": "github.com/ossf/scorecard",
  "Date": "2021-02-22",
  "Checks": [
    {
      "CheckName": "Active",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Branch-Protection",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "CI-Tests",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "CII-Best-Practices",
      "Pass": false,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Code-Review",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Contributors",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Frozen-Deps",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Fuzzing",
      "Pass": false,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Packaging",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Pull-Requests",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "SAST",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Security-Policy",
      "Pass": true,
      "Confidence": 10,
      "Details": null
    },
    {
      "CheckName": "Signed-Releases",
      "Pass": false,
      "Confidence": 5,
      "Details": null
    },
    {
      "CheckName": "Signed-Tags",
      "Pass": false,
      "Confidence": 7,
      "Details": null
    }
  ],
  "MetaData": [
    "envoy",
    "foo",
    "bar"
  ]
}
```


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

None

* **Other information**:
