### PR TITLE
🐛 Token permission check was failing on non-yaml files

### DIFF
--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -360,6 +360,9 @@ func testValidateGitHubActionTokenPermissions(pathfn string,
 // Check file content.
 func validateGitHubActionTokenPermissions(path string, content []byte,
 	dl checker.DetailLogger, data FileCbData) (bool, error) {
+	if !isWorkflowFile(path) {
+		return true, nil
+	}
 	// Verify the type of the data.
 	pdata, ok := data.(*permissionCbData)
 	if !ok {

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -230,6 +230,17 @@ func TestGithubTokenPermissions(t *testing.T) {
 				NumberOfDebug: 4,
 			},
 		},
+		{
+			name:     "Non-yaml file",
+			filename: "./testdata/script.sh",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
@@ -247,7 +258,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			}
 			dl := scut.TestDetailLogger{}
 			r := testValidateGitHubActionTokenPermissions(tt.filename, content, &dl)
-			scut.ValidateTestReturn(t, tt.name, &tt.expected, &r, &dl)
+			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &r, &dl) {
+				t.Fail()
+			}
 		})
 	}
 }


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
When a non-yaml file (such as a shell or python file) is present in `.github/workflows`, the check will fail with 
```
|--------|-------------------|--------------------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
| SCORE  |       NAME        |             REASON             |            DETAILS             |                                            DOCUMENTATION/REMEDIATION                                             |
|--------|-------------------|--------------------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
| 0 / 10 | Token-Permissions | non read-only tokens detected  | Warn: no permission defined:   | https://github.com/ossf/scorecard/blob/6562cc1f4488c7a018b5c6b4e031f990058d95a2/docs/checks.md#token-permissions |
|        |                   | in GitHub workflows            | .github/workflows/test.sh:1    |                                                                                                                  |
|--------|-------------------|--------------------------------|--------------------------------|------------------------------------------------------------------------------------------------------------------|
```
I noticed while doing my own testing, but I assume this error is happening for repos that are part of cron because this error was occurring in the pinned dependencies check (fixed in https://github.com/ossf/scorecard/pull/970).



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
