### PR TITLE
🐛 Skip pinned dependencies check for template Dockerfiles

### DIFF
--- a/checks/fileparser/listing.go
+++ b/checks/fileparser/listing.go
@@ -222,3 +222,22 @@ func CheckFileContainsCommands(content []byte, comment string) bool {
 	}
 	return false
 }
+
+// IsTemplateFile returns true if the file name contains a string commonly used in template files.
+func IsTemplateFile(pathfn string) bool {
+	parts := strings.FieldsFunc(path.Base(pathfn), func(r rune) bool {
+		switch r {
+		case '.', '-', '_':
+			return true
+		default:
+			return false
+		}
+	})
+	for _, part := range parts {
+		switch strings.ToLower(part) {
+		case "template", "tmpl", "tpl":
+			return true
+		}
+	}
+	return false
+}

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -1,0 +1,122 @@
+// Copyright 2021 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package fileparser
+
+import (
+	"testing"
+)
+
+func TestIsTemplateFile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		filename   string
+		isTemplate bool
+	}{
+		{
+			filename:   "Dockerfile.template",
+			isTemplate: true,
+		},
+		{
+			filename:   "Dockerfile.tmpl",
+			isTemplate: true,
+		},
+		{
+			filename:   "Dockerfile.template-debian",
+			isTemplate: true,
+		},
+		{
+			filename:   "Dockerfile.tmpl.",
+			isTemplate: true,
+		},
+		{
+			filename:   "Dockerfile-template",
+			isTemplate: true,
+		},
+		{
+			filename:   "tmpl.Dockerfile",
+			isTemplate: true,
+		},
+		{
+			filename:   "template.Dockerfile",
+			isTemplate: true,
+		},
+		{
+			filename:   "Dockerfile_template",
+			isTemplate: true,
+		},
+		{
+			filename:   "Dockerfile.tmpl.prod",
+			isTemplate: true,
+		},
+		{
+			filename:   "Dockerfile.Template",
+			isTemplate: true,
+		},
+		{
+			filename:   "dockerfile.tpl",
+			isTemplate: true,
+		},
+		{
+			filename:   "build/Dockerfile.tpl",
+			isTemplate: true,
+		},
+		{
+			filename:   "build/tpl.Dockerfile",
+			isTemplate: true,
+		},
+		{
+			filename:   "DockerfileTemplate",
+			isTemplate: false,
+		},
+		{
+			filename:   "Dockerfile.linux",
+			isTemplate: false,
+		},
+		{
+			filename:   "tmp.Dockerfile",
+			isTemplate: false,
+		},
+		{
+			filename:   "Dockerfile",
+			isTemplate: false,
+		},
+		{
+			filename:   "Dockerfile.temp.late",
+			isTemplate: false,
+		},
+		{
+			filename:   "Dockerfile.temp",
+			isTemplate: false,
+		},
+		{
+			filename:   "template/Dockerfile",
+			isTemplate: false,
+		},
+		{
+			filename:   "linux.Dockerfile",
+			isTemplate: false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.filename, func(t *testing.T) {
+			t.Parallel()
+			if got := IsTemplateFile(tt.filename); got != tt.isTemplate {
+				t.Errorf("%v: Got (%v) expected (%v)", tt.filename, got, tt.isTemplate)
+			}
+		})
+	}
+}

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -336,7 +336,6 @@ func validateDockerfileIsPinned(pathfn string, content []byte,
 	dl checker.DetailLogger, data fileparser.FileCbData) (bool, error) {
 	// Users may use various names, e.g.,
 	// Dockerfile.aarch64, Dockerfile.template, Dockerfile_template, dockerfile, Dockerfile-name.template
-	// Templates may trigger false positives, e.g. FROM { NAME }.
 
 	pdata := dataAsResultPointer(data)
 	// Return early if this is a script, e.g. script_dockerfile_something.sh
@@ -346,6 +345,11 @@ func validateDockerfileIsPinned(pathfn string, content []byte,
 	}
 
 	if !fileparser.CheckFileContainsCommands(content, "#") {
+		addPinnedResult(pdata, true)
+		return true, nil
+	}
+
+	if fileparser.IsTemplateFile(pathfn) {
 		addPinnedResult(pdata, true)
 		return true, nil
 	}


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bug fix


* **What is the current behavior?** (You can also link to an open issue here)
This [Dockerfile](https://github.com/traefik/mesh/blob/957da2d9ca4d4cdd4e00d0bdfbb9f5ae4f2685ff/tmpl.Dockerfile) was causing an error for the pinned dependencies check. It is a template Dockerfile, so it was unable to be parsed.
Part of https://github.com/ossf/scorecard/issues/839#issuecomment-974667652


* **What is the new behavior (if this is a feature change)?**
Template Dockerfiles will be skipped for this check. I did some searching of Github for different formats that filenames for template Dockerfiles take, and so this should cover most of them.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No