### PR TITLE
🐛  Add options to Stackdriver exporter

### DIFF
--- a/cron/monitoring/exporter.go
+++ b/cron/monitoring/exporter.go
@@ -16,13 +16,18 @@ package monitoring
 
 import (
 	"fmt"
+	"time"
 
 	"contrib.go.opencensus.io/exporter/stackdriver"
+	"contrib.go.opencensus.io/exporter/stackdriver/monitoredresource/gcp"
 
 	"github.com/ossf/scorecard/cron/config"
 )
 
-const stackdriverTimeSeriesQuota = 100
+const (
+	stackdriverTimeSeriesQuota = 200
+	timeoutMinutes             = 10
+)
 
 func NewStackDriverExporter() (*stackdriver.Exporter, error) {
 	projectID, err := config.GetProjectID()
@@ -30,8 +35,10 @@ func NewStackDriverExporter() (*stackdriver.Exporter, error) {
 		return nil, fmt.Errorf("error getting ProjectID: %w", err)
 	}
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
-		ProjectID:    projectID,
-		MetricPrefix: "scorecard-cron",
+		ProjectID:         projectID,
+		MetricPrefix:      "scorecard-cron",
+		MonitoredResource: gcp.Autodetect(),
+		Timeout:           timeoutMinutes * time.Minute,
 		// Stackdriver specific quotas based on https://cloud.google.com/monitoring/quotas
 		// `Time series included in a request`
 		BundleCountThreshold: stackdriverTimeSeriesQuota,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Adds options to Stackdriver exporter:
i) `MonitoredResource` limits the metric to be recorded against `gke_container` instead of `global`
ii) `Timeout` increases the deadline for API calls to Stackdriver.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.