### PR TITLE
:seedling: Revert Bump actions/github-script from v3 to v4.0.1

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -126,7 +126,7 @@ jobs:
             Integration tests ${{ job.status }} for [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}](https://github.com/ossf/scorecard/actions/runs/${{ github.run_id }})
 
       - name: set fork job status
-        uses: actions/github-script@v4.0.1
+        uses: actions/github-script@v3
         if: ${{ always() }}
         id: update-check-run
         env:


### PR DESCRIPTION
Reverts ossf/scorecard#354 as it breaks the `docker build`

🤦  I approved the previous PR from dependabot. 