### PR TITLE
✨ Update score for branch protection with levels

### DIFF
--- a/checks/branch_protection.go
+++ b/checks/branch_protection.go
@@ -280,7 +280,6 @@ func computeScore(scores []levelScore) (int, error) {
 	basicScore, maxBasicScore := computeNonAdminBasicScore(scores, maxScores)
 	adminBasicScore, maxAdminBasicScore := computeAdminBasicScore(scores, maxScores)
 	score += noarmalizeScore(basicScore+adminBasicScore, maxBasicScore+maxAdminBasicScore, level1)
-	// fmt.Printf("score level 1: %f\n", noarmalizeScore(basicScore+adminBasicScore, maxBasicScore+maxAdminBasicScore, level1))
 	if basicScore != maxBasicScore ||
 		adminBasicScore != maxAdminBasicScore {
 		return int(score), nil
@@ -290,7 +289,6 @@ func computeScore(scores []levelScore) (int, error) {
 	reviewScore, maxReviewScore := computeNonAdminReviewScore(scores, maxScores)
 	adminReviewScore, maxAdminReviewScore := computeAdminReviewScore(scores, maxScores)
 	score += noarmalizeScore(reviewScore+adminReviewScore, maxReviewScore+maxAdminReviewScore, level2)
-	// fmt.Printf("score level 2: %f\n", noarmalizeScore(reviewScore+adminReviewScore, maxReviewScore+maxAdminReviewScore, level2))
 	if reviewScore != maxReviewScore ||
 		adminReviewScore != maxAdminReviewScore {
 		return int(score), nil
@@ -299,7 +297,6 @@ func computeScore(scores []levelScore) (int, error) {
 	// Third, check the use of context.
 	contextScore, maxContextScore := computeNonAdminContextScore(scores, maxScores)
 	score += noarmalizeScore(contextScore, maxContextScore, level3)
-	// fmt.Printf("score level 3: %f\n", noarmalizeScore(contextScore, maxContextScore, level3))
 	if contextScore != maxContextScore {
 		return int(score), nil
 	}
@@ -307,7 +304,6 @@ func computeScore(scores []levelScore) (int, error) {
 	// Fourth, check the thorough non-admin review config.
 	thoroughReviewScore, maxThoroughReviewScore := computeNonAdminThoroughReviewScore(scores, maxScores)
 	score += noarmalizeScore(thoroughReviewScore, maxThoroughReviewScore, level4)
-	// fmt.Printf("score level 4: %f\n", noarmalizeScore(thoroughReviewScore, maxThoroughReviewScore, level4))
 	if thoroughReviewScore != maxThoroughReviewScore {
 		return int(score), nil
 	}
@@ -317,7 +313,6 @@ func computeScore(scores []levelScore) (int, error) {
 	// https://github.com/ossf/scorecard/issues/1027, so we may remove it.
 	adminThoroughReviewScore, maxAdminThoroughReviewScore := computeAdminThoroughReviewScore(scores, maxScores)
 	score += noarmalizeScore(adminThoroughReviewScore, maxAdminThoroughReviewScore, level5)
-	// fmt.Printf("score level 5: %f\n", noarmalizeScore(adminThoroughReviewScore, maxAdminThoroughReviewScore, level5))
 	if adminThoroughReviewScore != maxAdminThoroughReviewScore {
 		return int(score), nil
 	}

--- a/checks/branch_protection.go
+++ b/checks/branch_protection.go
@@ -429,22 +429,6 @@ func checkReleaseAndDevBranchProtection(
 	}
 }
 
-func testScore(protection *clients.BranchProtectionRule,
-	branch string, dl checker.DetailLogger) (int, error) {
-	var score levelScore
-	score.scores.basic, score.maxes.basic = basicNonAdminProtection(protection, branch, dl)
-	score.scores.adminBasic, score.maxes.adminBasic = adminBasicProtection(protection, branch, dl)
-	score.scores.review, score.maxes.review = nonAdminReviewProtection(protection)
-	score.scores.adminReview, score.maxes.adminReview = adminReviewProtection(protection, branch, dl)
-	score.scores.context, score.maxes.context = nonAdminContextProtection(protection, branch, dl)
-	score.scores.thoroughReview, score.maxes.thoroughReview =
-		nonAdminThoroughReviewProtection(protection, branch, dl)
-	score.scores.adminThoroughReview, score.maxes.adminThoroughReview =
-		adminThoroughReviewProtection(protection, branch, dl)
-
-	return computeScore([]levelScore{score})
-}
-
 func basicNonAdminProtection(protection *clients.BranchProtectionRule,
 	branch string, dl checker.DetailLogger) (int, int) {
 	score := 0

--- a/checks/branch_protection.go
+++ b/checks/branch_protection.go
@@ -38,16 +38,16 @@ const (
 	// First level.
 	allowForcePushes branchProtectionSetting = iota
 	allowDeletions
-	// Second level.
-	requireStatusChecksContexts
 	// Third and fourth level.
 	requireApprovingReviewCount
+	// Fourth level.
+	requireStatusChecksContexts
 	// Admin settings.
 	// First level.
 	enforceAdmins
 	// Second level.
 	requireUpToDateBeforeMerge
-	// Fourth level.
+	// Fifth level.
 	dismissStaleReviews
 	// requireCodeOwnerReviews no longer used.
 	// requireLinearHistory no longer used, see https://github.com/ossf/scorecard/issues/1027.

--- a/checks/branch_protection.go
+++ b/checks/branch_protection.go
@@ -30,11 +30,12 @@ const (
 	// CheckBranchProtection is the exported name for Branch-Protected check.
 	CheckBranchProtection = "Branch-Protection"
 	minReviews            = 2
-	level1                = 3
-	level2                = 3
-	level3                = 2
-	level4                = 1
-	level5                = 1
+	// Points incremented at each level.
+	level1 = 3
+	level2 = 3
+	level3 = 2
+	level4 = 1
+	level5 = 1
 	// First level.
 	allowForcePushes branchProtectionSetting = iota
 	allowDeletions
@@ -129,13 +130,9 @@ func BranchProtection(c *checker.CheckRequest) checker.CheckResult {
 }
 
 func updateMaxScore(s1, s2 int) (int, error) {
-	if s2 != 0 && s1 != 0 && s1 != s2 {
+	if s1 != s2 {
 		return 0, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("invalid score %d != %d",
 			s1, s2))
-	}
-
-	if s1 < s2 {
-		return s2, nil
 	}
 
 	return s1, nil

--- a/checks/branch_protection.go
+++ b/checks/branch_protection.go
@@ -38,7 +38,7 @@ const (
 	// First level.
 	allowForcePushes branchProtectionSetting = iota
 	allowDeletions
-	// Third and fourth level.
+	// Second and third level.
 	requireApprovingReviewCount
 	// Fourth level.
 	requireStatusChecksContexts
@@ -304,7 +304,7 @@ func computeScore(scores []levelScore) (int, error) {
 		return int(score), nil
 	}
 
-	// Fourth, check the through non-admin review config.
+	// Fourth, check the thorough non-admin review config.
 	thoroughReviewScore, maxThoroughReviewScore := computeNonAdminThoroughReviewScore(scores, maxScores)
 	score += noarmalizeScore(thoroughReviewScore, maxThoroughReviewScore, level4)
 	// fmt.Printf("score level 4: %f\n", noarmalizeScore(thoroughReviewScore, maxThoroughReviewScore, level4))
@@ -312,7 +312,7 @@ func computeScore(scores []levelScore) (int, error) {
 		return int(score), nil
 	}
 
-	// Last, check the through admin review config.
+	// Last, check the thorough admin review config.
 	// This one is controversial and has usability issues
 	// https://github.com/ossf/scorecard/issues/1027, so we may remove it.
 	adminThoroughReviewScore, maxAdminThoroughReviewScore := computeAdminThoroughReviewScore(scores, maxScores)

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -50,6 +50,22 @@ func scrubBranches(branches []*clients.BranchRef) []*clients.BranchRef {
 	return ret
 }
 
+func testScore(protection *clients.BranchProtectionRule,
+	branch string, dl checker.DetailLogger) (int, error) {
+	var score levelScore
+	score.scores.basic, score.maxes.basic = basicNonAdminProtection(protection, branch, dl)
+	score.scores.adminBasic, score.maxes.adminBasic = adminBasicProtection(protection, branch, dl)
+	score.scores.review, score.maxes.review = nonAdminReviewProtection(protection)
+	score.scores.adminReview, score.maxes.adminReview = adminReviewProtection(protection, branch, dl)
+	score.scores.context, score.maxes.context = nonAdminContextProtection(protection, branch, dl)
+	score.scores.thoroughReview, score.maxes.thoroughReview =
+		nonAdminThoroughReviewProtection(protection, branch, dl)
+	score.scores.adminThoroughReview, score.maxes.adminThoroughReview =
+		adminThoroughReviewProtection(protection, branch, dl)
+
+	return computeScore([]levelScore{score})
+}
+
 func TestReleaseAndDevBranchProtected(t *testing.T) {
 	t.Parallel()
 

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -14,7 +14,6 @@
 
 package checks
 
-/*
 import (
 	"testing"
 
@@ -676,4 +675,3 @@ func TestIsBranchProtected(t *testing.T) {
 		})
 	}
 }
-*/

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -59,7 +59,9 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 	trueVal := true
 	falseVal := false
 	var zeroVal int32
+
 	var oneVal int32 = 1
+
 	//nolint
 	tests := []struct {
 		name          string
@@ -73,7 +75,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			name: "Nil release and main branch names",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         -1,
+				Score:         checker.InconclusiveResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
@@ -84,9 +86,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      nil,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: clients.StatusChecksRule{
-							Strict:   &trueVal,
-							Contexts: []string{"foo"},
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &trueVal,
+							Contexts:             []string{"foo"},
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &trueVal,
@@ -103,9 +106,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      nil,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: clients.StatusChecksRule{
-							Strict:   &falseVal,
-							Contexts: nil,
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &falseVal,
+							Contexts:             nil,
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &falseVal,
@@ -126,8 +130,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			name: "Only development branch",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         1,
-				NumberOfWarn:  6,
+				Score:         2,
+				NumberOfWarn:  5,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
@@ -141,9 +145,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &main,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: falseVal,
-							Contexts: nil,
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &falseVal,
+							Contexts:             nil,
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &falseVal,
@@ -163,9 +168,9 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			name: "Take worst of release and development",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         5,
-				NumberOfWarn:  7,
-				NumberOfInfo:  10,
+				Score:         2,
+				NumberOfWarn:  6,
+				NumberOfInfo:  8,
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
@@ -174,9 +179,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &main,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: trueVal,
-							Contexts: []string{"foo"},
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &trueVal,
+							Contexts:             []string{"foo"},
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &trueVal,
@@ -193,9 +199,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &rel1,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: falseVal,
-							Contexts: nil,
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &falseVal,
+							Contexts:             nil,
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &falseVal,
@@ -215,9 +222,9 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			name: "Both release and development are OK",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         9,
+				Score:         8,
 				NumberOfWarn:  2,
-				NumberOfInfo:  16,
+				NumberOfInfo:  12,
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
@@ -226,9 +233,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &main,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: trueVal,
-							Contexts: []string{"foo"},
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &trueVal,
+							Contexts:             []string{"foo"},
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &trueVal,
@@ -245,9 +253,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &rel1,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: trueVal,
-							Contexts: []string{"foo"},
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &trueVal,
+							Contexts:             []string{"foo"},
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &trueVal,
@@ -267,8 +276,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			name: "Ignore a non-branch targetcommitish",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         1,
-				NumberOfWarn:  6,
+				Score:         2,
+				NumberOfWarn:  5,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
@@ -279,9 +288,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &main,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: falseVal,
-							Contexts: nil,
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &falseVal,
+							Contexts:             nil,
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &falseVal,
@@ -315,9 +325,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &main,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: falseVal,
-							Contexts: nil,
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &falseVal,
+							Contexts:             nil,
 						},
 						RequiredPullRequestReviews: clients.PullRequestReviewRule{
 							DismissStaleReviews:          &falseVal,
@@ -337,9 +348,9 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         0,
-				NumberOfWarn:  2,
+				NumberOfWarn:  4,
 				NumberOfInfo:  0,
-				NumberOfDebug: 0,
+				NumberOfDebug: 6,
 			},
 			nonadmin:      true,
 			defaultBranch: main,
@@ -350,9 +361,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &main,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: trueVal,
-							Contexts: []string{"foo"},
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &trueVal,
+							Contexts:             []string{"foo"},
 						},
 					},
 				},
@@ -360,9 +372,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					Name:      &rel1,
 					Protected: &trueVal,
 					BranchProtectionRule: clients.BranchProtectionRule{
-						RequiredStatusChecks: &clients.StatusChecksRule{
-							UpToDate: trueVal,
-							Contexts: []string{"foo"},
+						CheckRules: clients.StatusChecksRule{
+							RequiresStatusChecks: &trueVal,
+							UpToDateBeforeMerge:  &trueVal,
+							Contexts:             []string{"foo"},
 						},
 					},
 				},
@@ -428,15 +441,16 @@ func TestIsBranchProtected(t *testing.T) {
 			name: "Nothing is enabled",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         1,
-				NumberOfWarn:  6,
+				Score:         2,
+				NumberOfWarn:  5,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: falseVal,
-					Contexts: nil,
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &trueVal,
+					UpToDateBeforeMerge:  &falseVal,
+					Contexts:             nil,
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -454,9 +468,9 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         0,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  0,
-				NumberOfDebug: 0,
+				NumberOfDebug: 3,
 			},
 			protection: &clients.BranchProtectionRule{},
 		},
@@ -465,14 +479,15 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  5,
+				NumberOfWarn:  3,
 				NumberOfInfo:  4,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: trueVal,
-					Contexts: []string{"foo"},
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &trueVal,
+					UpToDateBeforeMerge:  &trueVal,
+					Contexts:             []string{"foo"},
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -490,14 +505,15 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  6,
+				NumberOfWarn:  4,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: trueVal,
-					Contexts: nil,
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &trueVal,
+					UpToDateBeforeMerge:  &trueVal,
+					Contexts:             nil,
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -515,14 +531,15 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  5,
+				NumberOfWarn:  4,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: falseVal,
-					Contexts: []string{"foo"},
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &trueVal,
+					UpToDateBeforeMerge:  &falseVal,
+					Contexts:             []string{"foo"},
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -540,14 +557,15 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         3,
-				NumberOfWarn:  5,
-				NumberOfInfo:  3,
+				NumberOfWarn:  3,
+				NumberOfInfo:  4,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: falseVal,
-					Contexts: []string{"foo"},
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &falseVal,
+					UpToDateBeforeMerge:  &falseVal,
+					Contexts:             []string{"foo"},
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -565,14 +583,15 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  5,
+				NumberOfWarn:  4,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: falseVal,
-					Contexts: []string{"foo"},
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &falseVal,
+					UpToDateBeforeMerge:  &falseVal,
+					Contexts:             []string{"foo"},
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -589,15 +608,16 @@ func TestIsBranchProtected(t *testing.T) {
 			name: "Allow force push enabled",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         0,
-				NumberOfWarn:  7,
-				NumberOfInfo:  1,
+				Score:         1,
+				NumberOfWarn:  5,
+				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: falseVal,
-					Contexts: []string{"foo"},
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &falseVal,
+					UpToDateBeforeMerge:  &falseVal,
+					Contexts:             []string{"foo"},
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -614,15 +634,16 @@ func TestIsBranchProtected(t *testing.T) {
 			name: "Allow deletions enabled",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         0,
-				NumberOfWarn:  7,
-				NumberOfInfo:  1,
+				Score:         1,
+				NumberOfWarn:  5,
+				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: falseVal,
-					Contexts: []string{"foo"},
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &falseVal,
+					UpToDateBeforeMerge:  &falseVal,
+					Contexts:             []string{"foo"},
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &falseVal,
@@ -639,15 +660,16 @@ func TestIsBranchProtected(t *testing.T) {
 			name: "Branches are protected",
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         9,
+				Score:         8,
 				NumberOfWarn:  1,
-				NumberOfInfo:  8,
+				NumberOfInfo:  6,
 				NumberOfDebug: 0,
 			},
 			protection: &clients.BranchProtectionRule{
-				RequiredStatusChecks: &clients.StatusChecksRule{
-					UpToDate: trueVal,
-					Contexts: []string{"foo"},
+				CheckRules: clients.StatusChecksRule{
+					RequiresStatusChecks: &falseVal,
+					UpToDateBeforeMerge:  &trueVal,
+					Contexts:             []string{"foo"},
 				},
 				RequiredPullRequestReviews: clients.PullRequestReviewRule{
 					DismissStaleReviews:          &trueVal,
@@ -666,8 +688,10 @@ func TestIsBranchProtected(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}
+			score, err := testScore(tt.protection, "test", &dl)
 			actual := &checker.CheckResult{
-				Score: isBranchProtected(tt.protection, "test", &dl),
+				Score: score,
+				Error: err,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, actual, &dl) {
 				t.Fail()

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -54,7 +54,7 @@ func testScore(protection *clients.BranchProtectionRule,
 	branch string, dl checker.DetailLogger) (int, error) {
 	var score levelScore
 	score.scores.basic, score.maxes.basic = basicNonAdminProtection(protection, branch, dl)
-	score.scores.adminBasic, score.maxes.adminBasic = adminBasicProtection(protection, branch, dl)
+	score.scores.adminBasic, score.maxes.adminBasic = basicAdminProtection(protection, branch, dl)
 	score.scores.review, score.maxes.review = nonAdminReviewProtection(protection)
 	score.scores.adminReview, score.maxes.adminReview = adminReviewProtection(protection, branch, dl)
 	score.scores.context, score.maxes.context = nonAdminContextProtection(protection, branch, dl)

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -97,6 +97,28 @@ Additionally, in some cases these rules will need to be suspended. For example,
 if a past commit includes illegal content such as child pornography, it may be
 necessary to use a force push to rewrite the history rather than simply hide the
 commit. 
+
+This test has tiered scoring. Each tier must be fully satisfied to achieve points at the next tier. For example, if you fulfill the Tier 3 checks but do not fulfill all the Tier 2 checks, you will not receive any points for Tier 3.
+
+Note: If Scorecard is run without an administrative access token, the requirements that specify “For administrators” are ignored.
+
+Tier 1 Requirements (3/10 points):
+  - Force push
+  - Force deletion
+  - For administrators: Include administrators
+
+Tier 2 Requirements (6/10 points):
+  - Required reviewers >=1 ​
+  - For administrators: Strict status checks (require branches to be up-to-date before merging)
+
+Tier 3 Requirements (8/10 points):
+  - Status checks defined
+
+Tier 4 Requirements (9/10 points):
+  - Required reviewers >= 2
+
+Tier 5 Requirements (10/10 points):
+  - For administrators: Dismiss stale reviews
  
 
 **Remediation steps**

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -176,9 +176,9 @@ checks:
       Note: If Scorecard is run without an administrative access token, the requirements that specify “For administrators” are ignored.
 
       Tier 1 Requirements (3/10 points):
-        - Force push
-        - Force deletion
-        - For administrators: Include administrators
+        - Prevent force push
+        - Prevent branch deletion
+        - For administrators: Include administrator for review
       
       Tier 2 Requirements (6/10 points):
         - Required reviewers >=1 ​

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -171,6 +171,28 @@ checks:
       necessary to use a force push to rewrite the history rather than simply hide the
       commit. 
 
+      This test has tiered scoring. Each tier must be fully satisfied to achieve points at the next tier. For example, if you fulfill the Tier 3 checks but do not fulfill all the Tier 2 checks, you will not receive any points for Tier 3.
+
+      Note: If Scorecard is run without an administrative access token, the requirements that specify “For administrators” are ignored.
+
+      Tier 1 Requirements (3/10 points):
+        - Force push
+        - Force deletion
+        - For administrators: Include administrators
+      
+      Tier 2 Requirements (6/10 points):
+        - Required reviewers >=1 ​
+        - For administrators: Strict status checks (require branches to be up-to-date before merging)
+      
+      Tier 3 Requirements (8/10 points):
+        - Status checks defined
+      
+      Tier 4 Requirements (9/10 points):
+        - Required reviewers >= 2
+      
+      Tier 5 Requirements (10/10 points):
+        - For administrators: Dismiss stale reviews
+
     remediation:
       - >-
         Enable branch protection settings in your source hosting provider to

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -43,9 +43,9 @@ var _ = Describe("E2E TEST:"+checks.CheckBranchProtection, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         8,
+				Score:         6,
 				NumberOfWarn:  1,
-				NumberOfInfo:  9,
+				NumberOfInfo:  6,
 				NumberOfDebug: 0,
 			}
 			result := checks.BranchProtection(&req)


### PR DESCRIPTION
Update score to work like 'stages':
- first stage: force push, force deletion. if admin, enforce admins. Those give 3/10
- second stage: review >= 1. for admins, up-to-date branch. Those gives 6/10. Maybe up-to-date branch could go to first stage?
- third stage: status checks defined. Gives 8/10. 
- fourth stage : reviews >= 2. Gives 9/10
- fifth stage: for admins, dismissal (very hard to use). Gives 10/10

If a stage is not satisfied, the score won't go up regardless of the settings of the next stages. Warn/Info messages are shown for all stage, regardless of the score.
I scorecard is run without admin access, the admin settings are ignored.

@olivekl how shall I word this in the checks.yaml?

FYI, I'm working on the unit tests right now but that should not hamper the review.