### PR TITLE
Fix - out of memory error for large repository

### DIFF
--- a/checks/checkforfile.go
+++ b/checks/checkforfile.go
@@ -18,6 +18,7 @@ import (
 	"archive/tar"
 	"compress/gzip"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/ossf/scorecard/checker"
@@ -35,8 +36,12 @@ func CheckIfFileExists(c checker.Checker, predicate func(name string,
 	url = strings.Replace(url, "{archive_format}", "tarball/", 1)
 	url = strings.Replace(url, "{/ref}", r.GetDefaultBranch(), 1)
 
-	// Download
-	resp, err := c.HttpClient.Get(url)
+	// Using the http.get instead of the checker httpClient because
+	// the default checker.HTTPClient caches everything in the memory and it causes oom.
+
+	//https://securego.io/docs/rules/g107.html
+	//nolint
+	resp, err := http.Get(url)
 	if err != nil {
 		return checker.RetryResult(err)
 	}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
Manually tested with the large repository `go run .  --repo=github.com/ApolloAuto/apollo  --checks=Frozen-Deps`
The subsequent PR's will update the test to include a large repository.


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug Fix


* **What is the current behavior?** (You can also link to an open issue here)
Fixed the cron job eviction bug. Fixes #265



* **What is the new behavior (if this is a feature change)?**

  The httpcache client caches everything in memory and if the repository is large then the process gets evicted with oom.
  
  Changed the implementation to use the standard http client to fetch the tarball.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None



* **Other information**:
None
