### PR TITLE
🌱 `make install` was not installing to GOPATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 SHELL := /bin/bash
-GOPATH := $(go env GOPATH)
 GINKGO := ginkgo
 GIT_HASH := $(shell git rev-parse HEAD)
 GIT_VERSION ?= $(shell git describe --tags --always --dirty)


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Tooling bug fix


* **What is the current behavior?** (You can also link to an open issue here)
I have my GOPATH set to a different location:
```
~/code/ossf/scorecard(main)$ echo $GOPATH
/home/chris/.go
```
The line
```
GOPATH := $(go env GOPATH)
```
appears to be overwriting my environment variable and turning it into a local variable. If I modify the install target to:
```
.PHONY: install
install: ## Installs all dependencies needed to compile Scorecard
install: | $(PROTOC)
	@echo Installing tools from tools/tools.go
	echo $$GOPATH
	go env GOPATH
	cd tools; cat tools.go | grep _ | awk -F'"' '{print $$2}' | xargs -tI % go install %
```
It outputs:
```
~/code/ossf/scorecard(main)$ make install
Installing tools from tools/tools.go
echo $GOPATH

go env GOPATH
/home/chris/go
cd tools; cat tools.go | grep _ | awk -F'"' '{print $2}' | xargs -tI % go install %
...
```
This causes the tools to be installed in `/home/chris/go` which is not in my $PATH.


* **What is the new behavior (if this is a feature change)?**
I checked with Naveen who added this line in https://github.com/ossf/scorecard/pull/460, and he thought it would be fine to remove this line.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
