### PR TITLE
✨ Check for shell script's insecure download

### DIFF
--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -74,7 +74,7 @@ func isShellScriptFreeOfInsecureDownloads(c *checker.CheckRequest) checker.Check
 func validateShellScriptDownloads(pathfn string, content []byte,
 	logf func(s string, f ...interface{})) (bool, error) {
 	// Validate the file type.
-	if !IsShellScriptFile(pathfn, content) {
+	if !isShellScriptFile(pathfn, content) {
 		return false, nil
 	}
 

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -78,6 +78,7 @@ func validateDockerfileDownloads(pathfn string, content []byte,
 		return false, fmt.Errorf("cannot read dockerfile content: %w", err)
 	}
 
+	// nolinter:prealloc
 	var bytes []byte
 
 	// Walk the Dockerfile's AST.

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -17,6 +17,7 @@ package checks
 import (
 	"errors"
 	"fmt"
+	"io/ioutil"
 	"regexp"
 	"strings"
 
@@ -42,12 +43,26 @@ func init() {
 
 // FrozenDeps will check the repository if it contains frozen dependecies.
 func FrozenDeps(c *checker.CheckRequest) checker.CheckResult {
-	return checker.MultiCheckAnd(
-		isPackageManagerLockFilePresent,
-		isGitHubActionsWorkflowPinned,
-		isDockerfilePinned,
-		isDockerfileFreeOfInsecureDownloads,
-	)(c)
+	// return checker.MultiCheckAnd(
+	// 	isPackageManagerLockFilePresent,
+	// 	isGitHubActionsWorkflowPinned,
+	// 	isDockerfilePinned,
+	// 	isDockerfileFreeOfInsecureDownloads,
+	// )(c)
+	var content []byte
+	content, err := ioutil.ReadFile("checks/test.sh")
+	if err != nil {
+		c.Logf("ioutil.ReadFile: %v", err)
+		return checker.MakeFailResult(CheckFrozenDeps, err)
+	}
+
+	r, err := validateShellScriptDownloads("some/path", content, c.Logf)
+	if err != nil || !r {
+		c.Logf("validateShellScriptDownloads: %v", err)
+		return checker.MakeFailResult(CheckFrozenDeps, err)
+	}
+	return checker.MakePassResult(CheckFrozenDeps)
+	// return CheckFilesContent(CheckFrozenDeps, "*", true, c, validateDockerfileDownloads)
 }
 
 // TODO(laurent): need to support GCB pinning.

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -100,7 +100,7 @@ func validateDockerfileDownloads(pathfn string, content []byte,
 		// Build a file content.
 		cmd := strings.Join(valueList, " ")
 		bytes = append(bytes, cmd...)
-		bytes = append(bytes, []byte("\n")...)
+		bytes = append(bytes, '\n')
 	}
 	return validateShellFile(pathfn, bytes, logf)
 }

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -17,7 +17,6 @@ package checks
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"regexp"
 	"strings"
 
@@ -43,26 +42,12 @@ func init() {
 
 // FrozenDeps will check the repository if it contains frozen dependecies.
 func FrozenDeps(c *checker.CheckRequest) checker.CheckResult {
-	// return checker.MultiCheckAnd(
-	// 	isPackageManagerLockFilePresent,
-	// 	isGitHubActionsWorkflowPinned,
-	// 	isDockerfilePinned,
-	// 	isDockerfileFreeOfInsecureDownloads,
-	// )(c)
-	var content []byte
-	content, err := ioutil.ReadFile("checks/test.sh")
-	if err != nil {
-		c.Logf("ioutil.ReadFile: %v", err)
-		return checker.MakeFailResult(CheckFrozenDeps, err)
-	}
-
-	r, err := validateShellScriptDownloads("some/path", content, c.Logf)
-	if err != nil || !r {
-		c.Logf("validateShellScriptDownloads: %v", err)
-		return checker.MakeFailResult(CheckFrozenDeps, err)
-	}
-	return checker.MakePassResult(CheckFrozenDeps)
-	// return CheckFilesContent(CheckFrozenDeps, "*", true, c, validateDockerfileDownloads)
+	return checker.MultiCheckAnd(
+		isPackageManagerLockFilePresent,
+		isGitHubActionsWorkflowPinned,
+		isDockerfilePinned,
+		isDockerfileFreeOfInsecureDownloads,
+	)(c)
 }
 
 // TODO(laurent): need to support GCB pinning.

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -61,7 +61,7 @@ func validateShellScriptDownloads(pathfn string, content []byte,
 	logf func(s string, f ...interface{})) (bool, error) {
 	// Validate the file type.
 	if !isShellScriptFile(pathfn, content) {
-		return false, nil
+		return true, nil
 	}
 
 	return validateShellFile(pathfn, content, logf)

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -58,7 +58,7 @@ func FrozenDeps(c *checker.CheckRequest) checker.CheckResult {
 
 	r, err := validateShellScriptDownloads("some/path", content, c.Logf)
 	if err != nil || !r {
-		c.Logf("validateDockerfileDownloads: %v", err)
+		c.Logf("validateShellScriptDownloads: %v", err)
 		return checker.MakeFailResult(CheckFrozenDeps, err)
 	}
 	return checker.MakePassResult(CheckFrozenDeps)

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -63,7 +63,6 @@ func validateShellScriptDownloads(pathfn string, content []byte,
 	if !isShellScriptFile(pathfn, content) {
 		return true, nil
 	}
-
 	return validateShellFile(pathfn, content, logf)
 }
 

--- a/checks/frozen_deps_test.go
+++ b/checks/frozen_deps_test.go
@@ -359,3 +359,86 @@ func TestDockerfileScriptDownload(t *testing.T) {
 		})
 	}
 }
+
+func TestShellScriptDownload(t *testing.T) {
+	t.Parallel()
+	//nolint
+	type args struct {
+		// Note: this seems to be defined in e2e/e2e_suite_test.go
+		Log      log
+		Filename string
+	}
+
+	type returnValue struct {
+		Error          error
+		Result         bool
+		NumberOfErrors int
+	}
+
+	//nolint
+	tests := []struct {
+		args args
+		want returnValue
+		name string
+	}{
+		{
+			name: "sh script",
+			args: args{
+				Filename: "testdata/script-sh",
+				Log:      log{},
+			},
+			want: returnValue{
+				Error:          nil,
+				Result:         false,
+				NumberOfErrors: 7,
+			},
+		},
+		{
+			name: "bash script",
+			args: args{
+				Filename: "testdata/script-bash",
+				Log:      log{},
+			},
+			want: returnValue{
+				Error:          nil,
+				Result:         false,
+				NumberOfErrors: 7,
+			},
+		},
+		{
+			name: "sh script 2",
+			args: args{
+				Filename: "testdata/script.sh",
+				Log:      log{},
+			},
+			want: returnValue{
+				Error:          nil,
+				Result:         false,
+				NumberOfErrors: 7,
+			},
+		},
+	}
+	//nolint
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var content []byte
+			var err error
+			content, err = ioutil.ReadFile(tt.args.Filename)
+			if err != nil {
+				panic(fmt.Errorf("cannot read file: %w", err))
+			}
+
+			r, err := validateShellScriptDownloads(tt.args.Filename, content, tt.args.Log.Logf)
+
+			if !errors.Is(err, tt.want.Error) ||
+				r != tt.want.Result ||
+				len(tt.args.Log.messages) != tt.want.NumberOfErrors {
+				t.Errorf("TestDockerfileScriptDownload:\"%v\": %v (%v,%v,%v) want (%v, %v, %v)\n%v",
+					tt.name, tt.args.Filename, r, err, len(tt.args.Log.messages), tt.want.Result, tt.want.Error, tt.want.NumberOfErrors,
+					strings.Join(tt.args.Log.messages, "\n"))
+			}
+		})
+	}
+}

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -15,6 +15,7 @@
 package checks
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"net/url"
@@ -43,6 +44,10 @@ var interpreters = []string{
 // cli options.
 var downloadUtils = []string{
 	"curl", "wget", "gsutil",
+}
+
+var shellNames = []string{
+	"sh", "bash", "dash", "ksh",
 }
 
 func isBinaryName(expected, name string) bool {
@@ -820,4 +825,46 @@ func validateShellCommand(cmd, pathfn string, downloadedFiles map[string]bool,
 	}
 
 	return ret, nil
+}
+
+func IsShellScriptFile(pathfn string, content []byte) bool {
+	r := strings.NewReader(string(content))
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		return false
+	}
+
+	for _, name := range shellNames {
+		// Look at the prefix.
+		if strings.HasPrefix(pathfn, "."+name) {
+			return true
+		}
+
+		// Look at file content.
+		line := scanner.Text()
+
+		//  #!/bin/XXX, #!XXX, #!/usr/bin/env XXX, #!env XXX
+		if !strings.HasPrefix(line, "#!") {
+			continue
+		}
+
+		line = line[2:]
+		parts := strings.Split(line, " ")
+		// #!/bin/bash, #!bash
+		if len(parts) == 1 && isBinaryName(name, parts[0]) {
+			return true
+		}
+
+		// #!/bin/env bash
+		if len(parts) == 2 &&
+			isBinaryName("env", parts[0]) &&
+			isBinaryName(name, parts[1]) {
+			return true
+		}
+	}
+
+	return false
+}
+
+func validateShellFile(pathfn string, content []byte, logf func(s string, f ...interface{})) (bool, error) {
 }

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -686,7 +686,7 @@ func isShellScriptFile(pathfn string, content []byte) bool {
 	// Check file extension first.
 	for _, name := range shellNames {
 		// Look at the prefix.
-		if strings.HasPrefix(pathfn, "."+name) {
+		if strings.HasSuffix(pathfn, "."+name) {
 			return true
 		}
 	}

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -682,36 +682,38 @@ func validateShellFileAndRecord(pathfn string, content []byte, files map[string]
 func isShellScriptFile(pathfn string, content []byte) bool {
 	r := strings.NewReader(string(content))
 	scanner := bufio.NewScanner(r)
-	if !scanner.Scan() {
-		return false
-	}
 
+	// Check file extension first.
 	for _, name := range shellNames {
 		// Look at the prefix.
 		if strings.HasPrefix(pathfn, "."+name) {
 			return true
 		}
+	}
 
-		// Look at file content.
-		line := scanner.Text()
+	for scanner.Scan() {
+		for _, name := range shellNames {
+			// Look at file content.
+			line := scanner.Text()
 
-		//  #!/bin/XXX, #!XXX, #!/usr/bin/env XXX, #!env XXX
-		if !strings.HasPrefix(line, "#!") {
-			continue
-		}
+			//  #!/bin/XXX, #!XXX, #!/usr/bin/env XXX, #!env XXX
+			if !strings.HasPrefix(line, "#!") {
+				continue
+			}
 
-		line = line[2:]
-		parts := strings.Split(line, " ")
-		// #!/bin/bash, #!bash -e
-		if len(parts) >= 1 && isBinaryName(name, parts[0]) {
-			return true
-		}
+			line = line[2:]
+			parts := strings.Split(line, " ")
+			// #!/bin/bash, #!bash -e
+			if len(parts) >= 1 && isBinaryName(name, parts[0]) {
+				return true
+			}
 
-		// #!/bin/env bash
-		if len(parts) >= 2 &&
-			isBinaryName("env", parts[0]) &&
-			isBinaryName(name, parts[1]) {
-			return true
+			// #!/bin/env bash
+			if len(parts) >= 2 &&
+				isBinaryName("env", parts[0]) &&
+				isBinaryName(name, parts[1]) {
+				return true
+			}
 		}
 	}
 

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -479,7 +479,7 @@ func recordFetchFileFromNode(node syntax.Node) (pathfn string, ok bool, err erro
 	return fn, true, nil
 }
 
-func isFetchStdinExecute(node syntax.Node, cmd, pathfn string,
+func isFetchProcSubsExecute(node syntax.Node, cmd, pathfn string,
 	logf func(s string, f ...interface{})) bool {
 	ce, ok := node.(*syntax.CallExpr)
 	if !ok {
@@ -646,7 +646,7 @@ func validateShellFileAndRecord(pathfn string, content []byte, files map[string]
 		}
 
 		// `bash <(wget -qO- http://website.com/my-script.sh)`. (supports `sudo`).
-		if isFetchStdinExecute(node, cmdStr, pathfn, logf) {
+		if isFetchProcSubsExecute(node, cmdStr, pathfn, logf) {
 			validated = false
 		}
 

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -435,27 +435,6 @@ func isUnpinnedPakageManagerDownload(node syntax.Node, cmd, pathfn string,
 	return false
 }
 
-// Detect `fetch | exec`.
-func validateCommandIsNotFetchPipeExecute(cmd, pathfn string, logf func(s string, f ...interface{})) (bool, error) {
-	in := strings.NewReader(cmd)
-	f, err := syntax.NewParser().Parse(in, "")
-	if err != nil {
-		return false, ErrParsingShellCommand
-	}
-
-	cmdValidated := true
-	syntax.Walk(f, func(node syntax.Node) bool {
-		if isFetchPipeExecute(node, cmd, pathfn, logf) {
-			cmdValidated = false
-		}
-
-		// Continue walking the node graph.
-		return true
-	})
-
-	return cmdValidated, nil
-}
-
 func recordFetchFileFromNode(node syntax.Node) (pathfn string, ok bool, err error) {
 	ss, ok := node.(*syntax.Stmt)
 	if !ok {

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -691,16 +691,16 @@ func isShellScriptFile(pathfn string, content []byte) bool {
 		}
 	}
 
+	// Look at file content.
 	for scanner.Scan() {
+		line := scanner.Text()
+
+		//  #!/bin/XXX, #!XXX, #!/usr/bin/env XXX, #!env XXX
+		if !strings.HasPrefix(line, "#!") {
+			continue
+		}
+
 		for _, name := range shellNames {
-			// Look at file content.
-			line := scanner.Text()
-
-			//  #!/bin/XXX, #!XXX, #!/usr/bin/env XXX, #!env XXX
-			if !strings.HasPrefix(line, "#!") {
-				continue
-			}
-
 			line = line[2:]
 			parts := strings.Split(line, " ")
 			// #!/bin/bash, #!bash -e

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -829,7 +829,7 @@ func validateShellCommand(cmd, pathfn string, downloadedFiles map[string]bool,
 	return ret, nil
 }
 
-func IsShellScriptFile(pathfn string, content []byte) bool {
+func isShellScriptFile(pathfn string, content []byte) bool {
 	r := strings.NewReader(string(content))
 	scanner := bufio.NewScanner(r)
 	if !scanner.Scan() {

--- a/checks/testdata/script-bash
+++ b/checks/testdata/script-bash
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Find input files
+MY_INPUT_FILE="${TEST_SRCDIR}/some/path/myinputfile.dat"
+readonly MY_INPUT_FILE
+MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
+readonly MY_OUTPUT_FILE
+
+# Do something
+echo hello || die "Failed in bar()"
+
+# Check something
+check_eq "${A}" "${B}"
+
+echo "PASS"
+
+if [ $1 -gt 100 ]
+then
+    echo Hey that\'s a large number.
+    pwd
+    echo hi && curl -s blabla | bash
+fi
+
+curl bla > myfile
+./myfile
+
+sh -c "curl bla | sh"
+curl bla > file2
+bash -c "file2"
+
+sh -c "curl bla > file1"
+sh -c "./file1"
+
+bash <(wget -qO- http://website.com/my-script.sh)
+
+wget http://file-with-sudo -O /tmp/file3
+bash /tmp/file3
+
+date

--- a/checks/testdata/script-bash
+++ b/checks/testdata/script-bash
@@ -1,4 +1,17 @@
 #!/bin/bash
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Find input files
 MY_INPUT_FILE="${TEST_SRCDIR}/some/path/myinputfile.dat"

--- a/checks/testdata/script-sh
+++ b/checks/testdata/script-sh
@@ -1,4 +1,17 @@
 #!env bash -euo pipefail
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Find input files
 MY_INPUT_FILE="${TEST_SRCDIR}/some/path/myinputfile.dat"

--- a/checks/testdata/script-sh
+++ b/checks/testdata/script-sh
@@ -1,0 +1,40 @@
+#!env bash -euo pipefail
+
+# Find input files
+MY_INPUT_FILE="${TEST_SRCDIR}/some/path/myinputfile.dat"
+readonly MY_INPUT_FILE
+MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
+readonly MY_OUTPUT_FILE
+
+# Do something
+echo hello || die "Failed in bar()"
+
+# Check something
+check_eq "${A}" "${B}"
+
+echo "PASS"
+
+if [ $1 -gt 100 ]
+then
+    echo Hey that\'s a large number.
+    pwd
+    echo hi && curl -s blabla | bash
+fi
+
+curl bla > myfile
+./myfile
+
+sh -c "curl bla | sh"
+
+curl bla > file2
+bash -c "file2"
+
+sh -c "curl bla > file1"
+sh -c "./file1"
+
+bash <(wget -qO- http://website.com/my-script.sh)
+
+wget http://file-with-sudo -O /tmp/file3
+bash /tmp/file3
+
+date

--- a/checks/testdata/script-sh
+++ b/checks/testdata/script-sh
@@ -1,4 +1,4 @@
-#!env bash -euo pipefail
+#!/bin/env bash -euo pipefail
 # Copyright 2021 Security Scorecard Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/checks/testdata/script.sh
+++ b/checks/testdata/script.sh
@@ -1,0 +1,39 @@
+#!/bin/env sh -e
+
+# Find input files
+MY_INPUT_FILE="${TEST_SRCDIR}/some/path/myinputfile.dat"
+readonly MY_INPUT_FILE
+MY_OUTPUT_FILE="${TEST_TMPDIR}/myoutput.txt"
+readonly MY_OUTPUT_FILE
+
+# Do something
+echo hello || die "Failed in bar()"
+
+# Check something
+check_eq "${A}" "${B}"
+
+echo "PASS"
+
+if [ $1 -gt 100 ]
+then
+    echo Hey that\'s a large number.
+    pwd
+    echo hi && curl -s blabla | bash
+fi
+
+curl bla > myfile
+./myfile
+
+sh -c "curl bla | sh"
+curl bla > file2
+bash -c "file2"
+
+sh -c "curl bla > file1"
+sh -c "./file1"
+
+bash <(wget -qO- http://website.com/my-script.sh)
+
+wget http://file-with-sudo -O /tmp/file3
+bash /tmp/file3
+
+date

--- a/checks/testdata/script.sh
+++ b/checks/testdata/script.sh
@@ -1,4 +1,17 @@
 #!/bin/env sh -e
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 # Find input files
 MY_INPUT_FILE="${TEST_SRCDIR}/some/path/myinputfile.dat"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
we don't support.


* **What is the new behavior (if this is a feature change)?**
we support `curl | bash` type detection for shell scripts.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
A lot of refactoring has happened in the code to be able to share the detection for docker, shell, and later makefiles/github workflows. The refactoring simplifies things, though.