### PR TITLE
🌱 Fix lint issues: thelper linter

### DIFF
--- a/roundtripper/roundtripper_test.go
+++ b/roundtripper/roundtripper_test.go
@@ -20,6 +20,7 @@ import (
 )
 
 func thelperHandleError(t *testing.T, e error) {
+	t.Helper()
 	if e != nil {
 		t.Errorf(e.Error())
 	}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ n/a] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Code quality improvement

* **What is the current behavior?** (You can also link to an open issue here)
This PR fixes issues from the [thelper](https://github.com/kulti/thelper/) linter (checks test helper functions call t.Helper()). \
Part of issue [#173](https://github.com/ossf/scorecard/issues/173).

* **What is the new behavior (if this is a feature change)?**
n/a

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Other information**:
Without this call to `t.Helper()`, if the first case of `Test_shouldUseDiskCache` were to fail, the test output would be:
```
    --- FAIL: Test_shouldUseBlobCache/Want_to_use_blob_Cache (0.00s)
        /home/chris/code/ossf/scorecard/roundtripper/roundtripper_test.go:24: Fail!
```
With the call to `t.Helper()`, the test output would be:
```
    --- FAIL: Test_shouldUseBlobCache/Want_to_use_blob_Cache (0.00s)
        /home/chris/code/ossf/scorecard/roundtripper/roundtripper_test.go:53: Fail!
```
In the former case, the stack trace indicates the error was within `thelperHandleError` whereas in the latter case, the stack trace indicates where in the test method the actual error occurred. 