### PR TITLE
📖 README.md: Add hyperlinks to docs/checks.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,22 +48,22 @@ The following checks are all run against the target project by default:
 
 Name                        | Description
 --------------------------- | -----------
-Binary-Artifacts            | Is the project free of checked-in binaries?
-Branch-Protection           | Does the project use [Branch Protection](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-protected-branches) ?
-CI-Tests                    | Does the project run tests in CI, e.g. [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions), [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)?
-CII-Best-Practices          | Does the project have a [CII Best Practices Badge](https://bestpractices.coreinfrastructure.org/en)?
-Code-Review                 | Does the project require code review before code is merged?
-Contributors                | Does the project have contributors from at least two different organizations?
-Dependency-Update-Tool      | Does the project use tools to help update its dependencies?
-Fuzzing                     | Does the project use fuzzing tools, e.g. [OSS-Fuzz](https://github.com/google/oss-fuzz)?
-Maintained                  | Is the project maintained?
-Pinned-Dependencies         | Does the project declare and pin [dependencies](https://docs.github.com/en/free-pro-team@latest/github/visualizing-repository-data-with-graphs/about-the-dependency-graph#supported-package-ecosystems)?
-Packaging                   | Does the project build and publish official packages from CI/CD, e.g. [GitHub Publishing](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-packaging-with-github-actions#workflows-for-publishing-packages) ?
-SAST                        | Does the project use static code analysis tools, e.g. [CodeQL](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/enabling-code-scanning-for-a-repository#enabling-code-scanning-using-actions), [SonarCloud](https://sonarcloud.io)?
-Security-Policy             | Does the project contain a [security policy](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository)?
-Signed-Releases             | Does the project cryptographically [sign releases](https://wiki.debian.org/Creating%20signed%20GitHub%20releases)?
-Token-Permissions           | Does the project declare GitHub workflow tokens as [read only](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)?
-Vulnerabilities             | Does the project have unfixed vulnerabilities? Uses the [OSV service](https://osv.dev).
+[Binary-Artifacts](docs/checks.md#binary-artifacts)            | Is the project free of checked-in binaries?
+[Branch-Protection](docs/checks.md#branch-protection)           | Does the project use [Branch Protection](https://docs.github.com/en/free-pro-team@latest/github/administering-a-repository/about-protected-branches) ?
+[CI-Tests](docs/checks.md#ci-tests)                    | Does the project run tests in CI, e.g. [GitHub Actions](https://docs.github.com/en/free-pro-team@latest/actions), [Prow](https://github.com/kubernetes/test-infra/tree/master/prow)?
+[CII-Best-Practices](docs/checks.md#cii-best-practices)          | Does the project have a [CII Best Practices Badge](https://bestpractices.coreinfrastructure.org/en)?
+[Code-Review](docs/checks.md#code-review)                 | Does the project require code review before code is merged?
+[Contributors](docs/checks.md#contributors)                | Does the project have contributors from at least two different organizations?
+[Dependency-Update-Tool](docs/checks.md#dependency-update-tool)      | Does the project use tools to help update its dependencies?
+[Fuzzing](docs/checks.md#fuzzing)                     | Does the project use fuzzing tools, e.g. [OSS-Fuzz](https://github.com/google/oss-fuzz)?
+[Maintained](docs/checks.md#Maintained)                  | Is the project maintained?
+[Pinned-Dependencies](docs/checks.md#pinned-dependencies)         | Does the project declare and pin [dependencies](https://docs.github.com/en/free-pro-team@latest/github/visualizing-repository-data-with-graphs/about-the-dependency-graph#supported-package-ecosystems)?
+[Packaging](docs/checks.md#packaging)                   | Does the project build and publish official packages from CI/CD, e.g. [GitHub Publishing](https://docs.github.com/en/free-pro-team@latest/actions/guides/about-packaging-with-github-actions#workflows-for-publishing-packages) ?
+[SAST](docs/checks.md#sast)                        | Does the project use static code analysis tools, e.g. [CodeQL](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code/enabling-code-scanning-for-a-repository#enabling-code-scanning-using-actions), [SonarCloud](https://sonarcloud.io)?
+[Security-Policy](docs/checks.md#security-policy)             | Does the project contain a [security policy](https://docs.github.com/en/free-pro-team@latest/github/managing-security-vulnerabilities/adding-a-security-policy-to-your-repository)?
+[Signed-Releases](docs/checks.md#signed-releases)             | Does the project cryptographically [sign releases](https://wiki.debian.org/Creating%20signed%20GitHub%20releases)?
+[Token-Permissions](docs/checks.md#token-permissions)           | Does the project declare GitHub workflow tokens as [read only](https://docs.github.com/en/actions/reference/authentication-in-a-workflow)?
+[Vulnerabilities](docs/checks.md#vulnerabilities)             | Does the project have unfixed vulnerabilities? Uses the [OSV service](https://osv.dev).
 
 To see detailed information about each check and remediation steps, check out
 the [checks documentation page](docs/checks.md).


### PR DESCRIPTION
This modifies README.md to add hyperlinks
directly to each of the details in `docs/checks.md`.
That way, people who want to know more about a specific check
can jump immediately to that information.

Signed-off-by: David A. Wheeler <dwheeler@dwheeler.com>