### PR TITLE
:book: Update Token-Permissions requirement in checks.yaml

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -488,19 +488,20 @@ Note: The check does not verify the signatures.
 
 Risk: `High` (vulnerable to malicious code additions)
 
-This check determines whether the project's automated workflows tokens are set
-to read-only by default. It is currently limited to repositories hosted on
+This check determines whether permissions for the project's automated workflows tokens are set
+explicitly and are not set to grant all permissions. It is currently limited to repositories hosted on
 GitHub, and does not support other source hosting repositories (i.e., Forges).
 
-Setting token permissions to read-only follows the principle of least privilege.
+Setting token permissions to the minimum needed follows the principle of least privilege.
 This is important because attackers may use a compromised token with write
 access to push malicious code into the project.
 
 The highest score is awarded when the permissions definitions in each workflow's
-yaml file are set as read-only at the
+yaml file are set explicitly either at the
 [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
-and the required write permissions are declared at the
-[run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).
+or for each of the jobs at the
+[run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions),
+and the permissions are not set to `write-all`.
         
 The check cannot detect if the "read-only" GitHub permission setting is
 enabled, as there is no API available.   

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -579,19 +579,19 @@ checks:
     description: |
       Risk: `High` (vulnerable to malicious code additions)
 
-      This check determines whether the project's automated workflows tokens are set
-      to read-only by default. It is currently limited to repositories hosted on
+      This check determines whether permissions for the project's automated workflows tokens are set
+      explicitly and are not set to grant all permissions. It is currently limited to repositories hosted on
       GitHub, and does not support other source hosting repositories (i.e., Forges).
 
-      Setting token permissions to read-only follows the principle of least privilege.
+      Setting token permissions to the minimum needed follows the principle of least privilege.
       This is important because attackers may use a compromised token with write
       access to push malicious code into the project.
 
       The highest score is awarded when the permissions definitions in each workflow's
-      yaml file are set as read-only at the
+      yaml file are set explicitly either at the
       [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
-      and the required write permissions are declared at the
-      [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).
+      or for each of the jobs at the
+      [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions), and the permissions are not set to `write-all`.
               
       The check cannot detect if the "read-only" GitHub permission setting is
       enabled, as there is no API available.   

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -591,7 +591,8 @@ checks:
       yaml file are set explicitly either at the
       [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
       or for each of the jobs at the
-      [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions), and the permissions are not set to `write-all`.
+      [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions),
+      and the permissions are not set to `write-all`.
               
       The check cannot detect if the "read-only" GitHub permission setting is
       enabled, as there is no API available.   


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Docs update - to change the requirement for the token permissions check. 


* **What is the current behavior?** (You can also link to an open issue here)
#1129


* **What is the new behavior (if this is a feature change)?**
New logic is in the PR


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
It will cause the score to increase for some repos. 


* **Other information**:
The logic for this change is the following:
1. If a developer has set explicit permissions for the token either at the workflow (top-level) or for each of the jobs (run-level), and it is not set to write-all, then at least some amount of effort has gone into deciding what the permissions should be. 
2. Calculating the exact permissions that the token should have is a hard problem and depends on the various different commands and actions being used in the workflow. Therefore, it may be best to check if a best effort has been put into deciding the permissions, rather than checking if the permissions are the exact minimum needed for each job. Otherwise it may happen that the assessment tool (Scorecards) miscalculates the minimum permissions, and as a result the developer may get an unfair score. 

The proposed change is a draft, and I expect it to evolve based on discussions...