### PR TITLE
📖 Update local install instructions to use v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ docker run -e GITHUB_AUTH_TOKEN=token gcr.io/openssf/scorecard:latest --show-det
 The program can run using just one argument, the URL of the repo:
 
 ```shell
-$ go get github.com/ossf/scorecard
+$ go get github.com/ossf/scorecard/v2
 $ scorecard --repo=github.com/kubernetes/kubernetes
 Starting [Signed-Tags]
 Starting [Automatic-Dependency-Update]


### PR DESCRIPTION
The docs instructions for installing locally would `go get` an older version of scorecards. This updates to `v2`.

Signed-off-by: Appu Goundan <appu@google.com>
