### PR TITLE
:bug:Security-Policy: really look for the security policy

### DIFF
--- a/checks/security_policy.go
+++ b/checks/security_policy.go
@@ -36,9 +36,12 @@ func SecurityPolicy(c *checker.CheckRequest) checker.CheckResult {
 	// TODO: not supported for local clients.
 	var r bool
 	// Check repository for repository-specific policy.
+	// https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file.
 	onFile := func(name string, dl checker.DetailLogger, data FileCbData) (bool, error) {
 		pdata := FileGetCbDataAsBoolPointer(data)
-		if strings.EqualFold(name, "security.md") {
+		if strings.EqualFold(name, "security.md") ||
+			strings.EqualFold(name, ".github/security.md") ||
+			strings.EqualFold(name, "docs/security.md") {
 			c.Dlogger.Info3(&checker.LogMessage{
 				Path: name,
 				Type: checker.FileTypeSource,
@@ -69,7 +72,9 @@ func SecurityPolicy(c *checker.CheckRequest) checker.CheckResult {
 		return checker.CreateMaxScoreResult(CheckSecurityPolicy, "security policy file detected")
 	}
 
-	// Checking for community default within the .github folder.
+	// I'm not sure what exactly the following code is supposed to do. It seems to always fail with
+	// Warn: repo unreachable: GET https://api.github.com/repos/systemd/.github: 404 Not Found []
+
 	// https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file.
 	logger, err := githubrepo.NewLogger(zap.InfoLevel)
 	if err != nil {


### PR DESCRIPTION
It was tested with [the systemd project](https://github.com/systemd/systemd/security) where the security policy
is kept in [docs/SECURITY.md](https://github.com/systemd/systemd/blob/main/docs/SECURITY.md). Without this patch `scorecard`
says that the security policy can't be found.