### PR TITLE
:sparkles: Add new frozen dependency check for Node

### DIFF
--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -1084,3 +1084,81 @@ func TestGitHubWorkflowShell(t *testing.T) {
 		})
 	}
 }
+
+func TestDependencyFrozenNodeModule(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		expected scut.TestReturn
+	}{
+		{
+			name:     "package.json with module pinned",
+			filename: "./testdata/frozen-package-json-module-pinned",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+		{
+			name:     "package.json with module not pinned",
+			filename: "./testdata/frozen-package-json-module-not-pinned",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+		{
+			name:     "package.json with bin pinned",
+			filename: "./testdata/frozen-package-json-bin-pinned",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+		{
+			name:     "package.json with bin not pinned",
+			filename: "./testdata/frozen-package-json-bin-not-pinned",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var content []byte
+			var err error
+
+			content, err = ioutil.ReadFile(tt.filename)
+			if err != nil {
+				panic(fmt.Errorf("cannot read file: %w", err))
+			}
+
+			dl := scut.TestDetailLogger{}
+			s, e := testIsDependencyFrozen(content)
+			actual := checker.CheckResult{
+				Score:  s,
+				Error2: e,
+			}
+			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
+				t.Fail()
+			}
+		})
+	}
+}

--- a/checks/testdata/frozen-package-json-bin-not-pinned
+++ b/checks/testdata/frozen-package-json-bin-not-pinned
@@ -1,0 +1,28 @@
+{
+  "name": "npm-package-json-lint",
+  "version": "5.2.3",
+  "description": "Configurable linter for package.json files.",
+  "keywords": [
+    "lint",
+    "linter",
+    "package.json",
+    "audit",
+    "auditor",
+    "npm-package-json-lint"
+  ],
+  "main": "src/api.js",
+  "files": [
+    "src",
+    "CONTRIBUTING.md",
+    "index.d.ts"
+  ],
+  "dependencies": {
+    "ajv": "^6.12.6",
+    "ajv-errors": "^1.0.1",
+    "chalk": "^4.1.2",
+    "cosmiconfig": "^6.0.0",
+    "debug": "^4.3.2",
+    "globby": "^11.0.4",
+    "ignore": "^5.1.8"
+  }
+}

--- a/checks/testdata/frozen-package-json-bin-pinned
+++ b/checks/testdata/frozen-package-json-bin-pinned
@@ -1,0 +1,30 @@
+{
+  "name": "npm-package-json-lint",
+  "version": "5.2.3",
+  "description": "Configurable linter for package.json files.",
+  "keywords": [
+    "lint",
+    "linter",
+    "package.json",
+    "audit",
+    "auditor",
+    "npm-package-json-lint"
+  ],
+  "bin": {
+    "npmPkgJsonLint": "src/cli.js"
+  },
+  "files": [
+    "src",
+    "CONTRIBUTING.md",
+    "index.d.ts"
+  ],
+  "dependencies": {
+    "ajv": "6.12.6",
+    "ajv-errors": "^1.0.1",
+    "chalk": "^4.1.2",
+    "cosmiconfig": "^6.0.0",
+    "debug": "4.3.2",
+    "globby": "^11.0.4",
+    "ignore": "^5.1.8"
+  }
+}

--- a/checks/testdata/frozen-package-json-module-not-pinned
+++ b/checks/testdata/frozen-package-json-module-not-pinned
@@ -1,0 +1,28 @@
+{
+  "name": "npm-package-json-lint",
+  "version": "5.2.3",
+  "description": "Configurable linter for package.json files.",
+  "keywords": [
+    "lint",
+    "linter",
+    "package.json",
+    "audit",
+    "auditor",
+    "npm-package-json-lint"
+  ],
+  "main": "src/api.js",
+  "files": [
+    "src",
+    "CONTRIBUTING.md",
+    "index.d.ts"
+  ],
+  "dependencies": {
+    "ajv": "^6.12.6",
+    "ajv-errors": "^1.0.1",
+    "chalk": "^4.1.2",
+    "cosmiconfig": "^6.0.0",
+    "debug": "^4.3.2",
+    "globby": "^11.0.4",
+    "ignore": "^5.1.8"
+  }
+}

--- a/checks/testdata/frozen-package-json-module-pinned
+++ b/checks/testdata/frozen-package-json-module-pinned
@@ -1,0 +1,28 @@
+{
+  "name": "npm-package-json-lint",
+  "version": "5.2.3",
+  "description": "Configurable linter for package.json files.",
+  "keywords": [
+    "lint",
+    "linter",
+    "package.json",
+    "audit",
+    "auditor",
+    "npm-package-json-lint"
+  ],
+  "main": "src/api.js",
+  "files": [
+    "src",
+    "CONTRIBUTING.md",
+    "index.d.ts"
+  ],
+  "dependencies": {
+    "ajv": "6.12.6",
+    "ajv-errors": "^1.0.1",
+    "chalk": "^4.1.2",
+    "cosmiconfig": "^6.0.0",
+    "debug": "4.3.2",
+    "globby": "^11.0.4",
+    "ignore": "^5.1.8"
+  }
+}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This PR add a new dependency check. The new check now will check for Node specific project based on the `package.json`. It checks to make sure no dependency version are pinned (a.k.a should be using ~ or ^).
