### PR TITLE
✨ Use checks.yaml to store which repo types are supported by each check

### DIFF
--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -32,10 +32,7 @@ import (
 	clients "github.com/ossf/scorecard/v3/clients"
 )
 
-var (
-	errUnsupportedFeature = errors.New("unsupported feature")
-	errInputRepoType      = errors.New("input repo should be of type repoLocal")
-)
+var errInputRepoType = errors.New("input repo should be of type repoLocal")
 
 //nolint:govet
 type localDirClient struct {
@@ -66,7 +63,7 @@ func (client *localDirClient) URI() string {
 
 // IsArchived implements RepoClient.IsArchived.
 func (client *localDirClient) IsArchived() (bool, error) {
-	return false, fmt.Errorf("IsArchived: %w", errUnsupportedFeature)
+	return false, fmt.Errorf("IsArchived: %w", clients.ErrUnsupportedFeature)
 }
 
 func isDir(p string) (bool, error) {
@@ -142,51 +139,51 @@ func (client *localDirClient) GetFileContent(filename string) ([]byte, error) {
 
 // ListMergedPRs implements RepoClient.ListMergedPRs.
 func (client *localDirClient) ListMergedPRs() ([]clients.PullRequest, error) {
-	return nil, fmt.Errorf("ListMergedPRs: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListMergedPRs: %w", clients.ErrUnsupportedFeature)
 }
 
 // ListBranches implements RepoClient.ListBranches.
 func (client *localDirClient) ListBranches() ([]*clients.BranchRef, error) {
-	return nil, fmt.Errorf("ListBranches: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListBranches: %w", clients.ErrUnsupportedFeature)
 }
 
 // GetDefaultBranch implements RepoClient.GetDefaultBranch.
 func (client *localDirClient) GetDefaultBranch() (*clients.BranchRef, error) {
-	return nil, fmt.Errorf("GetDefaultBranch: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("GetDefaultBranch: %w", clients.ErrUnsupportedFeature)
 }
 
 func (client *localDirClient) ListCommits() ([]clients.Commit, error) {
-	return nil, fmt.Errorf("ListCommits: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListCommits: %w", clients.ErrUnsupportedFeature)
 }
 
 // ListReleases implements RepoClient.ListReleases.
 func (client *localDirClient) ListReleases() ([]clients.Release, error) {
-	return nil, fmt.Errorf("ListReleases: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListReleases: %w", clients.ErrUnsupportedFeature)
 }
 
 // ListContributors implements RepoClient.ListContributors.
 func (client *localDirClient) ListContributors() ([]clients.Contributor, error) {
-	return nil, fmt.Errorf("ListContributors: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListContributors: %w", clients.ErrUnsupportedFeature)
 }
 
 // ListSuccessfulWorkflowRuns implements RepoClient.WorkflowRunsByFilename.
 func (client *localDirClient) ListSuccessfulWorkflowRuns(filename string) ([]clients.WorkflowRun, error) {
-	return nil, fmt.Errorf("ListSuccessfulWorkflowRuns: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListSuccessfulWorkflowRuns: %w", clients.ErrUnsupportedFeature)
 }
 
 // ListCheckRunsForRef implements RepoClient.ListCheckRunsForRef.
 func (client *localDirClient) ListCheckRunsForRef(ref string) ([]clients.CheckRun, error) {
-	return nil, fmt.Errorf("ListCheckRunsForRef: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListCheckRunsForRef: %w", clients.ErrUnsupportedFeature)
 }
 
 // ListStatuses implements RepoClient.ListStatuses.
 func (client *localDirClient) ListStatuses(ref string) ([]clients.Status, error) {
-	return nil, fmt.Errorf("ListStatuses: %w", errUnsupportedFeature)
+	return nil, fmt.Errorf("ListStatuses: %w", clients.ErrUnsupportedFeature)
 }
 
 // Search implements RepoClient.Search.
 func (client *localDirClient) Search(request clients.SearchRequest) (clients.SearchResponse, error) {
-	return clients.SearchResponse{}, fmt.Errorf("Search: %w", errUnsupportedFeature)
+	return clients.SearchResponse{}, fmt.Errorf("Search: %w", clients.ErrUnsupportedFeature)
 }
 
 func (client *localDirClient) Close() error {

--- a/clients/localdir/client_test.go
+++ b/clients/localdir/client_test.go
@@ -39,13 +39,13 @@ func TestClient_CreationAndCaching(t *testing.T) {
 		{
 			name:        "invalid fullpath",
 			outputFiles: []string{},
-			inputFolder: "/invalid/fullpath",
+			inputFolder: "file:///invalid/fullpath",
 			err:         os.ErrNotExist,
 		},
 		{
 			name:        "invalid relative path",
 			outputFiles: []string{},
-			inputFolder: "invalid/relative/path",
+			inputFolder: "file://invalid/relative/path",
 			err:         os.ErrNotExist,
 		},
 		{
@@ -53,7 +53,7 @@ func TestClient_CreationAndCaching(t *testing.T) {
 			outputFiles: []string{
 				"file0", "dir1/file1", "dir1/dir2/file2",
 			},
-			inputFolder: "testdata/repo0",
+			inputFolder: "file://testdata/repo0",
 			err:         nil,
 		},
 	}

--- a/clients/localdir/repo.go
+++ b/clients/localdir/repo.go
@@ -21,11 +21,17 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	clients "github.com/ossf/scorecard/v3/clients"
 )
 
-var errNotDirectory = errors.New("not a directory")
+var (
+	errNotDirectory = errors.New("not a directory")
+	errInvalidURI   = errors.New("invalid URI")
+)
+
+var filePrefix = "file://"
 
 type repoLocal struct {
 	path     string
@@ -77,7 +83,10 @@ func (r *repoLocal) IsScorecardRepo() bool {
 
 // MakeLocalDirRepo returns an implementation of clients.Repo interface.
 func MakeLocalDirRepo(pathfn string) (clients.Repo, error) {
-	p := path.Clean(pathfn)
+	if !strings.HasPrefix(pathfn, filePrefix) {
+		return nil, fmt.Errorf("%w", errInvalidURI)
+	}
+	p := path.Clean(pathfn[len(filePrefix):])
 	repo := &repoLocal{
 		path: p,
 	}
@@ -85,6 +94,5 @@ func MakeLocalDirRepo(pathfn string) (clients.Repo, error) {
 	if err := repo.IsValid(); err != nil {
 		return nil, fmt.Errorf("error in IsValid: %w", err)
 	}
-
 	return repo, nil
 }

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -15,6 +15,11 @@
 // Package clients defines the interface for RepoClient and related structs.
 package clients
 
+import "errors"
+
+// ErrUnsupportedFeature indicates an API that is not supported by the client.
+var ErrUnsupportedFeature = errors.New("unsupported feature")
+
 // RepoClient interface is used by Scorecard checks to access a repo.
 type RepoClient interface {
 	InitRepo(repo Repo) error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -106,7 +106,7 @@ func checksHavePolicies(sp *spol.ScorecardPolicy, enabledChecks checker.CheckNam
 
 func getSupportedChecks(r string, checkDocs docs.Doc) ([]string, error) {
 	allChecks := checks.AllChecks
-	checks := []string{}
+	supportedChecks := []string{}
 	for check := range allChecks {
 		c, e := checkDocs.GetCheck(check)
 		if e != nil {
@@ -115,11 +115,11 @@ func getSupportedChecks(r string, checkDocs docs.Doc) ([]string, error) {
 		types := c.GetSupportedRepoTypes()
 		for _, t := range types {
 			if r == t {
-				checks = append(checks, c.GetName())
+				supportedChecks = append(supportedChecks, c.GetName())
 			}
 		}
 	}
-	return checks, nil
+	return supportedChecks, nil
 }
 
 func isSupportedCheck(names []string, name string) bool {
@@ -195,7 +195,8 @@ func validateFormat(format string) bool {
 	}
 }
 
-func getRepoAccessors(ctx context.Context, uri string, logger *zap.Logger) (clients.Repo, clients.RepoClient, string, error) {
+func getRepoAccessors(ctx context.Context, uri string, logger *zap.Logger) (clients.Repo,
+	clients.RepoClient, string, error) {
 	var repo clients.Repo
 	var errLocal error
 	var errGitHub error

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -104,7 +104,7 @@ func checksHavePolicies(sp *spol.ScorecardPolicy, enabledChecks checker.CheckNam
 	return true
 }
 
-func supportedChecks(r string, checkDocs docs.Doc) ([]string, error) {
+func getSupportedChecks(r string, checkDocs docs.Doc) ([]string, error) {
 	allChecks := checks.AllChecks
 	checks := []string{}
 	for check := range allChecks {
@@ -289,7 +289,7 @@ var rootCmd = &cobra.Command{
 			log.Fatalf("cannot read yaml file: %v", err)
 		}
 
-		supportedChecks, err := supportedChecks(repoType, checkDocs)
+		supportedChecks, err := getSupportedChecks(repoType, checkDocs)
 		if err != nil {
 			log.Fatalf("cannot read supported checks: %v", err)
 		}

--- a/cron/format/mock_doc.go
+++ b/cron/format/mock_doc.go
@@ -22,7 +22,7 @@ import (
 
 type mockCheck struct {
 	name, risk, short, description, url string
-	tags, remediation                   []string
+	tags, remediation, repos            []string
 }
 
 func (c *mockCheck) GetName() string {
@@ -49,6 +49,14 @@ func (c *mockCheck) GetTags() []string {
 	l := make([]string, len(c.tags))
 	for i := range c.tags {
 		l[i] = strings.TrimSpace(c.tags[i])
+	}
+	return l
+}
+
+func (c *mockCheck) GetSupportedRepoTypes() []string {
+	l := make([]string, len(c.repos))
+	for i := range c.repos {
+		l[i] = strings.TrimSpace(c.repos[i])
 	}
 	return l
 }

--- a/docs/checks/doc.go
+++ b/docs/checks/doc.go
@@ -30,5 +30,6 @@ type CheckDoc interface {
 	GetDescription() string
 	GetRemediation() []string
 	GetTags() []string
+	GetSupportedRepoTypes() []string
 	GetDocumentationURL(commitish string) string
 }

--- a/docs/checks/impl.go
+++ b/docs/checks/impl.go
@@ -108,6 +108,16 @@ func (c *CheckDocImpl) GetRemediation() []string {
 	return c.internalCheck.Remediation
 }
 
+// GetSupportedRepoTypes retuns the list repo
+// types the check supports.
+func (c *CheckDocImpl) GetSupportedRepoTypes() []string {
+	l := strings.Split(c.internalCheck.Repos, ",")
+	for i := range l {
+		l[i] = strings.TrimSpace(l[i])
+	}
+	return l
+}
+
 // GetTags returns the list of tags or the check.
 func (c *CheckDocImpl) GetTags() []string {
 	l := strings.Split(c.internalCheck.Tags, ",")

--- a/docs/checks/impl.go
+++ b/docs/checks/impl.go
@@ -108,7 +108,7 @@ func (c *CheckDocImpl) GetRemediation() []string {
 	return c.internalCheck.Remediation
 }
 
-// GetSupportedRepoTypes retuns the list repo
+// GetSupportedRepoTypes returns the list of repo
 // types the check supports.
 func (c *CheckDocImpl) GetSupportedRepoTypes() []string {
 	l := strings.Split(c.internalCheck.Repos, ",")

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -18,6 +18,7 @@ checks:
   Maintained:
     risk: High
     tags: supply-chain, security
+    repos: GitHub
     short: Determines if the project is "actively maintained".
     description: |
       Risk: `High` (possibly unpatched vulnerabilities)
@@ -43,6 +44,7 @@ checks:
   Dependency-Update-Tool:
     risk: High
     tags: supply-chain, security, dependencies
+    repos: GitHub, local
     short: Determines if the project uses a dependency update tool.
     description: |
       Risk: `High` (possibly vulnerable to attacks on known flaws)  
@@ -73,6 +75,7 @@ checks:
   Binary-Artifacts:
     risk: High
     tags: supply-chain, security, dependencies
+    repos: GitHub, local
     short: Determines if the project has generated executable (binary) artifacts in the source repository.
     description: |
       Risk: `High` (non-reviewable code)
@@ -123,6 +126,7 @@ checks:
   Branch-Protection:
     risk: High
     tags: supply-chain, security, source-code, code-reviews
+    repos: GitHub
     short: Determines if the default and release branches are protected with GitHub's branch protection settings.
     description: |
       Risk: `High` (vulnerable to intentional malicious code injection)  
@@ -177,6 +181,7 @@ checks:
   CI-Tests:
     risk: Low
     tags: supply-chain, testing
+    repos: GitHub
     short: Determines if the project runs tests before pull requests are merged.
     description: |
       Risk: `Low` (possible unknown vulnerabilities)
@@ -210,6 +215,7 @@ checks:
   CII-Best-Practices:
     risk: Low
     tags: security-awareness, security-training, security
+    repos: GitHub
     short: Determines if the project has a CII Best Practices Badge.
     description: |
       Risk: `Low` (possibly not following security best practices)
@@ -249,6 +255,7 @@ checks:
   Code-Review:
     risk: High
     tags: supply-chain, security, source-code, code-reviews
+    repos: GitHub
     short: Determines if the project requires code review before pull requests (aka merge requests) are merged.
     description: |
       Risk: `High` (unintentional vulnerabilities or possible injection of malicious
@@ -306,6 +313,7 @@ checks:
   Contributors:
     risk: Low
     tags: source-code
+    repos: GitHub
     short: Determines if the project has a set of contributors from multiple organizations (e.g., companies).
     description: |
       Risk: `Low` (lower number of trusted code reviewers)
@@ -336,6 +344,7 @@ checks:
   Fuzzing:
     risk: Medium
     tags: supply-chain, security, testing
+    repos: GitHub
     short: Determines if the project uses fuzzing.
     description: |
       Risk: `Medium` (possible vulnerabilities in code)
@@ -361,6 +370,7 @@ checks:
   Packaging:
     risk: Medium
     tags: supply-chain, security, releases
+    repos: GitHub
     short: Determines if the project is published as a package that others can easily download, install, easily update, and uninstall.
     description: |
       Risk: `Medium` (users possibly missing security updates)
@@ -404,6 +414,7 @@ checks:
   Pinned-Dependencies:
     risk: Medium
     tags: supply-chain, security, dependencies
+    repos: GitHub, local
     short: Determines if the project has declared and pinned its dependencies.
     description: |
       Risk: `Medium` (possible compromised dependencies)
@@ -483,10 +494,10 @@ checks:
          Github's
         [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)
         or [renovate bot](https://github.com/renovatebot/renovate).
-
   SAST:
     risk: Medium
     tags: supply-chain, security, testing
+    repos: GitHub
     short: Determines if the project uses static code analysis.
     description: |
       Risk: `Medium` (possible unknown bugs)
@@ -517,6 +528,7 @@ checks:
   Security-Policy:
     risk: Medium
     short: Determines if the project has published a security policy.
+    repos: GitHub
     tags: supply-chain, security, policy
     description: |
       Risk: `Medium` (possible insecure reporting of vulnerabilities)
@@ -539,10 +551,10 @@ checks:
       - >-
         For GitHub, see more information
         [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository.).
-
   Signed-Releases:
     risk: High
     tags: supply-chain, security, releases
+    repos: GitHub
     short: Determines if the project cryptographically signs release artifacts.
     description: |
       Risk: `High` (possibility of installing malicious releases)
@@ -575,6 +587,7 @@ checks:
   Token-Permissions:
     risk: High
     tags: supply-chain, security, infrastructure
+    repos: GitHub, local
     short: Determines if the project's workflows follow the principle of least privilege.
     description: |
       Risk: `High` (vulnerable to malicious code additions)
@@ -602,6 +615,7 @@ checks:
   Vulnerabilities:
     risk: High
     tags: supply-chain, security, vulnerabilities
+    repos: GitHub, local
     short: Determines if the project has open, known unfixed vulnerabilities.
     description: |
       Risk: `High`  (known vulnerabilities)

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -615,7 +615,7 @@ checks:
   Vulnerabilities:
     risk: High
     tags: supply-chain, security, vulnerabilities
-    repos: GitHub, local
+    repos: GitHub
     short: Determines if the project has open, known unfixed vulnerabilities.
     description: |
       Risk: `High`  (known vulnerabilities)

--- a/docs/checks/internal/reader.go
+++ b/docs/checks/internal/reader.go
@@ -34,6 +34,7 @@ type Check struct {
 	Short       string   `yaml:"short"`
 	Description string   `yaml:"description"`
 	Tags        string   `yaml:"tags"`
+	Repos       string   `yaml:"repos"`
 	Remediation []string `yaml:"remediation"`
 	Name        string   `yaml:"-"`
 	URL         string   `yaml:"-"`

--- a/docs/checks/internal/validate/main.go
+++ b/docs/checks/internal/validate/main.go
@@ -21,7 +21,10 @@ import (
 	docs "github.com/ossf/scorecard/v3/docs/checks"
 )
 
-var allowedRisks = map[string]bool{"Critical": true, "High": true, "Medium": true, "Low": true}
+var (
+	allowedRisks     = map[string]bool{"Critical": true, "High": true, "Medium": true, "Low": true}
+	allowedRepoTypes = map[string]bool{"GitHub": true, "local": true}
+)
 
 func main() {
 	m, err := docs.Read()
@@ -56,6 +59,17 @@ func main() {
 		if _, exists := allowedRisks[r]; !exists {
 			// nolint: goerr113
 			panic(fmt.Errorf("risk for checkName: %s is invalid: '%s'", check, r))
+		}
+		repoTypes := c.GetSupportedRepoTypes()
+		if len(repoTypes) == 0 {
+			// nolint: goerr113
+			panic(fmt.Errorf("repos for checkName: %s is empty", check))
+		}
+		for _, rt := range repoTypes {
+			if _, exists := allowedRepoTypes[rt]; !exists {
+				// nolint: goerr113
+				panic(fmt.Errorf("repo type for checkName: %s is invalid: '%s'", check, rt))
+			}
 		}
 	}
 	for _, check := range m.GetChecks() {

--- a/pkg/mock_doc.go
+++ b/pkg/mock_doc.go
@@ -22,7 +22,7 @@ import (
 
 type mockCheck struct {
 	name, risk, short, description, url string
-	tags, remediation                   []string
+	tags, remediation, repos            []string
 }
 
 func (c *mockCheck) GetName() string {
@@ -49,6 +49,14 @@ func (c *mockCheck) GetTags() []string {
 	l := make([]string, len(c.tags))
 	for i := range c.tags {
 		l[i] = strings.TrimSpace(c.tags[i])
+	}
+	return l
+}
+
+func (c *mockCheck) GetSupportedRepoTypes() []string {
+	l := make([]string, len(c.repos))
+	for i := range c.repos {
+		l[i] = strings.TrimSpace(c.repos[i])
 	}
 	return l
 }

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -17,6 +17,7 @@ package pkg
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"sync"
 	"time"
@@ -55,7 +56,7 @@ func runEnabledChecks(ctx context.Context,
 
 func getRepoCommitHash(r clients.RepoClient) (string, error) {
 	commits, err := r.ListCommits()
-	if err != nil {
+	if err != nil && !errors.Is(err, clients.ErrUnsupportedFeature) {
 		return "", sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("ListCommits:%v", err.Error()))
 	}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

This is a feature with no breaking changes. 

close https://github.com/ossf/scorecard/issues/1184

The general behavior for check selection is as follows:
1. `--repo=X` => uses all checks supported by the repo interface
2. `--repo=X --check=Y` => uses check Y and verifies it's supported by repo interface
3. `--repo=X --policy=Z` => uses all checks defined in the policy file AND supported by repo interface
4. `--repo=X --policy=Z --checks=Y` => uses Y AND verifies Y is defined in the policy and verifies Y checks are supported by the repo interface

The one thing I don't like is that, if a user passes a policy, we're silently discarding checks not supported by the interface. I wonder if this may be confusing for users.