### PR TITLE
🐛 Fix integration test

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -34,6 +34,8 @@ jobs:
     steps:
       - name: pull_request actions/checkout
         uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.3.4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: setup-go
         uses: actions/setup-go@331ce1d993939866bb63c32c6cbbfd48fa76fc57 # v2.1.3


### PR DESCRIPTION
See this line https://github.com/ossf/scorecard/blob/main/.github/workflows/integration.yml#L36
We're not checking out the PR using `ref`, so we're effectively testing the main branch.

I unfortunately pushed a breaking change https://github.com/ossf/scorecard/pull/1316

To merge it it, we will need to disable integration tests temporarily in the GitHub UX.

close https://github.com/ossf/scorecard/issues/1317
