### PR TITLE
Fix - Updated golangci-lint based on warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -34,9 +34,7 @@ linters:
     - gosimple
     - govet
     - ineffassign
-    - interfacer
     - lll
-    - maligned
     - misspell
     - nakedret
     - nestif
@@ -64,6 +62,9 @@ linters-settings:
   errcheck:
     check-type-assertions: true
     check-blank: true
+  govet:
+    enable:
+      - fieldalignment
   godox:
     keywords:
       - BUG


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
N/A

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Address warnings


* **What is the current behavior?** (You can also link to an open issue here)
golang-ci warnings


* **What is the new behavior (if this is a feature change)?**
#### Fix - Updated golangci-lint based on warnings

```
golangci_lint: unexpected output on stderr: level=warning msg="[runner]
The linter 'interfacer' is deprecated due to: The repository of the linter has been archived by the owner."
level=warning msg="[runner] The linter 'maligned' is deprecated due to:
The repository of the linter has been archived by the owner. Use govet 'fieldalignment' instead."

```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
