### PR TITLE
🌱 Fix lint issues: tparallel linter

### DIFF
--- a/roundtripper/roundtripper_test.go
+++ b/roundtripper/roundtripper_test.go
@@ -25,6 +25,7 @@ func thelperHandleError(t *testing.T, e error) {
 	}
 }
 
+//nolint:tparallel // Since we're calling os.Setenv, we can't run the subtests in parallel.
 func Test_shouldUseDiskCache(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -66,6 +67,7 @@ func Test_shouldUseDiskCache(t *testing.T) {
 	}
 }
 
+//nolint:tparallel // Since we're calling os.Setenv, we can't run the subtests in parallel.
 func Test_shouldUseBlobCache(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ n/a] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Code quality improvement

* **What is the current behavior?** (You can also link to an open issue here)
This PR fixes issues from the [tparallel](https://github.com/moricho/tparallel/) linter (detects inappropriate usage of `t.Parallel()`). \
Part of issue [#173](https://github.com/ossf/scorecard/issues/173).

* **What is the new behavior (if this is a feature change)?**
n/a

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
My first thought was to remove tparallel from the list of linters since [paralleltest](https://github.com/kunwardeep/paralleltest) also checks for missing `t.Parallel()` calls. However, both linters do check for additional, distinct issues; for example, tparallel makes sure that if `t.Parallel()` is called in the sub-test, it is post-processed by `t.Cleanup()` instead of `defer`.