### PR TITLE
:sparkles:SAST: no longer skip "neutral" checks

### DIFF
--- a/checks/sast.go
+++ b/checks/sast.go
@@ -27,6 +27,8 @@ const CheckSAST = "SAST"
 
 var sastTools = map[string]bool{"github-code-scanning": true, "lgtm-com": true, "sonarcloud": true}
 
+var allowedConclusions = map[string]bool{"success": true, "neutral": true}
+
 //nolint:gochecknoinits
 func init() {
 	registerCheck(CheckSAST, SAST)
@@ -132,7 +134,7 @@ func sastToolInCheckRuns(c *checker.CheckRequest) (int, error) {
 			if cr.Status != "completed" {
 				continue
 			}
-			if cr.Conclusion != "success" {
+			if !allowedConclusions[cr.Conclusion] {
 				continue
 			}
 			if sastTools[cr.App.Slug] {


### PR DESCRIPTION
Some SASTs like LGTM don't analyze PRs where code hasn't been changed,
which leads to their status being "neutral" there.

It's a follow up to https://github.com/ossf/scorecard/pull/1232#issuecomment-965552702

I'm not sure what to do about one-offs like the one
mentioned in https://github.com/ossf/scorecard/pull/1232#issuecomment-965585962
that shouldn't affect the aggregate score but it can probably
be fixed later.

cc @laurentsimon