### PR TITLE
🐛  Fix panic error when RequiredPullRequestReviews is nil

### DIFF
--- a/checks/branch_protected.go
+++ b/checks/branch_protected.go
@@ -246,10 +246,11 @@ func requiresThoroughReviews(protection *github.Protection, branch string, dl ch
 		protection.RequiredPullRequestReviews.RequireCodeOwnerReviews {
 		return true
 	}
-	switch {
-	case protection.RequiredPullRequestReviews == nil:
+	if protection.RequiredPullRequestReviews == nil {
 		dl.Warn("Pullrequest reviews disabled on branch '%s'", branch)
-		fallthrough
+		return false
+	}
+	switch {
 	case protection.RequiredPullRequestReviews.RequiredApprovingReviewCount < minReviews:
 		dl.Warn("Number of required reviewers is only %d on branch '%s'",
 			protection.RequiredPullRequestReviews.RequiredApprovingReviewCount, branch)

--- a/checks/branch_protected_test.go
+++ b/checks/branch_protected_test.go
@@ -467,6 +467,17 @@ func TestIsBranchProtected(t *testing.T) {
 			},
 		},
 		{
+			name: "Nothing is enabled and values in github.Protection are nil",
+			expected: scut.TestReturn{
+				Errors:        nil,
+				Score:         2,
+				NumberOfWarn:  4,
+				NumberOfInfo:  2,
+				NumberOfDebug: 0,
+			},
+			protection: &github.Protection{},
+		},
+		{
 			name: "Required status check enabled",
 			expected: scut.TestReturn{
 				Errors:        nil,


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bug fix


* **What is the current behavior?** (You can also link to an open issue here)

When `github.Protection.RequiredPullRequestReviews == nil`, then `requiresThoroughReviews()` emits panic.
(it seemed caused by PR reviews are disabled in the repo or lack of GitHub token's permission?)


* **What is the new behavior (if this is a feature change)?**

When `github.Protection.RequiredPullRequestReviews == nil`, then `requiresThoroughReviews()` does not emit panic.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:
