### PR TITLE
:bug: Zero pad scorecard json filename.

### DIFF
--- a/cron/main.go
+++ b/cron/main.go
@@ -32,7 +32,7 @@ type Repository struct {
 }
 
 func main() {
-	fileName := fmt.Sprintf("%d-%d-%d.json", time.Now().Month(), time.Now().Day(), time.Now().Year())
+	fileName := fmt.Sprintf("%02d-%02d-%d.json", time.Now().Month(), time.Now().Day(), time.Now().Year())
 	result, err := os.Create(fileName)
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
Fixes https://github.com/ossf/scorecard/issues/323

Signed-off-by: Asra Ali <asraa@google.com>

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features) (local test)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** 
* Zero pads months and dates to follow a MM-DD-YYYY format.


* **What is the current behavior?** (You can also link to an open issue here)
No zero padding, may output M-D-YYYY

* **What is the new behavior (if this is a feature change)?**
Now zero pads.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes but switches back to consistent implementation.

* **Other information**:
