### PR TITLE
🌱 Fix intermittent test failure

### DIFF
--- a/roundtripper/roundtripper_test.go
+++ b/roundtripper/roundtripper_test.go
@@ -43,10 +43,8 @@ func Test_shouldUseDiskCache(t *testing.T) {
 			useDiskCache:  false,
 		},
 	}
-	for _, tt := range tests {
-		tt := tt
+	for _, tt := range tests { //nolint:paralleltest // Since we're calling os.Setenv, we can't run these in parallel.
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			if tt.useDiskCache {
 				if tt.diskCachePath != "" {
 					e := os.Setenv(UseDiskCache, "1")
@@ -86,10 +84,8 @@ func Test_shouldUseBlobCache(t *testing.T) {
 			useBlobCache: false,
 		},
 	}
-	for _, tt := range tests {
-		tt := tt
+	for _, tt := range tests { //nolint:paralleltest // Since we're calling os.Setenv, we can't run these in parallel.
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
 			if tt.useBlobCache {
 				e := os.Setenv(UseBlobCache, "1")
 				thelperHandleError(t, e)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Test fix


* **What is the current behavior?** (You can also link to an open issue here)
I believe I introduced a bug in one of the tests in  PR [#348](https://github.com/ossf/scorecard/pull/348). In `roundtripper_test.go`, I added `t.Parallel()` inside the `for` loops. Because these tests are calling `os.Setenv` and `os.Getenv` for the same environment variables, it is possible for one test case to interfere with another. This appears to have happened in https://github.com/ossf/scorecard/runs/2487189008.


* **What is the new behavior (if this is a feature change)?**
These tests should not intermittently fail.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
