### PR TITLE
✨  Feature: Include Check Score When Outputting JSON

### DIFF
--- a/checker/check_result.go
+++ b/checker/check_result.go
@@ -78,7 +78,7 @@ type CheckResult struct {
 	Version  int           `json:"-"` // Default value of 0 indicates old structure.
 	Error2   error         `json:"-"` // Runtime error indicate a filure to run the check.
 	Details2 []CheckDetail `json:"-"` // Details of tests and sub-checks
-	Score    int           `json:"-"` // {[-1,0...10], -1 = Inconclusive}
+	Score    int           // {[-1,0...10], -1 = Inconclusive}
 	Reason   string        `json:"-"` // A sentence describing the check result (score, etc)
 }
 

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -61,6 +61,7 @@ func (r *ScorecardResult) AsJSON(showDetails bool, logLevel zapcore.Level, write
 			Name:       checkResult.Name,
 			Pass:       checkResult.Pass,
 			Confidence: checkResult.Confidence,
+			Score:      checkResult.Score,
 		}
 		out.Checks = append(out.Checks, tmpResult)
 	}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
**Feature**
When outputting the results in JSON, it can be helpful to know the score as determined by the specific check.

* **What is the current behavior?** (You can also link to an open issue here)
Currently, the score field is not included when the output format is JSON.

* **What is the new behavior (if this is a feature change)?**
With these changes, the score field will be included in the check object.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
I can't think of any scenarios this would break anything.  The only case is if someone depends on a missing score field in the check object, but I'm not sure what use case that would have.

* **Other information**:
