### PR TITLE
✨ Add more github token names for env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ For example, `--checks=CI-Tests,Code-Review`.
 Before running Scorecard, you need to, either:
 
 -   [create a GitHub access token](https://docs.github.com/en/free-pro-team@latest/developers/apps/about-apps#personal-access-tokens)
-    and set it in environment variable `GITHUB_AUTH_TOKEN`. This helps to avoid
+    and set it in environment variable called `GITHUB_AUTH_TOKEN`, `GITHUB_TOKEN`, `GH_AUTH_TOKEN` or `GH_TOKEN`. This helps to avoid
     the GitHub's
     [api rate limits](https://developer.github.com/v3/#rate-limiting) with
     unauthenticated requests.
@@ -241,13 +241,27 @@ Before running Scorecard, you need to, either:
 ```shell
 # For posix platforms, e.g. linux, mac:
 export GITHUB_AUTH_TOKEN=<your access token>
+# Multiple tokens can be provided separated by comma to be utilized
+# in a round robin fashion.
+export GITHUB_AUTH_TOKEN=<your access token1>,<your access token2>
 
 # For windows:
 set GITHUB_AUTH_TOKEN=<your access token>
+set GITHUB_AUTH_TOKEN=<your access token1>,<your access token2>
 ```
 
-Multiple `GITHUB_AUTH_TOKEN` can be provided separated by comma to be utilized
-in a round robin fashion.
+-   create a GitHub App Installations for higher rate-limit quotas. If you have
+    an installed GitHub App and key file, you can use these three environment
+    variables, following the commands shown above for your platform.
+
+```
+GITHUB_APP_KEY_PATH=<path to the key file on disk>
+GITHUB_APP_INSTALLATION_ID=<installation id>
+GITHUB_APP_ID=<app id>
+```
+
+These can be obtained from the GitHub
+[developer settings](https://github.com/settings/apps) page.
 
 ### Understanding Scorecard results
 

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ For example, `--checks=CI-Tests,Code-Review`.
 Before running Scorecard, you need to, either:
 
 -   [create a GitHub access token](https://docs.github.com/en/free-pro-team@latest/developers/apps/about-apps#personal-access-tokens)
-    and set it in environment variable called `GITHUB_AUTH_TOKEN`, `GITHUB_TOKEN`, `GH_AUTH_TOKEN` or `GH_TOKEN`. This helps to avoid
+    and set it in an environment variable called `GITHUB_AUTH_TOKEN`, `GITHUB_TOKEN`, `GH_AUTH_TOKEN` or `GH_TOKEN`. This helps to avoid
     the GitHub's
     [api rate limits](https://developer.github.com/v3/#rate-limiting) with
     unauthenticated requests.

--- a/README.md
+++ b/README.md
@@ -249,19 +249,6 @@ set GITHUB_AUTH_TOKEN=<your access token>
 Multiple `GITHUB_AUTH_TOKEN` can be provided separated by comma to be utilized
 in a round robin fashion.
 
--   create a GitHub App Installations for higher rate-limit quotas. If you have
-    an installed GitHub App and key file, you can use these three environment
-    variables, following the commands shown above for your platform.
-
-```
-GITHUB_APP_KEY_PATH=<path to the key file on disk>
-GITHUB_APP_INSTALLATION_ID=<installation id>
-GITHUB_APP_ID=<app id>
-```
-
-These can be obtained from the GitHub
-[developer settings](https://github.com/settings/apps) page.
-
 ### Understanding Scorecard results
 
 Each check returns a **Pass / Fail** decision, as well as a confidence score

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,19 +61,6 @@ const (
 	formatDefault = "default"
 )
 
-func gitHubTokenExists() bool {
-	if token, exists := os.LookupEnv("GITHUB_AUTH_TOKEN"); exists && token != "" {
-		return true
-	}
-	if token, exists := os.LookupEnv("GITHUB_AUTH_TOKEN"); exists && token != "" {
-		return true
-	}
-	if token, exists := os.LookupEnv("GITHUB_AUTH_TOKEN"); exists && token != "" {
-		return true
-	}
-	return false
-}
-
 var rootCmd = &cobra.Command{
 	Use: `./scorecard --repo=<repo_url> [--checks=check1,...] [--show-details]
 or ./scorecard --{npm,pypi,rubgems}=<package_name> [--checks=check1,...] [--show-details]`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,19 @@ const (
 	formatDefault = "default"
 )
 
+func gitHubTokenExists() bool {
+	if token, exists := os.LookupEnv("GITHUB_AUTH_TOKEN"); exists && token != "" {
+		return true
+	}
+	if token, exists := os.LookupEnv("GITHUB_AUTH_TOKEN"); exists && token != "" {
+		return true
+	}
+	if token, exists := os.LookupEnv("GITHUB_AUTH_TOKEN"); exists && token != "" {
+		return true
+	}
+	return false
+}
+
 var rootCmd = &cobra.Command{
 	Use: `./scorecard --repo=<repo_url> [--checks=check1,...] [--show-details]
 or ./scorecard --{npm,pypi,rubgems}=<package_name> [--checks=check1,...] [--show-details]`,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,10 +80,6 @@ or ./scorecard --{npm,pypi,rubgems}=<package_name> [--checks=check1,...] [--show
 	Short: "Security Scorecards",
 	Long:  "A program that shows security scorecard for an open source software.",
 	Run: func(cmd *cobra.Command, args []string) {
-		if token, exists := os.LookupEnv("GITHUB_AUTH_TOKEN"); !exists || token == "" {
-			log.Fatalf("GITHUB_AUTH_TOKEN env var is not set. Please set this to your Github PAT before running this command.")
-		}
-
 		cfg := zap.NewProductionConfig()
 		cfg.Level.SetLevel(*logLevel)
 		logger, err := cfg.Build()

--- a/roundtripper/roundtripper.go
+++ b/roundtripper/roundtripper.go
@@ -41,7 +41,7 @@ const (
 	GithubAppInstallationID = "GITHUB_APP_INSTALLATION_ID"
 )
 
-func readGitHubToken() (string, bool) {
+func readGitHubTokens() (string, bool) {
 	for _, name := range GithubAuthTokens {
 		if token, exists := os.LookupEnv(name); exists && token != "" {
 			return token, exists
@@ -55,7 +55,7 @@ func NewTransport(ctx context.Context, logger *zap.SugaredLogger) http.RoundTrip
 	transport := http.DefaultTransport
 
 	// nolinter
-	if token, exists := readGitHubToken(); exists {
+	if token, exists := readGitHubTokens(); exists {
 		// Use GitHub PAT
 		transport = githubrepo.MakeGitHubTransport(transport, strings.Split(token, ","))
 	} else if keyPath := os.Getenv(GithubAppKeyPath); keyPath != "" { // Also try a GITHUB_APP

--- a/roundtripper/roundtripper.go
+++ b/roundtripper/roundtripper.go
@@ -24,6 +24,8 @@ import (
 
 	"github.com/bradleyfalzon/ghinstallation"
 	"go.uber.org/zap"
+
+	"github.com/ossf/scorecard/clients/githubrepo"
 )
 
 // GithubAuthTokens are for making requests to GiHub's API.

--- a/roundtripper/roundtripper.go
+++ b/roundtripper/roundtripper.go
@@ -54,7 +54,7 @@ func readGitHubTokens() (string, bool) {
 func NewTransport(ctx context.Context, logger *zap.SugaredLogger) http.RoundTripper {
 	transport := http.DefaultTransport
 
-	// nolinter
+	// nolint
 	if token, exists := readGitHubTokens(); exists {
 		// Use GitHub PAT
 		transport = githubrepo.MakeGitHubTransport(transport, strings.Split(token, ","))


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [] Tests for the changes have been added (for bug fixes / features)
- [X] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
we only use GITHUB_AUTH_TOKEN


* **What is the new behavior (if this is a feature change)?**
we add GITHUB_TOKEN and GH_TOKEN. This is helpful because some existing tools use different naming, so re-using the names requires users to set the env variable once only across multiple tools.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
