### PR TITLE
:sparkles:  fix: add github.com as default for owner/repo parameter 

### DIFF
--- a/repos/repo_url.go
+++ b/repos/repo_url.go
@@ -56,12 +56,25 @@ func (r *RepoURL) String() string {
 
 // Set parses a URL string into RepoURL struct.
 func (r *RepoURL) Set(s string) error {
-	// Allow skipping scheme for ease-of-use, default to https.
-	if !strings.Contains(s, "://") {
-		s = "https://" + s
+	var t string
+
+	c := strings.Split(s, "/")
+
+	switch l := len(c); {
+	// this will takes care for repo/owner format, by default use github.com
+	case l == 2:
+		t = "github.com/" + c[0] + "/" + c[1]
+		break
+	case l >= 3:
+		t = s
 	}
 
-	u, e := url.Parse(s)
+	// Allow skipping scheme for ease-of-use, default to https.
+	if !strings.Contains(t, "://") {
+		t = "https://" + t
+	}
+
+	u, e := url.Parse(t)
 	if e != nil {
 		//nolint:wrapcheck
 		return sce.Create(sce.ErrScorecardInternal, fmt.Sprintf("url.Parse: %v", e))

--- a/repos/repo_url.go
+++ b/repos/repo_url.go
@@ -58,14 +58,17 @@ func (r *RepoURL) String() string {
 func (r *RepoURL) Set(s string) error {
 	var t string
 
+	const two = 2
+	const three = 3
+
 	c := strings.Split(s, "/")
 
 	switch l := len(c); {
 	// this will takes care for repo/owner format, by default use github.com
-	case l == 2:
+	case l == two:
 		t = "github.com/" + c[0] + "/" + c[1]
 		break
-	case l >= 3:
+	case l >= three:
 		t = s
 	}
 

--- a/repos/repo_url.go
+++ b/repos/repo_url.go
@@ -64,10 +64,10 @@ func (r *RepoURL) Set(s string) error {
 	c := strings.Split(s, "/")
 
 	switch l := len(c); {
-	// this will takes care for repo/owner format, by default use github.com
+	// This will takes care for repo/owner format.
+	// By default it will use github.com
 	case l == two:
 		t = "github.com/" + c[0] + "/" + c[1]
-		break
 	case l >= three:
 		t = s
 	}

--- a/repos/repo_url_test.go
+++ b/repos/repo_url_test.go
@@ -64,6 +64,26 @@ func TestRepoURL_ValidGitHubUrl(t *testing.T) {
 			args:    args{s: "https://gitlab.com/foo/kubeflow"},
 			wantErr: true,
 		},
+		{
+			name: "github repository",
+			fields: fields{
+				Host:  "github.com",
+				Owner: "foo",
+				Repo:  "kubeflow",
+			},
+			args:    args{s: "foo/kubeflow"},
+			wantErr: false,
+		},
+		{
+			name: "github repository",
+			fields: fields{
+				Host:  "github.com",
+				Owner: "foo",
+				Repo:  "kubeflow",
+			},
+			args:    args{s: "https://github.com/foo/kubeflow"},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

New feature outlined #780 

* **What is the current behavior?** (You can also link to an open issue here)

Currently, it does not accept `repo/owner` format

* **What is the new behavior (if this is a feature change)?**

New behaviour will accept `repo/owner` format and using `github.com` as the default domain.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:
