### PR TITLE
🌱  Use TRUNCATE to load data into BigQuery

### DIFF
--- a/cron/bq/transfer.go
+++ b/cron/bq/transfer.go
@@ -1,0 +1,57 @@
+// Copyright 2021 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package bq
+
+import (
+	"context"
+	"fmt"
+	"log"
+
+	"cloud.google.com/go/bigquery"
+	"github.com/ossf/scorecard/cron/config"
+)
+
+func StartDataTransferJob(ctx context.Context, bucketURL, filename string) error {
+	projectID, err := config.GetProjectID()
+	if err != nil {
+		return fmt.Errorf("error getting ProjectId: %w", err)
+	}
+	bq, err := bigquery.NewClient(ctx, projectID)
+	if err != nil {
+		return fmt.Errorf("failed to create bigquery client: %w", err)
+	}
+
+	datasetName, err := config.GetBigQueryDataset()
+	if err != nil {
+		return fmt.Errorf("error getting BigQuery dataset: %w", err)
+	}
+	tableName, err := config.GetBigQueryTable()
+	if err != nil {
+		return fmt.Errorf("error getting BigQuery table: %w", err)
+	}
+	gcsRef := bigquery.NewGCSReference(fmt.Sprintf("%s/%s", bucketURL, filename))
+	gcsRef.AutoDetect = true
+	gcsRef.SourceFormat = bigquery.JSON
+	dataset := bq.Dataset(datasetName)
+	loader := dataset.Table(tableName).LoaderFrom(gcsRef)
+	loader.WriteDisposition = bigquery.WriteTruncate
+
+	job, err := loader.Run(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to create load job: %w", err)
+	}
+	log.Printf("Job created: %s", job.ID())
+	return nil
+}

--- a/cron/config/config.go
+++ b/cron/config/config.go
@@ -27,10 +27,12 @@ import (
 
 const (
 	ShardNumFilename       string = ".shard_num"
+	projectID              string = "SCORECARD_PROJECT_ID"
 	resultDataBucketURL    string = "SCORECARD_DATA_BUCKET_URL"
 	requestTopicURL        string = "SCORECARD_REQUEST_TOPIC_URL"
 	requestSubscriptionURL string = "SCORECARD_REQUEST_SUBSCRIPTION_URL"
-	inputReposFile         string = "SCORECARD_REPOS_FILE"
+	bigqueryDataset        string = "SCORECARD_BIGQUERY_DATASET"
+	bigqueryTable          string = "SCORECARD_BIQQUERY_TABLE"
 	shardSize              string = "SCORECARD_SHARD_SIZE"
 )
 
@@ -42,10 +44,12 @@ var (
 )
 
 type config struct {
+	ProjectID              string `yaml:"project-id"`
 	ResultDataBucketURL    string `yaml:"result-data-bucket-url"`
 	RequestTopicURL        string `yaml:"request-topic-url"`
 	RequestSubscriptionURL string `yaml:"request-subscription-url"`
-	InputReposFile         string `yaml:"input-repos-file"`
+	BigQueryDataset        string `yaml:"bigquery-dataset"`
+	BigQueryTable          string `yaml:"bigquery-table"`
 	ShardSize              int    `yaml:"shard-size"`
 }
 
@@ -99,6 +103,10 @@ func getIntConfigValue(envVar string, byteValue []byte, fieldName, configName st
 	}
 }
 
+func GetProjectID() (string, error) {
+	return getStringConfigValue(projectID, configYAML, "ProjectID", "project-id")
+}
+
 func GetResultDataBucketURL() (string, error) {
 	return getStringConfigValue(resultDataBucketURL, configYAML, "ResultDataBucketURL", "result-data-bucket-url")
 }
@@ -111,8 +119,12 @@ func GetRequestSubscriptionURL() (string, error) {
 	return getStringConfigValue(requestSubscriptionURL, configYAML, "RequestSubscriptionURL", "request-subscription-url")
 }
 
-func GetInputReposFile() (string, error) {
-	return getStringConfigValue(inputReposFile, configYAML, "InputReposFile", "input-repos-file")
+func GetBigQueryDataset() (string, error) {
+	return getStringConfigValue(bigqueryDataset, configYAML, "BigQueryDataset", "bigquery-dataset")
+}
+
+func GetBigQueryTable() (string, error) {
+	return getStringConfigValue(bigqueryTable, configYAML, "BigQueryTable", "bigquery-table")
 }
 
 func GetShardSize() (int, error) {

--- a/cron/config/config.yaml
+++ b/cron/config/config.yaml
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permisshandlerns and
 # limitathandlerns under the License.
 
+project-id: openssf
 result-data-bucket-url: gs://ossf-scorecard-data
 request-topic-url: gcppubsub://projects/openssf/topics/scorecard-batch-requests
 request-subscription-url: gcppubsub://projects/openssf/subscriptions/scorecard-batch-worker
-input-repos-file: projects.csv
+bigquery-dataset: scorecardcron
+bigquery-table: scorecard
 shard-size: 250

--- a/cron/config/testdata/basic.yaml
+++ b/cron/config/testdata/basic.yaml
@@ -14,5 +14,4 @@
 
 result-data-bucket-url: gs://ossf-scorecard-data
 request-topic-url: gcppubsub://projects/openssf/topics/scorecard-batch-requests
-input-repos-file: projects.csv
 shard-size: 250

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/ossf/scorecard
 go 1.16
 
 require (
+	cloud.google.com/go/bigquery v1.8.0
 	cloud.google.com/go/storage v1.15.0 // indirect
 	github.com/bradleyfalzon/ghinstallation v1.1.1
 	github.com/golangci/golangci-lint v1.40.1

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,7 @@ cloud.google.com/go/bigquery v1.3.0/go.mod h1:PjpwJnslEMmckchkHFfq+HTD2DmtT67aNF
 cloud.google.com/go/bigquery v1.4.0/go.mod h1:S8dzgnTigyfTmLBfrtrhyYhwRxG72rYxvftPBK2Dvzc=
 cloud.google.com/go/bigquery v1.5.0/go.mod h1:snEHRnqQbz117VIFhE8bmtwIDY80NLUZUMb4Nv6dBIg=
 cloud.google.com/go/bigquery v1.7.0/go.mod h1://okPTzCYNXSlb24MZs83e2Do+h+VXtc4gLoIoXIAPc=
+cloud.google.com/go/bigquery v1.8.0 h1:PQcPefKFdaIzjQFbiyOgAqyx8q5djaE7x9Sqe712DPA=
 cloud.google.com/go/bigquery v1.8.0/go.mod h1:J5hqkt3O0uAFnINi6JXValWIb1v0goeZM77hZzJN/fQ=
 cloud.google.com/go/datastore v1.0.0/go.mod h1:LXYbyblFSglQ5pkeyhO+Qmw7ukd3C+pD7TKLgZqpHYE=
 cloud.google.com/go/datastore v1.1.0/go.mod h1:umbIZjpQpHh4hmRpGhH4tLFup+FVzqBi1b3c64qFpCk=


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Uses TRUNCATE instead of APPEND to load GCS data into BQ.

* **What is the current behavior?** (You can also link to an open issue here)
Currently, the BQ scheduled data transfer service uses APPEND to load data into BQ table. But, we want the TRUNCATE behaviour for reasons discussed here: https://github.com/ossf/scorecard/issues/366. However, this can't be done for 2 reasons:
(i) the scheduled service does not allow for this option
(ii) TRUNCATE requires that all input data has the same `date` field

This PR implements that behaviour.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.