### PR TITLE
:bug: Added error for invalid checks

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -120,6 +120,8 @@ or ./scorecard --{npm,pypi,rubgems}=<package_name> [--checks=check1,...] [--show
 			for _, checkToRun := range checksToRun {
 				if checkFn, ok := checks.AllChecks[checkToRun]; ok {
 					enabledChecks[checkToRun] = checkFn
+				} else {
+					log.Fatalf("Invalid check: %s", checkToRun)
 				}
 			}
 		} else {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes #673


* **What is the current behavior?** (You can also link to an open issue here)
No error is returned if invalid checks are provided.


* **What is the new behavior (if this is a feature change)?**
An error is returned if an invalid check is provided.

```bash
scorecard --repo=github.com/ossf/scorecard --checks=invalid-check
2021/07/13 08:44:22 Invalid check: invalid-check
```

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Maybe, but only if users are providing `checks` arguments which are invalid anyway.


* **Other information**:
