### PR TITLE
🌱 Add new linter: errorlint

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,7 @@ linters:
     - dogsled
     - dupl
     - errcheck
+    - errorlint
     - exhaustive
     - exportloopref
     - gci

--- a/checks/checkforfile.go
+++ b/checks/checkforfile.go
@@ -17,6 +17,7 @@ package checks
 import (
 	"archive/tar"
 	"compress/gzip"
+	"errors"
 	"io"
 	"net/http"
 	"strings"
@@ -55,7 +56,7 @@ func CheckIfFileExists(checkName string, c *checker.CheckRequest, onFile func(na
 
 	for {
 		hdr, err := tr.Next()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
 			return checker.MakeRetryResult(checkName, err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -203,14 +203,14 @@ func fetchGitRepositoryFromNPM(packageName string) (string, error) {
 	}
 	resp, err := client.Get(fmt.Sprintf(npmSearchURL, packageName))
 	if err != nil {
-		return "", fmt.Errorf("failed to get npm package json: %v", err)
+		return "", fmt.Errorf("failed to get npm package json: %w", err)
 	}
 
 	defer resp.Body.Close()
 	v := &npmSearchResults{}
 	err = json.NewDecoder(resp.Body).Decode(v)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse npm package json: %v", err)
+		return "", fmt.Errorf("failed to parse npm package json: %w", err)
 	}
 	if len(v.Objects) == 0 {
 		return "", fmt.Errorf("could not find source repo for npm package: %s", packageName)
@@ -228,14 +228,14 @@ func fetchGitRepositoryFromPYPI(packageName string) (string, error) {
 	}
 	resp, err := client.Get(fmt.Sprintf(pypiSearchURL, packageName))
 	if err != nil {
-		return "", fmt.Errorf("failed to get pypi package json: %v", err)
+		return "", fmt.Errorf("failed to get pypi package json: %w", err)
 	}
 
 	defer resp.Body.Close()
 	v := &pypiSearchResults{}
 	err = json.NewDecoder(resp.Body).Decode(v)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse pypi package json: %v", err)
+		return "", fmt.Errorf("failed to parse pypi package json: %w", err)
 	}
 	if v.Info.ProjectUrls.Source == "" {
 		return "", fmt.Errorf("could not find source repo for pypi package: %s", packageName)
@@ -253,14 +253,14 @@ func fetchGitRepositoryFromRubyGems(packageName string) (string, error) {
 	}
 	resp, err := client.Get(fmt.Sprintf(rubyGemsSearchURL, packageName))
 	if err != nil {
-		return "", fmt.Errorf("failed to get ruby gem json: %v", err)
+		return "", fmt.Errorf("failed to get ruby gem json: %w", err)
 	}
 
 	defer resp.Body.Close()
 	v := &rubyGemsSearchResults{}
 	err = json.NewDecoder(resp.Body).Decode(v)
 	if err != nil {
-		return "", fmt.Errorf("failed to parse ruby gem json: %v", err)
+		return "", fmt.Errorf("failed to parse ruby gem json: %w", err)
 	}
 	if v.SourceCodeURI == "" {
 		return "", fmt.Errorf("could not find source repo for ruby gem: %s", packageName)

--- a/cron/data/iterator.go
+++ b/cron/data/iterator.go
@@ -63,7 +63,7 @@ type csvIterator struct {
 
 func (reader *csvIterator) HasNext() bool {
 	reader.err = reader.decoder.Decode(&reader.next)
-	return reader.err != io.EOF
+	return !errors.Is(reader.err, io.EOF)
 }
 
 func (reader *csvIterator) Next() (repos.RepoURL, error) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [n/a] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Code quality improvement


* **What is the current behavior?** (You can also link to an open issue here)
Adding one of the new linters listed in #173. [errorlint](https://github.com/polyfloyd/go-errorlint) checks for `fmt.Errorf` that uses `%v` instead of `%w` with an existing error and checks that comparisons between errors use `errors.check`.