### PR TITLE
🐛 Replace `errors.As` with `Is`

### DIFF
--- a/checks/security_policy.go
+++ b/checks/security_policy.go
@@ -105,7 +105,7 @@ func SecurityPolicy(c *checker.CheckRequest) checker.CheckResult {
 		if r {
 			return checker.CreateMaxScoreResult(CheckSecurityPolicy, "security policy file detected")
 		}
-	case !errors.As(err, &errIgnore):
+	case !errors.Is(err, errIgnore):
 		return checker.CreateRuntimeErrorResult(CheckSecurityPolicy, err)
 	}
 	return checker.CreateMinScoreResult(CheckSecurityPolicy, "security policy file not detected")

--- a/clients/githubrepo/tarball_test.go
+++ b/clients/githubrepo/tarball_test.go
@@ -148,7 +148,7 @@ func TestExtractTarball(t *testing.T) {
 			// Test GetFileContent API.
 			for _, getcontenttest := range testcase.getcontentTests {
 				content, err := handler.getFileContent(getcontenttest.filename)
-				if getcontenttest.err != nil && !errors.As(err, &getcontenttest.err) {
+				if getcontenttest.err != nil && !errors.Is(err, getcontenttest.err) {
 					t.Errorf("test failed: expected - %v, got - %v", getcontenttest.err, err)
 				}
 				if getcontenttest.err == nil && !cmp.Equal(getcontenttest.output, content) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -141,7 +141,6 @@ or ./scorecard --{npm,pypi,rubgems}=<package_name> [--checks=check1,...] [--show
 		githubClient := github.NewClient(httpClient)
 		graphClient := githubv4.NewClient(httpClient)
 		repoClient := githubrepo.CreateGithubRepoClient(ctx, githubClient, graphClient)
-		defer repoClient.Close()
 
 		repoResult, err := pkg.RunScorecards(ctx, repo, enabledChecks, repoClient, httpClient, githubClient, graphClient)
 		if err != nil {

--- a/cron/config/config.go
+++ b/cron/config/config.go
@@ -174,7 +174,7 @@ func GetShardSize() (int, error) {
 // GetWebhookURL returns the webhook URL to ping on a successful cron job completion.
 func GetWebhookURL() (string, error) {
 	url, err := getStringConfigValue(webhookURL, configYAML, "WebhookURL", "webhook-url")
-	if err != nil && !errors.As(err, &ErrorEmptyConfigValue) {
+	if err != nil && !errors.Is(err, ErrorEmptyConfigValue) {
 		return url, err
 	}
 	return url, nil

--- a/cron/worker/main.go
+++ b/cron/worker/main.go
@@ -95,7 +95,7 @@ func processRequest(ctx context.Context,
 	for _, repoURL := range repoURLs {
 		log.Printf("Running Scorecard for repo: %s", repoURL.URL())
 		result, err := pkg.RunScorecards(ctx, repoURL, checksToRun, repoClient, httpClient, githubClient, graphClient)
-		if errors.As(err, &errIgnore) {
+		if errors.Is(err, errIgnore) {
 			// Not accessible repo - continue.
 			continue
 		}
@@ -104,7 +104,7 @@ func processRequest(ctx context.Context,
 		}
 		for checkIndex := range result.Checks {
 			check := &result.Checks[checkIndex]
-			if !errors.As(check.Error2, &sce.ErrScorecardInternal) {
+			if !errors.Is(check.Error2, sce.ErrScorecardInternal) {
 				continue
 			}
 			errorMsg := fmt.Sprintf("check %s has a runtime error: %v", check.Name, check.Error2)
@@ -203,7 +203,6 @@ func main() {
 	}
 
 	repoClient, httpClient, githubClient, graphClient, logger := createNetClients(ctx)
-	defer repoClient.Close()
 
 	exporter, err := startMetricsExporter()
 	if err != nil {

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -91,6 +91,7 @@ func RunScorecards(ctx context.Context,
 		//nolint:wrapcheck
 		return ScorecardResult{}, err
 	}
+	defer repoClient.Close()
 
 	commits, err := repoClient.ListCommits()
 	if err != nil {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Replace `errors.As` calls with `Is` to avoid overwriting original error values. Thanks to @laurentsimon https://github.com/ossf/scorecard/pull/900#discussion_r695266616

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.