### PR TITLE
🐛 Get OSes from matrix.include if present

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -87,6 +87,14 @@ func getJobStrategyMatrixRows(job *actionlint.Job) map[string]*actionlint.Matrix
 	return nil
 }
 
+func getJobStrategyMatrixIncludeCombinations(job *actionlint.Job) []*actionlint.MatrixCombination {
+	if job != nil && job.Strategy != nil && job.Strategy.Matrix != nil && job.Strategy.Matrix.Include != nil &&
+		job.Strategy.Matrix.Include.Combinations != nil {
+		return job.Strategy.Matrix.Include.Combinations
+	}
+	return nil
+}
+
 // FormatActionlintError combines the errors into a single one.
 func FormatActionlintError(errs []*actionlint.Error) error {
 	if len(errs) == 0 {
@@ -122,6 +130,19 @@ func GetOSesForJob(job *actionlint.Job) ([]string, error) {
 		}
 		for _, os := range rowValue.Values {
 			jobOSes = append(jobOSes, strings.Trim(os.String(), "'\""))
+		}
+	}
+
+	matrixCombinations := getJobStrategyMatrixIncludeCombinations(job)
+	for _, combination := range matrixCombinations {
+		if combination.Assigns == nil {
+			continue
+		}
+		for _, assign := range combination.Assigns {
+			if assign.Key == nil || assign.Key.Value != os || assign.Value == nil {
+				continue
+			}
+			jobOSes = append(jobOSes, strings.Trim(assign.Value.String(), "'\""))
 		}
 	}
 

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -50,6 +50,16 @@ func TestGitHubWorkflowShell(t *testing.T) {
 			expectedShells: []string{"pwsh"},
 		},
 		{
+			name:           "all windows, OSes listed in matrix.include",
+			filename:       "../testdata/github-workflow-shells-all-windows-matrix-include.yaml",
+			expectedShells: []string{"pwsh"},
+		},
+		{
+			name:           "all windows, empty matrix.include",
+			filename:       "../testdata/github-workflow-shells-all-windows-matrix-include-empty.yaml",
+			expectedShells: []string{"pwsh"},
+		},
+		{
 			name:           "all windows",
 			filename:       "../testdata/github-workflow-shells-all-windows.yaml",
 			expectedShells: []string{"pwsh"},

--- a/checks/testdata/github-workflow-shells-all-windows-matrix-include-empty.yaml
+++ b/checks/testdata/github-workflow-shells-all-windows-matrix-include-empty.yaml
@@ -1,0 +1,23 @@
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jobs:
+  Job1:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-2019, windows-latest]
+        include:
+    steps:
+      - run: echo "hello, github"

--- a/checks/testdata/github-workflow-shells-all-windows-matrix-include.yaml
+++ b/checks/testdata/github-workflow-shells-all-windows-matrix-include.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jobs:
+  Job1:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - {name: Windows, python: '3.9', os: windows-latest}
+          - {name: Windows, python: '3.8', os: windows-2019}
+    steps:
+      - run: echo "hello, github"


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
This [workflow file](https://github.com/mahmoud/boltons/blob/270e974975984f662f998c8f6eb0ebebd964de82/.github/workflows/tests.yaml) was causing an error for the Pinned-Dependencies check. It was because the only OSes listed in strategy.matrix were in the `include` section. Previously, `fileparser.JobAlwaysRunsOnWindows()` may have returned incorrect results if `strategy.matrix.os` and 'strategy.matrix.include` had different operating systems listed. That will be fixed here.
Part of https://github.com/ossf/scorecard/issues/839#issuecomment-974667652.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No
