### PR TITLE
🐛  Use only olivekl@ in CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,4 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*       @inferno-chromium @naveensrinivasan @azeemshaikh38 @laurentsimon
 *.md    @olivekl
 docs/checks/internal/checks.yaml    @olivekl

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,4 +1,5 @@
 # https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
+.github/workflows/*       @inferno-chromium @naveensrinivasan @azeemshaikh38 @laurentsimon
 *.md    @olivekl
 docs/checks/internal/checks.yaml    @olivekl


### PR DESCRIPTION
We recently changed CODEOWNER file, but it now automatically adds several people as reviewers for all PRs. This is overwhelming.
Let's only use this for the documentation and workflows.