### PR TITLE
🐛  Fix bug in GitHub token access

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,6 @@ require (
 	golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a // indirect
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616 // indirect
 	golang.org/x/net v0.0.0-20210510120150-4163338589ed // indirect
-	golang.org/x/oauth2 v0.0.0-20210427180440-81ed05c6b58c
 	golang.org/x/sys v0.0.0-20210514084401-e8d321eab015 // indirect
 	google.golang.org/api v0.46.0 // indirect
 	google.golang.org/genproto v0.0.0-20210513213006-bf773b8c8384 // indirect

--- a/roundtripper/roundtripper.go
+++ b/roundtripper/roundtripper.go
@@ -42,9 +42,9 @@ const (
 func NewTransport(ctx context.Context, logger *zap.SugaredLogger) http.RoundTripper {
 	transport := http.DefaultTransport
 
-	// Start with oauth
 	if token := os.Getenv(GithubAuthToken); token != "" {
-		transport = MakeOAuthTransport(ctx, strings.Split(token, ","))
+		// Use GitHub PAT
+		transport = MakeGitHubTransport(transport, strings.Split(token, ","))
 	} else if keyPath := os.Getenv(GithubAppKeyPath); keyPath != "" { // Also try a GITHUB_APP
 		appID, err := strconv.Atoi(os.Getenv(GithubAppID))
 		if err != nil {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Remove the oauth library usage which was causing issues in token access. 
The `oauth.Token()` fn relies on [`Token.Expiry` field](https://github.com/golang/oauth2/blob/f6687ab2804c/token.go#L50). Without this, it always [returns the same token](https://github.com/golang/oauth2/blob/f6687ab2804c/oauth2.go#L301). This was unintentionally working fine before https://github.com/ossf/scorecard/pull/461 since we always created a new instance of the oauth client. 
For our usecase, it is enough if we set the correct `Authorization` header. So updating to use that instead of the oauth library.

FYI, this issue is causing the cron job to be stuck forever.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.