### PR TITLE
:bug:Binary-Artifacts: skip files that look like tests

### DIFF
--- a/checks/binary_artifact.go
+++ b/checks/binary_artifact.go
@@ -98,6 +98,13 @@ func checkBinaryFileContent(path string, content []byte,
 		return false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("filetype.Get:%v", err))
 	}
 
+	if strings.Contains(strings.ToLower(path), "test") {
+		dl.Debug3(&checker.LogMessage{
+			Text: fmt.Sprintf("%s looks like a test, skipping", path),
+		})
+		return true, nil
+	}
+
 	if _, ok := binaryFileTypes[t.Extension]; ok {
 		dl.Warn3(&checker.LogMessage{
 			Path: path, Type: checker.FileTypeBinary,


### PR DESCRIPTION
Should address https://github.com/ossf/scorecard/issues/1256

I'm not sure how to figure out whether files are tests or not
by just looking at their names but it seems almost all the tools
analyzing source code I've seen so far either skip or demote files
containing "test" in their names. Some go even farther and admit that
they can't detect tests and allow users to specify where tests are one
way or another