### PR TITLE
Fix - Made the results.json wellformed from cron

### DIFF
--- a/Dockerfile.gsutil
+++ b/Dockerfile.gsutil
@@ -26,7 +26,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"' -o /out/scorecard .
 
-FROM gcr.io/cloud-builders/gsutil
+FROM gcr.io/google.com/cloudsdktool/cloud-sdk:slim 
 COPY --from=build /out/scorecard /
 COPY ./cron/ /cron/
 ENTRYPOINT [ "/scorecard" ] 

--- a/cron/cron.sh
+++ b/cron/cron.sh
@@ -17,7 +17,7 @@ SOURCE="${BASH_SOURCE[0]}"
 input=$(dirname "$SOURCE")/projects.txt
 output=$(date +"%m-%d-%Y").json
 touch "$output"
-curl https://raw.githubusercontent.com/ossf/scorecard/main/cron/projects.txt >projects.txt
+echo "{ \"results\": [" >> "$output"
 
 # sort and uniqify these, in case there are duplicates
 # shellcheck disable=SC2002
@@ -28,7 +28,10 @@ while read -r proj; do
     fi
     echo "$proj"
     ../scorecard --repo="$proj" --show-details --format=json >> "$output"
+    echo "," >> "$output"
 done <<< "$projects"
+sed -i '$d' "$output" # removing the trailing comma which will be last line.
+echo "]}" >> "$output"
 
 gsutil cp "$output" gs://"$GCS_BUCKET"
 # Also copy the most recent run into a "latest.json" file


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
fix #269


* **What is the new behavior (if this is a feature change)?**

  Fixed the results.json to be wellformed from the cron job.

 Changed the docker image from gsutil to cloudsdk:slim to `sed` binary which is being used with the cron.sh



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 Yes, the latest.json will be wellformed.


* **Other information**:
