### PR TITLE
✨ Decouple scorecard json from cron json

### DIFF
--- a/cron/worker/main.go
+++ b/cron/worker/main.go
@@ -112,11 +112,11 @@ func processRequest(ctx context.Context,
 			log.Print(errorMsg)
 		}
 		result.Date = batchRequest.GetJobTime().AsTime()
-		if err := result.AsJSON(true /*showDetails*/, zapcore.InfoLevel, &buffer); err != nil {
+		if err := AsJSON(&result, true /*showDetails*/, zapcore.InfoLevel, &buffer); err != nil {
 			return fmt.Errorf("error during result.AsJSON: %w", err)
 		}
 
-		if err := result.AsJSON2(true /*showDetails*/, zapcore.InfoLevel, &buffer2); err != nil {
+		if err := AsJSON2(&result, true /*showDetails*/, zapcore.InfoLevel, &buffer2); err != nil {
 			return fmt.Errorf("error during result.AsJSON2: %w", err)
 		}
 	}

--- a/pkg/common.go
+++ b/pkg/common.go
@@ -32,6 +32,7 @@ func textToMarkdown(s string) string {
 	return strings.ReplaceAll(s, "\n", "  ")
 }
 
+// DetailToString turns a detail information into a string.
 func DetailToString(d *checker.CheckDetail, logLevel zapcore.Level) string {
 	// UPGRADEv3: remove swtch statement.
 	switch d.Msg.Version {

--- a/pkg/common.go
+++ b/pkg/common.go
@@ -32,7 +32,7 @@ func textToMarkdown(s string) string {
 	return strings.ReplaceAll(s, "\n", "  ")
 }
 
-func detailToString(d *checker.CheckDetail, logLevel zapcore.Level) string {
+func DetailToString(d *checker.CheckDetail, logLevel zapcore.Level) string {
 	// UPGRADEv3: remove swtch statement.
 	switch d.Msg.Version {
 	//nolint
@@ -61,7 +61,7 @@ func detailsToString(details []checker.CheckDetail, logLevel zapcore.Level) (str
 	var sa []string
 	for i := range details {
 		v := details[i]
-		s := detailToString(&v, logLevel)
+		s := DetailToString(&v, logLevel)
 		if s != "" {
 			sa = append(sa, s)
 		}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [] Tests for the changes have been added (for bug fixes / features)
- [X] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
feature


* **What is the current behavior?** (You can also link to an open issue here)
use same json for cron and scorecard


* **What is the new behavior (if this is a feature change)?**
separate the two json. This way we can change the scorecard JSON format without affecting the cron job.
We already decoupled the scorecard JSON format from the internal scorecard structure used to store result. This is the next step.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
no


* **Other information**:
This PR blocks https://github.com/ossf/scorecard/pull/934. I will add schema validation and unit tests once we have migrated the cron JSON to be the same as https://github.com/ossf/scorecard/pull/934 