### PR TITLE
Reduced GitHub API calls for security check

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ ci-e2e: build check-env
 	$(call ndef, GITHUB_AUTH_TOKEN)
 	mkdir -p $(OUTPUT)
 	mkdir -p cache
-	DISK_CACHE_PATH="./cache" ./scorecard --repo=https://github.com/ossf/scorecard --show-details --metadata=openssf  --format json > ./$(OUTPUT)/results.json
+	USE_DISK_CACHE=1 DISK_CACHE_PATH="./cache" ./scorecard --repo=https://github.com/ossf/scorecard --show-details --metadata=openssf  --format json > ./$(OUTPUT)/results.json
 	@sleep 30
 	ginkgo -p  -v -cover --skip="E2E TEST:blob"  ./...
 

--- a/checker/check.go
+++ b/checker/check.go
@@ -32,6 +32,13 @@ var retryResult = CheckResult{
 	ShouldRetry: true,
 }
 
+const pass int = 10
+
+var PassResult = CheckResult{
+	Pass:       true,
+	Confidence: pass,
+}
+
 var maxConfidence int = 10
 
 func RetryResult(err error) CheckResult {

--- a/checks/checkforfile.go
+++ b/checks/checkforfile.go
@@ -1,0 +1,76 @@
+// Copyright 2020 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"io"
+	"strings"
+
+	"github.com/ossf/scorecard/checker"
+)
+
+// CheckIfFileExists downloads the tar of the repository and calls the predicate to check
+// for the occurrence.
+func CheckIfFileExists(c checker.Checker, predicate func(name string,
+	Logf func(s string, f ...interface{})) bool) checker.CheckResult {
+	r, _, err := c.Client.Repositories.Get(c.Ctx, c.Owner, c.Repo)
+	if err != nil {
+		return checker.RetryResult(err)
+	}
+	url := r.GetArchiveURL()
+	url = strings.Replace(url, "{archive_format}", "tarball/", 1)
+	url = strings.Replace(url, "{/ref}", r.GetDefaultBranch(), 1)
+
+	// Download
+	resp, err := c.HttpClient.Get(url)
+	if err != nil {
+		return checker.RetryResult(err)
+	}
+	defer resp.Body.Close()
+
+	gz, err := gzip.NewReader(resp.Body)
+	if err != nil {
+		return checker.RetryResult(err)
+	}
+	tr := tar.NewReader(gz)
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return checker.RetryResult(err)
+		}
+
+		// Strip the repo name
+		const splitLength = 2
+		names := strings.SplitN(hdr.Name, "/", splitLength)
+		if len(names) < splitLength {
+			continue
+		}
+
+		name := names[1]
+		if predicate(name, c.Logf) {
+			return checker.PassResult
+		}
+	}
+	const confidence = 5
+	return checker.CheckResult{
+		Pass:       false,
+		Confidence: confidence,
+	}
+}

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -15,9 +15,6 @@
 package checks
 
 import (
-	"archive/tar"
-	"compress/gzip"
-	"io"
 	"strings"
 
 	"github.com/ossf/scorecard/checker"
@@ -27,81 +24,39 @@ func init() {
 	registerCheck("Frozen-Deps", FrozenDeps)
 }
 
-var passResult = checker.CheckResult{
-	Pass: true,
-	//nolint:gomnd
-	Confidence: 10,
+// FrozenDeps will check the repository if it contains frozen dependecies.
+func FrozenDeps(c checker.Checker) checker.CheckResult {
+	return CheckIfFileExists(c, filePredicate)
 }
 
-func FrozenDeps(c checker.Checker) checker.CheckResult {
-	r, _, err := c.Client.Repositories.Get(c.Ctx, c.Owner, c.Repo)
-	if err != nil {
-		return checker.RetryResult(err)
-	}
-	url := r.GetArchiveURL()
-	url = strings.Replace(url, "{archive_format}", "tarball/", 1)
-	url = strings.Replace(url, "{/ref}", r.GetDefaultBranch(), 1)
-
-	// Download
-	resp, err := c.HttpClient.Get(url)
-	if err != nil {
-		return checker.RetryResult(err)
-	}
-	defer resp.Body.Close()
-
-	gz, err := gzip.NewReader(resp.Body)
-	if err != nil {
-		return checker.RetryResult(err)
-	}
-	tr := tar.NewReader(gz)
-
-	for {
-		hdr, err := tr.Next()
-		if err == io.EOF {
-			break
-		} else if err != nil {
-			return checker.RetryResult(err)
-		}
-
-		// Strip the repo name
-		const splitLength = 2
-		names := strings.SplitN(hdr.Name, "/", splitLength)
-		if len(names) < splitLength {
-			continue
-		}
-
-		name := names[1]
-
-		switch strings.ToLower(name) {
-		case "go.mod", "go.sum":
-			c.Logf("go modules found: %s", name)
-			return passResult
-		case "vendor/", "third_party/", "third-party/":
-			c.Logf("vendor dir found: %s", name)
-			return passResult
-		case "package-lock.json", "npm-shrinkwrap.json":
-			c.Logf("nodejs packages found: %s", name)
-			return passResult
-		case "requirements.txt", "pipfile.lock":
-			c.Logf("python requirements found: %s", name)
-			return passResult
-		case "gemfile.lock":
-			c.Logf("ruby gems found: %s", name)
-			return passResult
-		case "cargo.lock":
-			c.Logf("rust crates found: %s", name)
-			return passResult
-		case "yarn.lock":
-			c.Logf("yarn packages found: %s", name)
-			return passResult
-		case "composer.lock":
-			c.Logf("composer packages found: %s", name)
-			return passResult
-		}
-	}
-	const confidence = 5
-	return checker.CheckResult{
-		Pass:       false,
-		Confidence: confidence,
+// filePredicate will validate the if frozen dependecies file name exists.
+func filePredicate(name string, logf func(s string, f ...interface{})) bool {
+	switch strings.ToLower(name) {
+	case "go.mod", "go.sum":
+		logf("go modules found: %s", name)
+		return true
+	case "vendor/", "third_party/", "third-party/":
+		logf("vendor dir found: %s", name)
+		return true
+	case "package-lock.json", "npm-shrinkwrap.json":
+		logf("nodejs packages found: %s", name)
+		return true
+	case "requirements.txt", "pipfile.lock":
+		logf("python requirements found: %s", name)
+		return true
+	case "gemfile.lock":
+		logf("ruby gems found: %s", name)
+		return true
+	case "cargo.lock":
+		logf("rust crates found: %s", name)
+		return true
+	case "yarn.lock":
+		logf("yarn packages found: %s", name)
+		return true
+	case "composer.lock":
+		logf("composer packages found: %s", name)
+		return true
+	default:
+		return false
 	}
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes/features)
No, the `e2e` test cover for these

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Reduce the number of API calls to GitHub. Closes #221 


* **What is the current behavior?** (You can also link to an open issue here)
The current behavior uses up to `16` calls to GitHub API for checking the existence of Security.md 


* **What is the new behavior (if this is a feature change)?**
Reduced the number of calls to GitHub API from 16 to a max of 2 calls.
Utilized tarball to download and check for the contents of those files.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
