### PR TITLE
✨ Provide remediation suggestions in results

### DIFF
--- a/checker/check_runner.go
+++ b/checker/check_runner.go
@@ -47,7 +47,7 @@ func (l *logger) Logf(s string, f ...interface{}) {
 	l.messages = append(l.messages, fmt.Sprintf(s, f...))
 }
 
-func logStats(ctx context.Context, startTime time.Time, result CheckResult) error {
+func logStats(ctx context.Context, startTime time.Time, result *CheckResult) error {
 	runTimeInSecs := time.Now().Unix() - startTime.Unix()
 	opencensusstats.Record(ctx, stats.CheckRuntimeInSec.M(runTimeInSecs))
 
@@ -84,7 +84,7 @@ func (r *Runner) Run(ctx context.Context, f CheckFn) CheckResult {
 	}
 	res.Details = l.messages
 
-	if err := logStats(ctx, startTime, res); err != nil {
+	if err := logStats(ctx, startTime, &res); err != nil {
 		panic(err)
 	}
 	return res

--- a/checks/checks.md
+++ b/checks/checks.md
@@ -86,6 +86,13 @@ This check tries to determine if the project uses a fuzzing system. It currently
 **Remediation steps**
 - Integrate the project with OSS-Fuzz by following the instructions [here](https://google.github.io/oss-fuzz/).
 
+## Packaging 
+
+This check tries to determine if a project has a GitHub workflow that publishes to a package repository. 
+
+**Remediation steps**
+- Create a GitHub workflow that publishes this repository to the package repository for your language (e.g. npm, maven, Docker, pypi).
+
 ## Pull-Requests 
 
 This check tries to determine if the project requires pull requests for all changes to the default branch. It works by looking at recent commits (first page, ~30) and uses the GitHub API to search for associated pull requests. The check discards commits by usernames containing 'bot' or 'gardener'. The check considers a commit containing the string `Reviewed-on` as being reviewed through gerrit; and does not check for a corresponding PR. 

--- a/checks/checks.yaml
+++ b/checks/checks.yaml
@@ -14,6 +14,13 @@
 
 # This is the source of truth for all check descriptions and remediation steps.
 # Run `cd checks/main && go run /main` to generate `checks.json` and `checks.md`.
+
+# If a check has differing remediation steps based on the specific issue found,
+# then codes can be assigned to those issues and those codes can be associated
+# to specific remediation steps in this file. See "Frozen-Deps" as an example.
+# If a set of remediation steps is not associated here with any code, those
+# steps will be included for any failed check.
+
 checks:
   Token-Permissions:
     description: >-
@@ -24,6 +31,7 @@ checks:
       this check succeeds. Otherwise it fails. The check cannot detect if the "read-only"
       GitHub permission settings is enabled, as there is no API available.
     remediation:
+    - steps:
       - >-
         Set permissions as `read-all` or `contents: read` as described in
         GitHub's [documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions).
@@ -33,6 +41,7 @@ checks:
       policy. It works by looking for a file named `SECURITY.md`
       (case-insensitive) in a few well-known directories.
     remediation:
+    - steps:
       - >-
         Place a security policy file `SECURITY.md` in the root directory of your
         repository. This makes it easily discoverable by a vulnerability
@@ -48,6 +57,7 @@ checks:
       [renovatebot](https://docs.renovatebot.com/configuration-options/). This check only looks if 
       it is enabled and does not ensure that it is run and pull requests are merged.
     remediation:
+    - steps:
       - >-
         Signup for automatic dependency updates with dependabot or renovatebot and place the config
         file in the locations that are recommended by these tools.
@@ -56,6 +66,7 @@ checks:
       This check tries to determine if a project has binary artifacts in the source repository.
       These binaries could be compromised artifacts.Building from the source is recommended.
     remediation:
+    - steps:
       - >-
         Remove the binary artifacts from the repository. 
   Contributors:
@@ -66,6 +77,7 @@ checks:
       must have at least 5 commint in the last 30 commits. The check succeeds if
       all contributor span  at least 2 different companies.
     remediation:
+    - steps:
       - >-
         There is *NO* remediation work needed here. This is just to provide some
         insights on which organization(s) have contributed to the project and
@@ -83,6 +95,7 @@ checks:
       the files in (1) AND all the dependencies in (2) are pinned, the check
       succeds.
     remediation:
+    - steps:
       - >-
         Declare all your dependencies with specific versions in your package
         format file (e.g. `package.json` for npm, `requirements.txt` for
@@ -93,19 +106,28 @@ checks:
         npm), make sure to check these in the source code as well. These files
         maintain signatures for the entire dependency tree and saves from future
         exploitation in case the package is compromised.
+      codes:
+      - FDP03
+    - steps:
       - >-
         For Dockerfiles and github workflows, pin dependencies by hash. See example
         [gitcache-docker.yaml](https://github.com/ossf/scorecard/blob/main/.github/workflows/gitcache-docker.yaml#L36)
         and [Dockerfile](https://github.com/ossf/scorecard/blob/main/cron/worker/Dockerfile) examples.
+      codes:
+      - FDP01
+      - FDP02
+    - steps:
       - >-
         To help update your dependencies after pinning them, use tools such as 
         Github's [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)
         or [renovate bot](https://github.com/renovatebot/renovate).
+
   Signed-Tags:
     description: >-
       This check looks for cryptographically signed tags in the last 5 tags. The
       check does not verify the signature, but relies on github's verification.
     remediation:
+    - steps:
       - Generate a new signing key.
       - Add your key to your source hosting provider.
       - Configure your key and email in git.
@@ -120,6 +142,7 @@ checks:
       (https://github.com/jedisct1/minisign), *.asc (pgp), *.sign. for the last
       5 GitHub releases. The check does not verify the signatures.
     remediation:
+    - steps:
       - Publish the release.
       - Generate a signing key.
       - Download the release as an archive locally.
@@ -139,6 +162,7 @@ checks:
       successful pull requests have at least one successful check associated
       with them.
     remediation:
+    - steps:
       - Check-in scripts that run all the tests in your repository.
       - >-
         Integrate those scripts with a CI/CD platform that runs it on every pull
@@ -158,6 +182,7 @@ checks:
       (labels "lgtm" or "approved"). If this fails, it does the same but looking
       for gerrit-specific commit messages ("Reviewed-on" and "Reviewed-by").
     remediation:
+    - steps:
       - >-
         Follow security best practices by performing strict code reviews for
         every new pull request.
@@ -174,6 +199,7 @@ checks:
       for the Git repo and the CII API. The check does not consider  if the repo
       has a solver or gold levels for passing the test.
     remediation:
+    - steps:
       - >-
         Sign up for the [CII Best Practices
         program](https://bestpractices.coreinfrastructure.org/en).
@@ -187,6 +213,7 @@ checks:
       `Reviewed-on` as being reviewed through gerrit; and does not check for a
       corresponding PR.
     remediation:
+    - steps:
       - >-
         Always open a pull request for any change you intend to make, big or
         small.
@@ -202,6 +229,7 @@ checks:
       currently works by checking if the repo name is in the
       [OSS-Fuzz](https://github.com/google/oss-fuzz) project list.
     remediation:
+    - steps:
       - >-
         Integrate the project with OSS-Fuzz by following the instructions
         [here](https://google.github.io/oss-fuzz/).
@@ -216,6 +244,7 @@ checks:
       the check succeeds. If the above fails, the check instead looks for the
       use of "github/codeql-action" in a github workflow.
     remediation:
+    - steps:
       - >-
         Run CodeQL checks in your CI/CD by following the instructions
         [here](https://github.com/github/codeql-action#usage).
@@ -227,6 +256,7 @@ checks:
       currently works by looking for commits within the last 90 days, and
       succeeds if there are at least 2 commits in the last 90 days.
     remediation:
+    - steps:
       - >-
         There is *NO* remediation work needed here. This is just to indicate
         your project activity and maintenance commitment.
@@ -243,6 +273,7 @@ checks:
       enabled), RequiredPullRequestReviews (>=1), DismissStaleReviews (enabled),
       RequireCodeOwnerReviews (enabled).
     remediation:
+    - steps:
       - >-
         Enable branch protection settings in your source hosting provider to
         avoid force pushes or deletion of your important branches.
@@ -254,6 +285,7 @@ checks:
       This check determines whether if there are open, unfixed vulnerabilities
       in the project using the [OSV](https://osv.dev) service.
     remediation:
+    - steps:
       - >-
         Fix the vulnerabilities. The details of each vulnerability can be found
         on <https://osv.dev>.

--- a/checks/checks.yaml
+++ b/checks/checks.yaml
@@ -289,3 +289,12 @@ checks:
       - >-
         Fix the vulnerabilities. The details of each vulnerability can be found
         on <https://osv.dev>.
+  Packaging:
+    description: >-
+      This check tries to determine if a project has a GitHub workflow that publishes
+      to a package repository.
+    remediation:
+    - steps:
+      - >-
+        Create a GitHub workflow that publishes this repository to the package
+        repository for your language (e.g. npm, maven, Docker, pypi).

--- a/checks/frozen_deps.go
+++ b/checks/frozen_deps.go
@@ -131,7 +131,9 @@ func validateDockerfileDownloads(pathfn string, content []byte,
 }
 
 func isDockerfilePinned(c *checker.CheckRequest) checker.CheckResult {
-	return CheckFilesContent(CheckFrozenDeps, "*Dockerfile*", false, c, validateDockerfile)
+	result := CheckFilesContent(CheckFrozenDeps, "*Dockerfile*", false, c, validateDockerfile)
+	result.AddFailureCode("FDP01")
+	return result
 }
 
 func validateDockerfile(pathfn string, content []byte,
@@ -273,7 +275,9 @@ func validateGitHubWorkflowShellScriptDownloads(pathfn string, content []byte,
 
 // Check pinning of github actions in workflows.
 func isGitHubActionsWorkflowPinned(c *checker.CheckRequest) checker.CheckResult {
-	return CheckFilesContent(CheckFrozenDeps, ".github/workflows/*", true, c, validateGitHubActionWorkflow)
+	result := CheckFilesContent(CheckFrozenDeps, ".github/workflows/*", true, c, validateGitHubActionWorkflow)
+	result.AddFailureCode("FDP02")
+	return result
 }
 
 // Check file content.
@@ -312,7 +316,9 @@ func validateGitHubActionWorkflow(pathfn string, content []byte, logf func(s str
 
 // Check presence of lock files thru validatePackageManagerFile().
 func isPackageManagerLockFilePresent(c *checker.CheckRequest) checker.CheckResult {
-	return CheckIfFileExists(CheckFrozenDeps, c, validatePackageManagerFile)
+	result := CheckIfFileExists(CheckFrozenDeps, c, validatePackageManagerFile)
+	result.AddFailureCode("FDP03")
+	return result
 }
 
 // validatePackageManagerFile will validate the if frozen dependecies file name exists.

--- a/checks/main/main.go
+++ b/checks/main/main.go
@@ -19,12 +19,9 @@ import (
 	"sort"
 
 	"gopkg.in/yaml.v2"
-)
 
-type doc struct {
-	Description string   `yaml:"description"`
-	Remediation []string `yaml:"remediation"`
-}
+	"github.com/ossf/scorecard/checks"
+)
 
 func main() {
 	yamlFile, err := os.Open("../checks.yaml")
@@ -37,7 +34,7 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	m := make(map[string]map[string]doc)
+	m := make(map[string]map[string]checks.CheckInfo)
 	err = yaml.Unmarshal(byteValue, &m)
 	if err != nil {
 		panic(err)
@@ -82,9 +79,11 @@ please contribute!
 			panic(err)
 		}
 		for _, r := range m["checks"][k].Remediation {
-			_, err = f.WriteString("- " + r + "\n")
-			if err != nil {
-				panic(err)
+			for _, s := range r.Steps {
+				_, err = f.WriteString("- " + s + "\n")
+				if err != nil {
+					panic(err)
+				}
 			}
 		}
 		_, err = f.WriteString("\n")

--- a/checks/remediation.go
+++ b/checks/remediation.go
@@ -1,0 +1,88 @@
+// Copyright 2021 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+
+	// Used to embed checks.yaml.
+	_ "embed"
+	"errors"
+	"fmt"
+
+	"gopkg.in/yaml.v2"
+
+	"github.com/ossf/scorecard/checker"
+)
+
+var (
+	//go:embed checks.yaml
+	checksYAMLBytes []byte
+	// ErrUnknownCheckName is when the name of a check is not present in checks.yaml.
+	ErrUnknownCheckName = errors.New("unknown check name")
+)
+
+// CheckInfo is the structure for checks.yaml.
+type CheckInfo struct {
+	Description string        `yaml:"description"`
+	Remediation []Remediation `yaml:"remediation"`
+}
+
+type Remediation struct {
+	Steps []string `yaml:"steps"`
+	Codes []string `yaml:"codes"`
+}
+
+// GetRemediationSteps returns a list of steps that can be done to remediate the issues (if there are any).
+func GetRemediationSteps(result *checker.CheckResult) ([]string, error) {
+	steps := make([]string, 0)
+	if !result.DoShowRemediation() {
+		return steps, nil
+	}
+	m := make(map[string]map[string]CheckInfo)
+	err := yaml.Unmarshal(checksYAMLBytes, &m)
+	if err != nil {
+		return steps, fmt.Errorf("error unmarshalling checks.yaml: %w", err)
+	}
+	checkInfo, found := m["checks"][result.Name]
+	if !found {
+		return steps, fmt.Errorf("%w: %s", ErrUnknownCheckName, result.Name)
+	}
+
+	var remediationNoCodes *Remediation
+	for i, remediation := range checkInfo.Remediation {
+		if len(remediation.Codes) == 0 {
+			remediationNoCodes = &checkInfo.Remediation[i]
+		} else if anyItemsMatch(remediation.Codes, result.FailureCodes) {
+			steps = append(steps, remediation.Steps...)
+		}
+	}
+
+	// Whether any codes matched or not, we'll add the "generic" remediation steps.
+	if remediationNoCodes != nil {
+		steps = append(steps, remediationNoCodes.Steps...)
+	}
+	return steps, nil
+}
+
+func anyItemsMatch(slice1, slice2 []string) bool {
+	for _, item1 := range slice1 {
+		for _, item2 := range slice2 {
+			if item1 == item2 {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/checks/remediation_test.go
+++ b/checks/remediation_test.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/checker"
+)
+
+// TestRemediationSteps tests that every check has remediation steps.
+func TestRemediationSteps(t *testing.T) {
+	t.Parallel()
+	for checkName := range AllChecks {
+		result := checker.CheckResult{
+			Name:       checkName,
+			Confidence: checker.MaxResultConfidence,
+		}
+		steps, err := GetRemediationSteps(&result)
+		if err != nil {
+			t.Errorf("GetRemediationSteps() for %s gave error: %s", checkName, err.Error())
+		} else if len(steps) == 0 {
+			// If there is a check where all the remediation steps have a code assigned, then this test should be
+			// modified to use one of those codes for that check.
+			t.Errorf("GetRemediationSteps() for %s returned 0 steps", checkName)
+		}
+	}
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
Remediation results are not included in the terminal results
Closes #304 

* **What is the new behavior (if this is a feature change)?**
When run with the `--show-details` flag, the results in the terminal will include remediation suggestions. Remediation will only be displayed if the check has a certain level of confidence (currently 5 or higher but I'm open to modifying that number). This should prevent remediation steps from showing if the check failed due to internal issues such as being rate-limited in API requests.

The remediation steps are pulled from `checks.yaml` which will be embedded into the `scorecard` binary. This PR increases the size of the binary from 19.93MB. to 19.95MB.

If a check has differing remediation steps based on the specific issue found, then codes can be assigned to those issues and those codes can be associated to specific remediation steps in `checks.yaml`. See "Frozen-Deps" as an example. If a set of remediation steps is not associated here with any code, those steps will be included for any failed check.

Here is a partial view of output that includes remediation steps:
![image](https://user-images.githubusercontent.com/8961650/124492930-e9dfe080-dd69-11eb-9c17-d2635d7a0ec0.png)
Notice that the remediation results include markdown syntax. I thought about ways to scrub the markdown but I couldn't think of a way to do it that didn't disrupt the flow of the sentence.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
Here are some areas I'd like feedback on:
- Is 5 the right confidence level for displaying remediation?
- Should there be a separate flag for displaying remediation? Or should it always be displayed?
- Is there a decent way to clean up the markdown syntax in the results?