### PR TITLE
🐛 Move `repos.RepoResult` -> `pkg.ScorecardResult`

### DIFF
--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -75,18 +75,18 @@ func RunScorecards(ctx context.Context,
 	repoClient clients.RepoClient,
 	httpClient *http.Client,
 	githubClient *github.Client,
-	graphClient *githubv4.Client) (repos.RepoResult, error) {
+	graphClient *githubv4.Client) (ScorecardResult, error) {
 	ctx, err := tag.New(ctx, tag.Upsert(stats.Repo, repo.URL()))
 	if err != nil {
-		return repos.RepoResult{}, fmt.Errorf("error during tag.New: %w", err)
+		return ScorecardResult{}, fmt.Errorf("error during tag.New: %w", err)
 	}
 	defer logStats(ctx, time.Now())
 
 	if err := repoClient.InitRepo(repo.Owner, repo.Repo); err != nil {
-		return repos.RepoResult{}, fmt.Errorf("error during InitRepo for %s: %w", repo.URL(), err)
+		return ScorecardResult{}, fmt.Errorf("error during InitRepo for %s: %w", repo.URL(), err)
 	}
 
-	ret := repos.RepoResult{
+	ret := ScorecardResult{
 		Repo: repo.URL(),
 		Date: time.Now().Format("2006-01-02"),
 	}

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package repos
+package pkg
 
 import (
 	"encoding/csv"
@@ -25,7 +25,7 @@ import (
 	"github.com/ossf/scorecard/checker"
 )
 
-type RepoResult struct {
+type ScorecardResult struct {
 	Repo     string
 	Date     string
 	Checks   []checker.CheckResult
@@ -33,8 +33,8 @@ type RepoResult struct {
 }
 
 // AsJSON outputs the result in JSON format with a newline at the end.
-// If called on []RepoResult will create NDJson formatted output.
-func (r *RepoResult) AsJSON(showDetails bool, writer io.Writer) error {
+// If called on []ScorecardResult will create NDJson formatted output.
+func (r *ScorecardResult) AsJSON(showDetails bool, writer io.Writer) error {
 	encoder := json.NewEncoder(writer)
 	if showDetails {
 		if err := encoder.Encode(r); err != nil {
@@ -42,7 +42,7 @@ func (r *RepoResult) AsJSON(showDetails bool, writer io.Writer) error {
 		}
 		return nil
 	}
-	out := RepoResult{
+	out := ScorecardResult{
 		Repo:     r.Repo,
 		Date:     r.Date,
 		Metadata: r.Metadata,
@@ -61,7 +61,7 @@ func (r *RepoResult) AsJSON(showDetails bool, writer io.Writer) error {
 	return nil
 }
 
-func (r *RepoResult) AsCSV(showDetails bool, writer io.Writer) error {
+func (r *ScorecardResult) AsCSV(showDetails bool, writer io.Writer) error {
 	w := csv.NewWriter(writer)
 	record := []string{r.Repo}
 	columns := []string{"Repository"}
@@ -85,7 +85,7 @@ func (r *RepoResult) AsCSV(showDetails bool, writer io.Writer) error {
 	return nil
 }
 
-func (r *RepoResult) AsString(showDetails bool, writer io.Writer) error {
+func (r *ScorecardResult) AsString(showDetails bool, writer io.Writer) error {
 	fmt.Fprintf(writer, "Repo: %s\n", r.Repo)
 	for _, checkResult := range r.Checks {
 		fmt.Fprintf(writer, "%s: %s %d\n", checkResult.Name, displayResult(checkResult.Pass), checkResult.Confidence)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Moves `repos.RepoResult` to `pkg.ScorecardResult`. This decouples the `repos` package from `checker` package. This allows us to import `repos` inside `checker` as intended. Today, we were unable to do this since `repos.RepoResult` depended on `checker`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.