### PR TITLE
✨ Validate check.yaml's repo interface support

### DIFF
--- a/docs/checks/internal/validate/main.go
+++ b/docs/checks/internal/validate/main.go
@@ -53,9 +53,11 @@ var (
 	}
 )
 
+// Indentify the source file that declares each check.
 func listCheckFiles() (map[string]string, error) {
 	checkFiles := make(map[string]string)
 	// Use regex to determine the file that contains the entry point.
+	// We're looking for `const someVarName = "CheckName"`.
 	regex := regexp.MustCompile(`const\s+[^"]*=\s+"(.*)"`)
 	files, err := ioutil.ReadDir("checks/")
 	if err != nil {
@@ -88,6 +90,7 @@ func listCheckFiles() (map[string]string, error) {
 	return checkFiles, nil
 }
 
+// extract API names for RepoClient interface.
 func extractAPINames() ([]string, error) {
 	fns := []string{}
 	interfaceRe := regexp.MustCompile(`type\s+RepoClient\s+interface\s+{\s*`)
@@ -119,19 +122,6 @@ func extractAPINames() ([]string, error) {
 	return fns, nil
 }
 
-func isSubsetOf(a, b []string) bool {
-	mb := make(map[string]bool)
-	for _, vb := range b {
-		mb[vb] = true
-	}
-	for _, va := range a {
-		if _, exists := mb[va]; !exists {
-			return false
-		}
-	}
-	return true
-}
-
 func contains(l []string, elt string) bool {
 	for _, v := range l {
 		if v == elt {
@@ -141,9 +131,10 @@ func contains(l []string, elt string) bool {
 	return false
 }
 
+// extract supported interfaces frmo a check implementation file.
 func supportedInterfacesFromImplementation(checkName string, checkFiles map[string]string) ([]string, error) {
 	// Special case. No APIs are used,
-	// but we need the repo name for a db lookup.
+	// but we need the repo name for an online database lookup.
 	if checkName == "CII-Best-Practices" {
 		return []string{"GitHub"}, nil
 	}

--- a/docs/checks/internal/validate/main.go
+++ b/docs/checks/internal/validate/main.go
@@ -15,7 +15,13 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
+	"path"
+	"regexp"
 	"strings"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/ossf/scorecard/v3/checks"
 	docs "github.com/ossf/scorecard/v3/docs/checks"
@@ -24,41 +30,212 @@ import (
 var (
 	allowedRisks     = map[string]bool{"Critical": true, "High": true, "Medium": true, "Low": true}
 	allowedRepoTypes = map[string]bool{"GitHub": true, "local": true}
+	supportedAPIs    = map[string][]string{
+		"InitRepo":                   {"GitHub"},
+		"URI":                        {"GitHub", "local"},
+		"IsArchived":                 {"GitHub"},
+		"ListFiles":                  {"GitHub", "local"},
+		"GetFileContent":             {"GitHub", "local"},
+		"ListMergedPRs":              {"GitHub"},
+		"ListBranches":               {"GitHub"},
+		"GetDefaultBranch":           {"GitHub"},
+		"ListCommits":                {"GitHub"},
+		"ListReleases":               {"GitHub"},
+		"ListContributors":           {"GitHub"},
+		"ListSuccessfulWorkflowRuns": {"GitHub"},
+		"ListCheckRunsForRef":        {"GitHub"},
+		"ListStatuses":               {"GitHub"},
+		"Search":                     {"GitHub", "local"},
+		"Close":                      {"GitHub", "local"},
+	}
 )
+
+func listCheckFiles() (map[string]string, error) {
+	checkFiles := make(map[string]string)
+	// Use regex to determine the file that contains the entry point.
+	regex := regexp.MustCompile(`const\s+[^"]*=\s+"(.*)"`)
+	files, err := ioutil.ReadDir("checks/")
+	if err != nil {
+		return nil, fmt.Errorf("ioutil.ReadDir: %w", err)
+	}
+
+	for _, file := range files {
+		if !strings.HasSuffix(file.Name(), ".go") || file.IsDir() {
+			continue
+		}
+
+		fullpath := path.Join("checks/", file.Name())
+		content, err := ioutil.ReadFile(fullpath)
+		if err != nil {
+			return nil, fmt.Errorf("ioutil.ReadFile: %s: %w", fullpath, err)
+		}
+
+		res := regex.FindStringSubmatch(string(content))
+		if len(res) != 2 {
+			continue
+		}
+
+		r := res[1]
+		if entry, exists := checkFiles[r]; exists {
+			//nolint:goerr113
+			return nil, fmt.Errorf("check %s already exists: %v", r, entry)
+		}
+		checkFiles[r] = fullpath
+	}
+	return checkFiles, nil
+}
+
+func extractAPINames() ([]string, error) {
+	fns := []string{}
+	interfaceRe := regexp.MustCompile(`type\s+RepoClient\s+interface\s+{\s*`)
+	content, err := ioutil.ReadFile("clients/repo_client.go")
+	if err != nil {
+		return nil, fmt.Errorf("ioutil.ReadFile: %s: %w", "clients/repo_client.go", err)
+	}
+
+	locs := interfaceRe.FindIndex(content)
+	if len(locs) != 2 || locs[1] == 0 {
+		//nolint:goerr113
+		return nil, fmt.Errorf("FindIndex: cannot find Doc interface definition")
+	}
+
+	nameRe := regexp.MustCompile(`[\s]+([A-Z]\S+)\s*\(.*\).+[\n]+`)
+	matches := nameRe.FindAllStringSubmatch(string(content[locs[1]-1:]), -1)
+	if len(matches) == 0 {
+		//nolint:goerr113
+		return nil, fmt.Errorf("FindAllStringSubmatch: no match found")
+	}
+
+	for _, v := range matches {
+		if len(v) != 2 {
+			//nolint:goerr113
+			return nil, fmt.Errorf("invalid length: %d", len(v))
+		}
+		fns = append(fns, v[1])
+	}
+	return fns, nil
+}
+
+func isSubsetOf(a, b []string) bool {
+	mb := make(map[string]bool)
+	for _, vb := range b {
+		mb[vb] = true
+	}
+	for _, va := range a {
+		if _, exists := mb[va]; !exists {
+			return false
+		}
+	}
+	return true
+}
+
+func validateRepoTypeAPIs(checkName string, repoTypes []string, checkFiles map[string]string) error {
+	// For now, we only list APIs in a check's implementation.
+	// Long-term, we should use the callgraph feature using
+	// https://github.com/golang/tools/blob/master/cmd/callgraph/main.go.
+	//
+
+	pathfn, exists := checkFiles[checkName]
+	if !exists {
+		//nolint:goerr113
+		return fmt.Errorf("check %s does not exists", checkName)
+	}
+
+	content, err := ioutil.ReadFile(pathfn)
+	if err != nil {
+		return fmt.Errorf("ioutil.ReadFile: %s: %w", pathfn, err)
+	}
+
+	// For each API, check if it's used or not.
+	for api, supportedInterfaces := range supportedAPIs {
+		regex := fmt.Sprintf(`\.%s`, api)
+		re := regexp.MustCompile(regex)
+		r := re.Match(content)
+		// Check if the API is used but should not.
+		if r && !isSubsetOf(repoTypes, supportedInterfaces) {
+			//nolint:goerr113
+			return fmt.Errorf("mismatch for check %s, file %s: found unexpected API use: %s(): %s not a subset of %s",
+				checkName, pathfn, api, repoTypes, supportedInterfaces)
+		}
+	}
+
+	return nil
+}
+
+func validateAPINames() error {
+	// Extract API names.
+	fns, err := extractAPINames()
+	if err != nil {
+		return fmt.Errorf("invalid functions: %w", err)
+	}
+
+	// Validate function names.
+	functions := []string{}
+	for v := range supportedAPIs {
+		functions = append(functions, v)
+	}
+
+	if !cmp.Equal(functions, fns, cmpopts.SortSlices(func(x, y string) bool { return x < y })) {
+		//nolint:goerr113
+		return fmt.Errorf("got diff: %s", cmp.Diff(functions, fns))
+	}
+
+	return nil
+}
 
 func main() {
 	m, err := docs.Read()
 	if err != nil {
-		panic(fmt.Errorf("docs.Read: %w", err))
+		panic(fmt.Sprintf("docs.Read: %v", err))
+	}
+
+	if err := validateAPINames(); err != nil {
+		panic(fmt.Sprintf("cannot extract function names: %v", err))
+	}
+
+	checkFiles, err := listCheckFiles()
+	if err != nil {
+		panic(err)
 	}
 
 	allChecks := checks.AllChecks
 	for check := range allChecks {
 		c, e := m.GetCheck(check)
 		if e != nil {
-			panic(fmt.Errorf("GetCheck: %w: %s", e, check))
+			panic(fmt.Sprintf("GetCheck: %v: %s", e, check))
 		}
 
+		if check != c.GetName() {
+			panic(fmt.Sprintf("invalid checkName: %s != %s", check, c.GetName()))
+		}
 		if c.GetDescription() == "" {
-			// nolint: goerr113
-			panic(fmt.Errorf("description for checkName: %s is empty", check))
+			panic(fmt.Sprintf("description for checkName: %s is empty", check))
 		}
 		if strings.TrimSpace(strings.Join(c.GetRemediation(), "")) == "" {
-			// nolint: goerr113
-			panic(fmt.Errorf("remediation for checkName: %s is empty", check))
+			panic(fmt.Sprintf("remediation for checkName: %s is empty", check))
 		}
 		if c.GetShort() == "" {
-			// nolint: goerr113
-			panic(fmt.Errorf("short for checkName: %s is empty", check))
+			panic(fmt.Sprintf("short for checkName: %s is empty", check))
 		}
 		if len(c.GetTags()) == 0 {
-			// nolint: goerr113
-			panic(fmt.Errorf("tags for checkName: %s is empty", check))
+			panic(fmt.Sprintf("tags for checkName: %s is empty", check))
 		}
 		r := c.GetRisk()
 		if _, exists := allowedRisks[r]; !exists {
-			// nolint: goerr113
-			panic(fmt.Errorf("risk for checkName: %s is invalid: '%s'", check, r))
+			panic(fmt.Sprintf("risk for checkName: %s is invalid: '%s'", check, r))
+		}
+		repoTypes := c.GetSupportedRepoTypes()
+		if len(repoTypes) == 0 {
+			panic(fmt.Sprintf("repos for checkName: %s is empty", check))
+		}
+		for _, rt := range repoTypes {
+			if _, exists := allowedRepoTypes[rt]; !exists {
+				panic(fmt.Sprintf("repo type for checkName: %s is invalid: '%s'", check, rt))
+			}
+		}
+		// Validate that the check only calls API the interface supports.
+		if err := validateRepoTypeAPIs(check, repoTypes, checkFiles); err != nil {
+			panic(fmt.Sprintf("validateRepoTypeAPIs: %v", err))
 		}
 		repoTypes := c.GetSupportedRepoTypes()
 		if len(repoTypes) == 0 {
@@ -74,8 +251,7 @@ func main() {
 	}
 	for _, check := range m.GetChecks() {
 		if _, exists := allChecks[check.GetName()]; !exists {
-			// nolint: goerr113
-			panic(fmt.Errorf("check present in checks.yaml is not part of `checks.AllChecks`: %s", check.GetName()))
+			panic(fmt.Sprintf("check present in checks.yaml is not part of `checks.AllChecks`: %s", check.GetName()))
 		}
 	}
 }

--- a/docs/checks/internal/validate/main.go
+++ b/docs/checks/internal/validate/main.go
@@ -31,6 +31,9 @@ var (
 	allowedRisks     = map[string]bool{"Critical": true, "High": true, "Medium": true, "Low": true}
 	allowedRepoTypes = map[string]bool{"GitHub": true, "local": true}
 	supportedAPIs    = map[string][]string{
+		// InitRepo is supported for local reepos in general. However, in the context of checks,
+		// this is only used to look up remote data, e.g. in Fuzzinng check.
+		// So we only have "GitHub" supported.
 		"InitRepo":                   {"GitHub"},
 		"URI":                        {"GitHub", "local"},
 		"IsArchived":                 {"GitHub"},


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

This PR adds validation to ensure the `repos` field in the checks.yaml file is consistent with the check's implementation. It currently uses regex to look for repo client APIs, but later we could use a callgraph if needed.

No breaking change in this PR.