### PR TITLE
✨Add version cli subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,27 @@ IMAGE_NAME = scorecard
 OUTPUT = output
 IGNORED_CI_TEST="E2E TEST:blob|E2E TEST:executable"
 
+# generate VERSION_LDFLAGS
+GIT_VERSION ?= $(shell git describe --tags --always --dirty)
+GIT_HASH ?= $(shell git rev-parse HEAD)
+DATE_FMT = +'%Y-%m-%dT%H:%M:%SZ'
+SOURCE_DATE_EPOCH ?= $(shell git log -1 --pretty=%ct)
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+GIT_TREESTATE = clean
+DIFF = $(shell git diff --quiet >/dev/null 2>&1; if [ $$? -eq 1 ]; then echo "1"; fi)
+ifeq ($(DIFF), 1)
+    GIT_TREESTATE = dirty
+endif
+
+# version should be injected in the cmd package
+PKG=$(shell go list -m | head -n1)/cmd
+
+VERSION_LDFLAGS=-X $(PKG).gitVersion=$(GIT_VERSION) -X $(PKG).gitCommit=$(GIT_HASH) -X $(PKG).gitTreeState=$(GIT_TREESTATE) -X $(PKG).buildDate=$(BUILD_DATE)
+
 ############################### make help #####################################
 .PHONY: help
 help:  ## Display this help
@@ -94,7 +115,7 @@ checks/checks.md: checks/checks.yaml checks/main/*.go
 
 build-scorecard: ## Runs go build on repo
 	# Run go build and generate scorecard executable
-	CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static"'
+	CGO_ENABLED=0 go build -a -tags netgo -ldflags '-w -extldflags "-static" $(VERSION_LDFLAGS)'
 
 build-pubsub: ## Runs go build on the PubSub cron job
 	# Run go build and the PubSub cron job

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+// Base version information.
+//
+// This is the fallback data used when version information from git is not
+// provided via go ldflags in the Makefile. See version.mk.
+var (
+	// Output of "git describe". The prerequisite is that the branch should be
+	// tagged using the correct versioning strategy.
+	gitVersion = "unknown"
+	// SHA1 from git, output of $(git rev-parse HEAD).
+	gitCommit = "unknown"
+	// State of git tree, either "clean" or "dirty".
+	gitTreeState = "unknown"
+	// Build date in ISO8601 format, output of $(date -u +'%Y-%m-%dT%H:%M:%SZ').
+	buildDate = "unknown"
+)
+
+//nolint:gochecknoinits
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print version information",
+	Long:  ``,
+	Run: func(cmd *cobra.Command, args []string) {
+		// not using logger, since it prints timing info, etc
+		fmt.Printf("GitVersion:\t%s\n", gitVersion)
+		fmt.Printf("GitCommit:\t%s\n", gitCommit)
+		fmt.Printf("GitTreeState:\t%s\n", gitTreeState)
+		fmt.Printf("BuildDate:\t%s\n", buildDate)
+		fmt.Printf("GoVersion:\t%s\n", runtime.Version())
+		fmt.Printf("Compiler:\t%s\n", runtime.Compiler)
+		fmt.Printf("Platform:\t%s/%s\n", runtime.GOOS, runtime.GOARCH)
+	},
+}


### PR DESCRIPTION
`scorecard version` will print out something like

```
GitVersion:     v2.0.0-73-g7fd331a-dirty
GitCommit:      7fd331adf2a0f6578b78d951e16646da03e6a6f5
GitTreeState:   dirty
BuildDate:      2021-07-27T14:14:34Z
GoVersion:      go1.16.4
Compiler:       gc
Platform:       linux/amd64
```

Signed-off-by: Appu Goundan <appu@google.com>
