### PR TITLE
🐛 Fix e2e branch protection test

### DIFF
--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -52,7 +52,7 @@ var _ = Describe("E2E TEST:"+checks.CheckBranchProtection, func() {
 			// UPGRADEv2: to remove.
 			// Old version.
 			Expect(result.Error).Should(BeNil())
-			Expect(result.Pass).Should(BeTrue())
+			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "branch protection accessible", &expected, &result, &dl)).Should(BeTrue())
 			Expect(repoClient.Close()).Should(BeNil())

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("E2E TEST:"+checks.CheckBranchProtection, func() {
 	Context("E2E TEST:Validating branch protection", func() {
-		It("Should fail to return branch protection on other repositories (1)", func() {
+		It("Should fail to return branch protection on other repositories", func() {
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-branch-protection-e2e")
 			Expect(err).Should(BeNil())

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("E2E TEST:"+checks.CheckBranchProtection, func() {
 	Context("E2E TEST:Validating branch protection", func() {
-		It("Should fail to return branch protection on other repositories", func() {
+		It("Should fail to return branch protection on other repositories (1)", func() {
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-branch-protection-e2e")
 			Expect(err).Should(BeNil())

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -53,6 +53,7 @@ var _ = Describe("E2E TEST:"+checks.CheckBranchProtection, func() {
 			// Old version.
 			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
+
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "branch protection accessible", &expected, &result, &dl)).Should(BeTrue())
 			Expect(repoClient.Close()).Should(BeNil())


### PR DESCRIPTION
See title. There was old code checking the Fail/Pass that is failing because the score calculation has changed.
The PR validation complains about the description not being long enough, so I've added this line.