### PR TITLE
🐛 Fix truncated file extraction from tarball

### DIFF
--- a/checks/checkforcontent.go
+++ b/checks/checkforcontent.go
@@ -90,7 +90,7 @@ func getTarReader(in io.Reader) (*tar.Reader, error) {
 	return tr, nil
 }
 
-func readEntireFile(tr *tar.Reader, hdr *tar.Header) (content []byte, err error) {
+func readEntireFile(tr *tar.Reader) (content []byte, err error) {
 	var buf bytes.Buffer
 	_, err = io.Copy(&buf, tr)
 	if err != nil {
@@ -161,9 +161,9 @@ func CheckFilesContent(checkName, shellPathFnPattern string,
 			continue
 		}
 
-		content, err := readEntireFile(tr, hdr)
+		content, err := readEntireFile(tr)
 		if err != nil {
-			return checker.MakeFailResult(checkName, err)
+			return checker.MakeRetryResult(checkName, err)
 		}
 
 		// We should have reached the end of files AND
@@ -175,7 +175,6 @@ func CheckFilesContent(checkName, shellPathFnPattern string,
 			return checker.MakeRetryResult(checkName, ErrReadFile)
 		}
 
-		// We truncate the file to remove trailing 0 (sparse format).
 		rr, err := onFileContent(fullpath, content, c.Logf)
 		if err != nil {
 			return checker.MakeFailResult(checkName, err)

--- a/checks/checkforcontent.go
+++ b/checks/checkforcontent.go
@@ -16,6 +16,7 @@ package checks
 
 import (
 	"archive/tar"
+	"bytes"
 	"compress/gzip"
 	"errors"
 	"fmt"
@@ -89,6 +90,16 @@ func getTarReader(in io.Reader) (*tar.Reader, error) {
 	return tr, nil
 }
 
+func readEntireFile(tr *tar.Reader, hdr *tar.Header) (content []byte, err error) {
+	var buf bytes.Buffer
+	_, err = io.Copy(&buf, tr)
+	if err != nil {
+		return nil, fmt.Errorf("io.Copy: %w", err)
+	}
+
+	return buf.Bytes(), nil
+}
+
 // CheckFilesContent downloads the tar of the repository and calls the onFileContent() function
 // shellPathFnPattern is used for https://golang.org/pkg/path/#Match
 // Warning: the pattern is used to match (1) the entire path AND (2) the filename alone. This means:
@@ -150,22 +161,22 @@ func CheckFilesContent(checkName, shellPathFnPattern string,
 			continue
 		}
 
-		content := make([]byte, hdr.Size)
-		n, err := tr.Read(content)
-		if err != nil && err != io.EOF {
-			return checker.MakeRetryResult(checkName, err)
+		content, err := readEntireFile(tr, hdr)
+		if err != nil {
+			return checker.MakeFailResult(checkName, err)
 		}
+
 		// We should have reached the end of files AND
 		// the number of bytes should be the same as number
 		// indicated in header, unless the file format supports
 		// sparse regions. Only USTAR format does not support
 		// spare regions -- see https://golang.org/pkg/archive/tar/
-		if b := headerSizeMatchesFileSize(hdr, n); !b {
+		if b := headerSizeMatchesFileSize(hdr, len(content)); !b {
 			return checker.MakeRetryResult(checkName, ErrReadFile)
 		}
 
 		// We truncate the file to remove trailing 0 (sparse format).
-		rr, err := onFileContent(fullpath, content[:n], c.Logf)
+		rr, err := onFileContent(fullpath, content, c.Logf)
 		if err != nil {
 			return checker.MakeFailResult(checkName, err)
 		}

--- a/checks/frozen_deps_test.go
+++ b/checks/frozen_deps_test.go
@@ -24,6 +24,7 @@ import (
 
 func TestGithubWorkflowPinning(t *testing.T) {
 	t.Parallel()
+	//nolint
 	type args struct {
 		Log      log
 		Filename string
@@ -35,6 +36,7 @@ func TestGithubWorkflowPinning(t *testing.T) {
 		NumberOfErrors int
 	}
 
+	//nolint
 	tests := []struct {
 		args args
 		want returnValue

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -117,7 +117,6 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 	}
-	//nolint
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		l.messages = []string{}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
bug fix

* **What is the current behavior?** (You can also link to an open issue here)
tarball files were truncated if the call to `tr.Read` did not return all the bytes at once.


* **What is the new behavior (if this is a feature change)?**
fix the above.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
