### PR TITLE
:sparkles:ci: drop trailing whitespaces

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -1,5 +1,5 @@
 name: Scorecard analysis workflow
-on: 
+on:
   push:
     # Only the default branch is supported.
     branches: [main, master]
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       security-events: write
-    
+
     steps:
       - name: "Checkout code"
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579
@@ -37,7 +37,7 @@ jobs:
           name: SARIF file
           path: results.sarif
           retention-days: 5
-      
+
       - name: "Upload SARIF results"
         uses: github/codeql-action/upload-sarif@v1
         with:


### PR DESCRIPTION
This should help to prevent various linters from complaining about
trailing whitespaces when the file is copy-pasted to other repositories:
```
.github/workflows/scorecard-analysis.yml:2: trailing whitespace.
+on:
.github/workflows/scorecard-analysis.yml:18: trailing whitespace.
+
.github/workflows/scorecard-analysis.yml:40: trailing whitespace.
+
```