### PR TITLE
🐛  Make sarif generation deterministic

### DIFF
--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"sort"
 	"strings"
 	"time"
 
@@ -474,8 +475,16 @@ func computeCategory(repos []string) (string, error) {
 
 func createSARIFRuns(runs map[string]*run) []run {
 	res := []run{}
-	for _, v := range runs {
-		res = append(res, *v)
+	// Sort keys.
+	keys := make([]string, 0)
+	for k := range runs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// Iterate over keys.
+	for _, k := range keys {
+		res = append(res, *runs[k])
 	}
 	return res
 }

--- a/pkg/testdata/check8.sarif
+++ b/pkg/testdata/check8.sarif
@@ -4,77 +4,6 @@
    "runs": [
       {
          "automationDetails": {
-            "id": "supply-chain/online-scm/ccbc59901773ab4c051dfcea0cc4201a1567abdd-17 Aug 21 18:57 +0000"
-         },
-         "tool": {
-            "driver": {
-               "name": "Scorecard",
-               "informationUri": "https://github.com/ossf/scorecard",
-               "semanticVersion": "1.2.3",
-               "rules": [
-                  {
-                     "id": "Check-Name4",
-                     "name": "Check-Name4",
-                     "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name4",
-                     "shortDescription": {
-                        "text": "Check-Name4"
-                     },
-                     "fullDescription": {
-                        "text": "short description 4"
-                     },
-                     "help": {
-                        "text": "short description 4",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 4"
-                     },
-                     "defaultConfiguration": {
-                        "level": "error"
-                     },
-                     "properties": {
-                        "precision": "high",
-                        "problem.severity": "recommendation",
-                        "security-severity": "1.0",
-                        "tags": [
-                           "tag1",
-                           "tag2",
-                           "tag3",
-                           "tag 4"
-                        ]
-                     }
-                  }
-               ]
-            }
-         },
-         "results": [
-            {
-               "ruleId": "Check-Name4",
-               "ruleIndex": 0,
-               "message": {
-                  "text": "warn message"
-               },
-               "locations": [
-                  {
-                     "physicalLocation": {
-                        "region": {
-                           "startLine": 5,
-                           "snippet": {
-                              "text": "if (bad) {BUG();}"
-                           }
-                        },
-                        "artifactLocation": {
-                           "uri": "src/file1.cpp",
-                           "uriBaseId": "%SRCROOT%"
-                        }
-                     },
-                     "message": {
-                        "text": "warn message"
-                     }
-                  }
-               ]
-            }
-         ]
-      },
-      {
-         "automationDetails": {
             "id": "supply-chain/local/ccbc59901773ab4c051dfcea0cc4201a1567abdd-17 Aug 21 18:57 +0000"
          },
          "tool": {
@@ -294,6 +223,77 @@
          "results": [
             {
                "ruleId": "Check-Name6",
+               "ruleIndex": 0,
+               "message": {
+                  "text": "warn message"
+               },
+               "locations": [
+                  {
+                     "physicalLocation": {
+                        "region": {
+                           "startLine": 5,
+                           "snippet": {
+                              "text": "if (bad) {BUG();}"
+                           }
+                        },
+                        "artifactLocation": {
+                           "uri": "src/file1.cpp",
+                           "uriBaseId": "%SRCROOT%"
+                        }
+                     },
+                     "message": {
+                        "text": "warn message"
+                     }
+                  }
+               ]
+            }
+         ]
+      },
+      {
+         "automationDetails": {
+            "id": "supply-chain/online-scm/ccbc59901773ab4c051dfcea0cc4201a1567abdd-17 Aug 21 18:57 +0000"
+         },
+         "tool": {
+            "driver": {
+               "name": "Scorecard",
+               "informationUri": "https://github.com/ossf/scorecard",
+               "semanticVersion": "1.2.3",
+               "rules": [
+                  {
+                     "id": "Check-Name4",
+                     "name": "Check-Name4",
+                     "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name4",
+                     "shortDescription": {
+                        "text": "Check-Name4"
+                     },
+                     "fullDescription": {
+                        "text": "short description 4"
+                     },
+                     "help": {
+                        "text": "short description 4",
+                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 4"
+                     },
+                     "defaultConfiguration": {
+                        "level": "error"
+                     },
+                     "properties": {
+                        "precision": "high",
+                        "problem.severity": "recommendation",
+                        "security-severity": "1.0",
+                        "tags": [
+                           "tag1",
+                           "tag2",
+                           "tag3",
+                           "tag 4"
+                        ]
+                     }
+                  }
+               ]
+            }
+         },
+         "results": [
+            {
+               "ruleId": "Check-Name4",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"


### PR DESCRIPTION
This makes the generation of sarif results deterministic: it will always use the same order for run categories and details.
No breaking changes

Found in https://github.com/ossf/scorecard/pull/1232#issuecomment-964754088