### PR TITLE
Fix - Change log.fatal to error in URL parsing

### DIFF
--- a/gitcache/main.go
+++ b/gitcache/main.go
@@ -41,13 +41,16 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		c := &cache{}
 		if err := d.Decode(c); err != nil {
 			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
 		}
 		cache, err := pkg.NewCacheService(blob, logf)
 		if err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 		if err := cache.UpdateCache(c.URL); err != nil {
 			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
 		}
 
 	default:

--- a/gitcache/pkg/repourl.go
+++ b/gitcache/pkg/repourl.go
@@ -15,7 +15,6 @@ package pkg
 
 import (
 	"fmt"
-	"log"
 	"net/url"
 	"strings"
 
@@ -47,7 +46,7 @@ func (r *RepoURL) Set(s string) error {
 	const splitLen = 2
 	split := strings.SplitN(strings.Trim(parsedURL.Path, "/"), "/", splitLen)
 	if len(split) != splitLen {
-		log.Fatalf("invalid repo flag: [%s], pass the full repository URL", s)
+		return errors.Errorf("invalid repo flag: [%s], pass the full repository URL", s)
 	}
 
 	r.Host, r.Owner, r.Repo = parsedURL.Host, split[0], split[1]


### PR DESCRIPTION
Fix the repo parsing from log.fatal to error. This was causing the
process to terminate.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
The process was terminating because of log.Fatal


* **What is the new behavior (if this is a feature change)?**
Changed the log.Fatal to error


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None


* **Other information**:
