### PR TITLE
🐛 Fixing parsing errors for github workflows

### DIFF
--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -670,6 +670,10 @@ func testIsGitHubActionsWorkflowPinned(pathfn string, content []byte, dl checker
 // should continue executing after this file.
 func validateGitHubActionWorkflow(pathfn string, content []byte,
 	dl checker.DetailLogger, data FileCbData) (bool, error) {
+	if !isWorkflowFile(pathfn) {
+		return true, nil
+	}
+
 	pdata := dataAsWorkflowResultPointer(data)
 
 	if !CheckFileContainsCommands(content, "#") {

--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -79,6 +79,17 @@ func TestGithubWorkflowPinning(t *testing.T) {
 				NumberOfDebug: 0,
 			},
 		},
+		{
+			name:     "Non-yaml file",
+			filename: "./testdata/script.sh",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  2,
+				NumberOfDebug: 0,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
Pinned dependency check fails when non-yaml files are present in `.github/workflows`. This will fix some of the repos Azeem mentioned in https://github.com/ossf/scorecard/issues/839#issuecomment-933949532. I had these lines originally in https://github.com/ossf/scorecard/pull/970, but they were removed in a later PR, most likely inadvertently (merging is hard).


* **What is the new behavior (if this is a feature change)?**
The check for unpinned actions will skip non-yaml files.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

