### PR TITLE
🐛 Disable pinning lock file search in repo

### DIFF
--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -651,7 +651,7 @@ func isPackageManagerLockFilePresent(c *checker.CheckRequest) (int, error) {
 // validatePackageManagerFile will validate the if frozen dependecies file name exists.
 // TODO(laurent): need to differentiate between libraries and programs.
 // TODO(laurent): handle multi-language repos.
-//nolint:unused,deadcode
+//nolint:unused
 func validatePackageManagerFile(name string, dl checker.DetailLogger, data fileparser.FileCbData) (bool, error) {
 	switch strings.ToLower(name) {
 	// TODO(laurent): "go.mod" is for libraries

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -45,10 +45,15 @@ func init() {
 // PinnedDependencies will check the repository if it contains frozen dependecies.
 func PinnedDependencies(c *checker.CheckRequest) checker.CheckResult {
 	// Lock file.
+	/* WARNING: this code is inherently incorrect:
+	- does not differenetiate between libs and main
+	- only looks at root fodler.
+	=> disabling to avoid false positives.
 	lockScore, lockErr := isPackageManagerLockFilePresent(c)
 	if lockErr != nil {
 		return checker.CreateRuntimeErrorResult(CheckPinnedDependencies, lockErr)
 	}
+	*/
 
 	// GitHub actions.
 	actionScore, actionErr := isGitHubActionsWorkflowPinned(c)
@@ -81,13 +86,12 @@ func PinnedDependencies(c *checker.CheckRequest) checker.CheckResult {
 	}
 
 	// Scores may be inconclusive.
-	lockScore = maxScore(0, lockScore)
 	actionScore = maxScore(0, actionScore)
 	dockerFromScore = maxScore(0, dockerFromScore)
 	dockerDownloadScore = maxScore(0, dockerDownloadScore)
 	scriptScore = maxScore(0, scriptScore)
 	actionScriptScore = maxScore(0, actionScriptScore)
-	score := checker.AggregateScores(lockScore, actionScore, dockerFromScore,
+	score := checker.AggregateScores(actionScore, dockerFromScore,
 		dockerDownloadScore, scriptScore, actionScriptScore)
 
 	if score == checker.MaxResultScore {

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -47,7 +47,7 @@ func PinnedDependencies(c *checker.CheckRequest) checker.CheckResult {
 	// Lock file.
 	/* WARNING: this code is inherently incorrect:
 	- does not differenetiate between libs and main
-	- only looks at root fodler.
+	- only looks at root folder.
 	=> disabling to avoid false positives.
 	lockScore, lockErr := isPackageManagerLockFilePresent(c)
 	if lockErr != nil {

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -633,6 +633,7 @@ func addWorkflowPinnedResult(w *worklowPinningResult, to, isGitHub bool) {
 }
 
 // Check presence of lock files thru validatePackageManagerFile().
+//nolint:deadcode
 func isPackageManagerLockFilePresent(c *checker.CheckRequest) (int, error) {
 	var r pinnedResult
 	err := fileparser.CheckIfFileExists(CheckPinnedDependencies, c, validatePackageManagerFile, &r)
@@ -650,6 +651,7 @@ func isPackageManagerLockFilePresent(c *checker.CheckRequest) (int, error) {
 // validatePackageManagerFile will validate the if frozen dependecies file name exists.
 // TODO(laurent): need to differentiate between libraries and programs.
 // TODO(laurent): handle multi-language repos.
+//nolint:deadcode
 func validatePackageManagerFile(name string, dl checker.DetailLogger, data fileparser.FileCbData) (bool, error) {
 	switch strings.ToLower(name) {
 	// TODO(laurent): "go.mod" is for libraries

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -46,7 +46,7 @@ func init() {
 func PinnedDependencies(c *checker.CheckRequest) checker.CheckResult {
 	// Lock file.
 	/* WARNING: this code is inherently incorrect:
-	- does not differenetiate between libs and main
+	- does not differentiate between libs and main
 	- only looks at root folder.
 	=> disabling to avoid false positives.
 	lockScore, lockErr := isPackageManagerLockFilePresent(c)

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -633,7 +633,7 @@ func addWorkflowPinnedResult(w *worklowPinningResult, to, isGitHub bool) {
 }
 
 // Check presence of lock files thru validatePackageManagerFile().
-//nolint:deadcode
+//nolint:unused,deadcode
 func isPackageManagerLockFilePresent(c *checker.CheckRequest) (int, error) {
 	var r pinnedResult
 	err := fileparser.CheckIfFileExists(CheckPinnedDependencies, c, validatePackageManagerFile, &r)
@@ -651,7 +651,7 @@ func isPackageManagerLockFilePresent(c *checker.CheckRequest) (int, error) {
 // validatePackageManagerFile will validate the if frozen dependecies file name exists.
 // TODO(laurent): need to differentiate between libraries and programs.
 // TODO(laurent): handle multi-language repos.
-//nolint:deadcode
+//nolint:unused,deadcode
 func validatePackageManagerFile(name string, dl checker.DetailLogger, data fileparser.FileCbData) (bool, error) {
 	switch strings.ToLower(name) {
 	// TODO(laurent): "go.mod" is for libraries

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -45,8 +45,8 @@ var _ = Describe("E2E TEST:"+checks.CheckBranchProtection, func() {
 				Error:         nil,
 				Score:         6,
 				NumberOfWarn:  1,
-				NumberOfInfo:  6,
-				NumberOfDebug: 0,
+				NumberOfInfo:  3,
+				NumberOfDebug: 3,
 			}
 			result := checks.BranchProtection(&req)
 			// UPGRADEv2: to remove.

--- a/e2e/pinned_dependencies_test.go
+++ b/e2e/pinned_dependencies_test.go
@@ -46,7 +46,7 @@ var _ = Describe("E2E TEST:"+checks.CheckPinnedDependencies, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         3,
-				NumberOfWarn:  150,
+				NumberOfWarn:  149,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			}


### PR DESCRIPTION
The code looking for lock files in package managers is incorrect:

- libraries vs cli https://github.com/ossf/scorecard/issues/689 => false positives
- we only look for lock files in the top folder => false positives

This PR disables this part of the code until we have a better solution. Looking for a lock files next to a manifest file is also error prone: users may copy lock files into dockerfiles from different locations, etc.

I think the right approach is to ensure any scripted installation command requires all dependencies and transitive dependencies to be pinned by hash:
- https://github.com/ossf/scorecard/pull/1314 - `npm ci`
- https://github.com/ossf/scorecard/pull/1313 - `pip install -r <> --require-hashes`

Updates should be performed by tools (dependabot/renovabot), never in scripts.

@meder @inferno-chromium  FYI