### PR TITLE
:seedling: Check for OSV for a go.mod changes to scorecard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ $(PROTOC):
 
 ################################## make all ###################################
 all:  ## Runs build, test and verify
-all-targets = update-dependencies build check-linter unit-test add-projects validate-projects tree-status
+all-targets = update-dependencies build check-linter check-osv unit-test add-projects validate-projects tree-status 
 .PHONY: all $(all-targets)
 all: $(all-targets)
 
@@ -60,6 +60,16 @@ check-linter: ## Install and run golang linter
 check-linter: $(GOLANGGCI_LINT)
 	# Run golangci-lint linter
 	golangci-lint run -c .golangci.yml
+
+check-osv: ## Checks osv.dev for any vulnerabilities
+check-osv: $(install)
+	# Run stunning-tribble for checking the dependencies have any OSV
+	go list -m -f '{{if not (or  .Main)}}{{.Path}}@{{.Version}}_{{.Replace}}{{end}}' all \
+			| stunning-tribble GO-2020-0016,GO-2020-0018,GO-2020-0008
+	# Checking the tools which also has go.mod
+	cd tools 
+	go list -m -f '{{if not (or  .Main)}}{{.Path}}@{{.Version}}_{{.Replace}}{{end}}' all \
+			| stunning-tribble GO-2020-0016,GO-2020-0018,GO-2020-0008
 
 add-projects: ## Adds new projects to ./cron/data/projects.csv
 add-projects: ./cron/data/projects.csv | build-add-script

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -5,6 +5,7 @@ go 1.17
 require (
 	github.com/golangci/golangci-lint v1.42.1
 	github.com/google/addlicense v1.0.0
+	github.com/naveensrinivasan/stunning-tribble v0.4.2
 	github.com/onsi/ginkgo v1.16.4
 	google.golang.org/protobuf v1.27.1
 )

--- a/tools/go.sum
+++ b/tools/go.sum
@@ -505,6 +505,8 @@ github.com/mwitkow/go-proto-validators v0.0.0-20180403085117-0950a7990007/go.mod
 github.com/mwitkow/go-proto-validators v0.2.0/go.mod h1:ZfA1hW+UH/2ZHOWvQ3HnQaU0DtnpXu850MZiy+YUgcc=
 github.com/nakabonne/nestif v0.3.0 h1:+yOViDGhg8ygGrmII72nV9B/zGxY188TYpfolntsaPw=
 github.com/nakabonne/nestif v0.3.0/go.mod h1:dI314BppzXjJ4HsCnbo7XzrJHPszZsjnk5wEBSYHI2c=
+github.com/naveensrinivasan/stunning-tribble v0.4.2 h1:JD4DSLi9JoRbgxfsBZXE9lnc830TA4/sTQzq1WwR4eU=
+github.com/naveensrinivasan/stunning-tribble v0.4.2/go.mod h1:r2dbvNDqCzDSNmw9OjE6u2R5sIwLqnMBuLnpVQrhycI=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 h1:4kuARK6Y6FxaNu/BnU2OAaLF86eTVhP2hjTB6iMvItA=
 github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354/go.mod h1:KSVJerMDfblTH7p5MZaTt+8zaT2iEk3AkVb9PQdZuE8=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -19,6 +19,7 @@ package main
 import (
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/google/addlicense"
+	_ "github.com/naveensrinivasan/stunning-tribble"
 	_ "github.com/onsi/ginkgo/ginkgo"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

    At present we don't have a way to identify any new dependencies to go.mod that have osv/cve.
    With this it will query the osv.dev for any vulnerabilities and report if it found any.

    It also has an option to ignore any vulnerabilities if we chose to ignore.

    At present we are ignoring 3 osv that are in our dependencies.

    https://github.com/naveensrinivasan/stunning-tribble


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
None


* **Other information**:
