### PR TITLE
✨  Allow pip install with --require-hashes only

### DIFF
--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -641,7 +641,7 @@ func TestDockerfileScriptDownload(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  31,
+				NumberOfWarn:  33,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			},

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -471,9 +471,7 @@ func isUnpinnedPipInstall(cmd []string) bool {
 	hasWhl := false
 	hashHashes := false
 	hasAddArgs := false
-	fmt.Println("testing", cmd, len(cmd))
 	for i := 1; i < len(cmd); i++ {
-		fmt.Println("", cmd[i])
 		// Search for install commands.
 		if strings.EqualFold(cmd[i], "install") {
 			isInstall = true
@@ -506,7 +504,6 @@ func isUnpinnedPipInstall(cmd []string) bool {
 
 	// We get here only for
 	// `pip install [bla.whl ...]`, `pip install <> --require-hashes`
-	fmt.Println(cmd, !((hasWhl && !hasAddArgs) || hashHashes))
 	return isInstall && !((hasWhl && !hasAddArgs) || hashHashes)
 }
 

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -494,8 +494,8 @@ func isUnpinnedPipInstall(cmd []string) bool {
 			continue
 		}
 
-		// Other arguments are present.
-		hasAddArgs = true
+		// Unresolved dependencies are present.
+		hasUnresolvedDeps = true
 	}
 
 	// We get here only for

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -482,8 +482,8 @@ func isUnpinnedPipInstall(cmd []string) bool {
 
 		// https://github.com/ossf/scorecard/issues/1306#issuecomment-974539197.
 		if strings.EqualFold(cmd[i], "--require-hashes") {
-			hashHashes = true
-			continue
+			hasUnresolvedDeps = false
+			break
 		}
 
 		// Exclude *.whl as they're mostly used

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -484,9 +484,7 @@ func isUnpinnedPipInstall(cmd []string) bool {
 			continue
 		}
 
-		// TODO(laurent): https://github.com/ossf/scorecard/pull/611#discussion_r660203476.
-		// Support -r <> --require-hashes.
-
+		// https://github.com/ossf/scorecard/issues/1306#issuecomment-974539197.
 		if strings.EqualFold(cmd[i], "--require-hashes") {
 			hashHashes = true
 			continue

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -477,7 +477,7 @@ func isUnpinnedPipInstall(cmd []string) bool {
 		}
 
 		if !isInstall {
-			continue
+			break
 		}
 
 		// https://github.com/ossf/scorecard/issues/1306#issuecomment-974539197.

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -497,8 +497,7 @@ func isUnpinnedPipInstall(cmd []string) bool {
 			continue
 		}
 
-		// Any other arguments are considered unpinned,
-		// unless hashHashes is true.
+		// Other arguments are present.
 		hasAddArgs = true
 	}
 

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -468,9 +468,7 @@ func isUnpinnedPipInstall(cmd []string) bool {
 	}
 
 	isInstall := false
-	hasWhl := false
-	hashHashes := false
-	hasAddArgs := false
+	hasUnresolvedDeps := false
 	for i := 1; i < len(cmd); i++ {
 		// Search for install commands.
 		if strings.EqualFold(cmd[i], "install") {

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -500,7 +500,7 @@ func isUnpinnedPipInstall(cmd []string) bool {
 
 	// We get here only for
 	// `pip install [bla.whl ...]`, `pip install <> --require-hashes`
-	return isInstall && !((hasWhl && !hasAddArgs) || hashHashes)
+	return isInstall && hasUnresolvedDeps
 }
 
 func isPythonCommand(cmd []string) bool {

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -491,7 +491,6 @@ func isUnpinnedPipInstall(cmd []string) bool {
 		// Exclude *.whl as they're mostly used
 		// for tests. See https://github.com/ossf/scorecard/pull/611.
 		if strings.HasSuffix(cmd[i], ".whl") {
-			hasWhl = true
 			// We continue because a command may contain
 			// multiple packages to install, not just `.whl` files.
 			continue

--- a/checks/testdata/Dockerfile-pkg-managers
+++ b/checks/testdata/Dockerfile-pkg-managers
@@ -37,6 +37,11 @@ RUN pip install
 RUN pip3 install
 RUN pip install -r any_file
 RUN pip3 install -r bla-requirements.txt
+RUN ["pip", "install", "-r", "requirements.txt", "--require-hashes"]
+RUN ["pip3", "install", "-r", "requirements.txt", "--require-hashes"]
+RUN ["/bin/pip", "install", "--upgrade", "-r", "requirements.txt"]
+RUN ["/bin/pip", "install", "--upgrade"]
+RUN pip3 install -r bla-requirements.txt --require-hashes
 
 RUN pip install somepkg
 RUN pip3 install somepkg==1.2.3

--- a/checks/testdata/Dockerfile-pkg-managers
+++ b/checks/testdata/Dockerfile-pkg-managers
@@ -42,6 +42,7 @@ RUN ["pip3", "install", "-r", "requirements.txt", "--require-hashes"]
 RUN ["/bin/pip", "install", "--upgrade", "-r", "requirements.txt"]
 RUN ["/bin/pip", "install", "--upgrade"]
 RUN pip3 install -r bla-requirements.txt --require-hashes
+RUN pip3 install --require-hashes -r bla-requirements.txt
 
 RUN pip install somepkg
 RUN pip3 install somepkg==1.2.3

--- a/checks/testdata/github-workflow-pkg-managers.yaml
+++ b/checks/testdata/github-workflow-pkg-managers.yaml
@@ -43,6 +43,8 @@ jobs:
       - name:
         run: npm i -g typescript
       - name:
+        run: pip3 install -r bla-requirements.txt --require-hashes && pip3 install --require-hashes -r bla-requirements.txt
+      - name:
         run: go get github.com@some_tag
       - name:
         run: go install github.com@some_tag

--- a/checks/testdata/script-pkg-managers
+++ b/checks/testdata/script-pkg-managers
@@ -35,6 +35,7 @@ pip install
 pip install -r any_file
 pip3 install -r bla-requirements.txt
 pip3 install -r bla-requirements.txt --require-hashes
+pip3 install --require-hashes -r bla-requirements.txt
 
 pip install somepkg
 pip3 install somepkg==1.2.3

--- a/checks/testdata/script-pkg-managers
+++ b/checks/testdata/script-pkg-managers
@@ -34,6 +34,7 @@ pip3 install
 pip install
 pip install -r any_file
 pip3 install -r bla-requirements.txt
+pip3 install -r bla-requirements.txt --require-hashes
 
 pip install somepkg
 pip3 install somepkg==1.2.3


### PR DESCRIPTION
See discussion in https://github.com/ossf/scorecard/issues/1306#issuecomment-974539197
We've had a TODO in https://github.com/ossf/scorecard/blob/main/checks/shell_download_validate.go#L484 for a while.

This means that any `pip install`, `pip --upgrade`, `pip -U` are flagged, as is already the case.
We only allow: `pip install -r <> --require-hashes` and `pip install *.whl`