### PR TITLE
:bug:Binary-Artifacts: no longer fall back to file extensions

### DIFF
--- a/checks/binary_artifact.go
+++ b/checks/binary_artifact.go
@@ -15,12 +15,7 @@
 package checks
 
 import (
-	"fmt"
-	"path/filepath"
-	"strings"
-
 	"github.com/h2non/filetype"
-	"github.com/h2non/filetype/types"
 
 	"github.com/ossf/scorecard/v3/checker"
 	sce "github.com/ossf/scorecard/v3/errors"
@@ -52,61 +47,11 @@ func BinaryArtifacts(c *checker.CheckRequest) checker.CheckResult {
 func checkBinaryFileContent(path string, content []byte,
 	dl checker.DetailLogger, data FileCbData) (bool, error) {
 	pfound := FileGetCbDataAsBoolPointer(data)
-	binaryFileTypes := map[string]bool{
-		"crx":     true,
-		"deb":     true,
-		"dex":     true,
-		"dey":     true,
-		"elf":     true,
-		"bin":     true,
-		"o":       true,
-		"so":      true,
-		"iso":     true,
-		"class":   true,
-		"jar":     true,
-		"bundle":  true,
-		"dylib":   true,
-		"lib":     true,
-		"msi":     true,
-		"acm":     true,
-		"ax":      true,
-		"cpl":     true,
-		"dll":     true,
-		"drv":     true,
-		"efi":     true,
-		"exe":     true,
-		"mui":     true,
-		"ocx":     true,
-		"scr":     true,
-		"sys":     true,
-		"tsp":     true,
-		"pyc":     true,
-		"pyo":     true,
-		"par":     true,
-		"rpm":     true,
-		"swf":     true,
-		"torrent": true,
-		"cab":     true,
-		"whl":     true,
-	}
-	var t types.Type
-	var err error
 	if len(content) == 0 {
 		return true, nil
 	}
-	if t, err = filetype.Get(content); err != nil {
-		return false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("filetype.Get:%v", err))
-	}
 
-	if _, ok := binaryFileTypes[t.Extension]; ok {
-		dl.Warn3(&checker.LogMessage{
-			Path: path, Type: checker.FileTypeBinary,
-			Text: "binary detected",
-		})
-		*pfound = true
-		return true, nil
-	} else if _, ok := binaryFileTypes[strings.ReplaceAll(filepath.Ext(path), ".", "")]; ok {
-		// Falling back to file based extension.
+	if filetype.IsArchive(content) {
 		dl.Warn3(&checker.LogMessage{
 			Path: path, Type: checker.FileTypeBinary,
 			Text: "binary detected",


### PR DESCRIPTION
Looks like isArchive is supposed to cover all the filetypes
the Binary-Artifacts check is interested in:
https://github.com/h2non/filetype#archive. If types like dll
aren't supported they probably should be added to the matchers
library (by the way there is an in-flight PR trying to
achieve exactly that: https://github.com/h2non/filetype/pull/103)

With this patch applied scorecard no longer complains about
systemd:
```
    {
      "details": null,
      "score": 10,
      "reason": "no binaries found in the repo",
      "name": "Binary-Artifacts",
      "documentation": {
        "url": "https://github.com/ossf/scorecard/blob/63e3b92466f0403159c02f1ccedd43f9400e8b26/docs/checks.md#binary-artifacts",
        "short": "Determines if the project has generated executable (binary) artifacts in the source repository."
      }
```
and still can successfuly flag repositories with suspicious
elf files for example
```
./scorecard --verbosity Debug  --show-details --format json  --repo=https://github.com/evverx/binary-artifacts-test --checks Binary-Artifacts | jq | tee OUT
{
  "repo": {
    "name": "github.com/evverx/binary-artifacts-test",
    "commit": "11cbc0fddac398f346639b0552061f859e506b02"
  },
...
  "score": 0.0,
  "checks": [
    {
      "details": [
        "Warn: binary detected: date",
        "Warn: binary detected: nothing-to-see-here-hehe.txt"
      ],
      "score": 0,
      "reason": "binaries present in source code",
      "name": "Binary-Artifacts",
...
```
