### PR TITLE
✨ Token-Permission: Allow top level permissions not defined if all run level permissions are

### DIFF
--- a/checks/errors.go
+++ b/checks/errors.go
@@ -20,13 +20,14 @@ import (
 
 //nolint
 var (
-	errInternalInvalidDockerFile = errors.New("invalid Dockerfile")
-	errInternalInvalidYamlFile   = errors.New("invalid yaml file")
-	errInternalFilenameMatch     = errors.New("filename match error")
-	errInternalEmptyFile         = errors.New("empty file")
-	errInternalCommitishNil      = errors.New("commitish is nil")
-	errInternalBranchNotFound    = errors.New("branch not found")
-	errInvalidGitHubWorkflow     = errors.New("invalid GitHub workflow")
-	errInternalNoReviews         = errors.New("no reviews found")
-	errInternalNoCommits         = errors.New("no commits found")
+	errInternalInvalidDockerFile  = errors.New("invalid Dockerfile")
+	errInternalInvalidYamlFile    = errors.New("invalid yaml file")
+	errInternalFilenameMatch      = errors.New("filename match error")
+	errInternalEmptyFile          = errors.New("empty file")
+	errInternalCommitishNil       = errors.New("commitish is nil")
+	errInternalBranchNotFound     = errors.New("branch not found")
+	errInvalidGitHubWorkflow      = errors.New("invalid GitHub workflow")
+	errInternalNoReviews          = errors.New("no reviews found")
+	errInternalNoCommits          = errors.New("no commits found")
+	errInternalInvalidPermissions = errors.New("invalid permissions")
 )

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -255,7 +255,8 @@ func calculateScore(result permissionCbData) int {
 	// Start with a perfect score.
 	score := float32(checker.MaxResultScore)
 
-	// If no top level permissions are defined...
+	// If no top level permissions are defined, all the permissions
+	// are enabled by default, hence "all". In this case,
 	if permissionIsPresentInTopLevel(result, "all") {
 		if permissionIsPresentInRunLevel(result, "all") {
 			// ... give lowest score if no run level permissions are defined either.

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -207,7 +207,8 @@ func validateRunLevelPermissions(workflow *actionlint.Workflow, path string,
 			recordAllPermissionsWrite(pdata.runLevelWritePermissions)
 			continue
 		}
-		err := validatePermissions(job.Permissions, runLevelPermission, path, dl, pdata.runLevelWritePermissions, ignoredPermissions)
+		err := validatePermissions(job.Permissions, runLevelPermission,
+			path, dl, pdata.runLevelWritePermissions, ignoredPermissions)
 		if err != nil {
 			return err
 		}

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -253,7 +253,7 @@ func calculateScore(result permissionCbData) int {
 	// Start with a perfect score.
 	score := float32(checker.MaxResultScore)
 
-	// If not top level permissions are defined...
+	// If no top level permissions are defined...
 	if permissionIsPresentInTopLevel(result, "all") {
 		switch permissionIsPresentInRunLevel(result, "all") {
 		case true:

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -142,6 +142,7 @@ func validatePermissions(permissions *actionlint.Permissions, permLevel, path st
 		if permissions.All.Pos != nil {
 			lineNumber = permissions.All.Pos.Line
 		}
+
 		if !strings.EqualFold(val, "read-all") && val != "" {
 			dl.Warn3(&checker.LogMessage{
 				Path:   path,
@@ -256,14 +257,12 @@ func calculateScore(result permissionCbData) int {
 
 	// If no top level permissions are defined...
 	if permissionIsPresentInTopLevel(result, "all") {
-		switch permissionIsPresentInRunLevel(result, "all") {
-		case true:
-			// ... loweset score if no run level permissions are defined either.
+		if permissionIsPresentInRunLevel(result, "all") {
+			// ... give lowest score if no run level permissions are defined either.
 			return checker.MinResultScore
-		case false:
-			// ... reduce score if run level permissions are defined.
-			score--
 		}
+		// ... reduce score if run level permissions are defined.
+		score--
 	}
 
 	// status: https://docs.github.com/en/rest/reference/repos#statuses.

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -104,9 +104,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  2,
+				NumberOfWarn:  1,
 				NumberOfInfo:  0,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -115,9 +115,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -126,9 +126,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  2,
+				NumberOfWarn:  1,
 				NumberOfInfo:  0,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -137,9 +137,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 6,
 			},
 		},
 		{
@@ -148,9 +148,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  0,
 				NumberOfInfo:  10,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -159,9 +159,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  0,
 				NumberOfInfo:  10,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -170,9 +170,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -181,9 +181,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 1,
-				NumberOfWarn:  3,
+				NumberOfWarn:  2,
 				NumberOfInfo:  2,
-				NumberOfDebug: 5,
+				NumberOfDebug: 6,
 			},
 		},
 		{
@@ -192,9 +192,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 2,
-				NumberOfWarn:  3,
+				NumberOfWarn:  2,
 				NumberOfInfo:  3,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -203,9 +203,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  2,
+				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -214,9 +214,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  2,
+				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -225,9 +225,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  2,
+				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -261,6 +261,17 @@ func TestGithubTokenPermissions(t *testing.T) {
 				NumberOfWarn:  0,
 				NumberOfInfo:  3,
 				NumberOfDebug: 3,
+			},
+		},
+		{
+			name:     "workflow jobs only",
+			filename: "./testdata/github-workflow-permissions-jobs-only.yaml",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         9,
+				NumberOfWarn:  1,
+				NumberOfInfo:  3,
+				NumberOfDebug: 4,
 			},
 		},
 	}

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -104,9 +104,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  0,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -115,9 +115,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  0,
+				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -126,9 +126,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  0,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -137,9 +137,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  0,
+				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -148,9 +148,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  0,
+				NumberOfWarn:  1,
 				NumberOfInfo:  10,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -159,9 +159,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  0,
+				NumberOfWarn:  1,
 				NumberOfInfo:  10,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -170,9 +170,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
-				NumberOfWarn:  0,
+				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -181,9 +181,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 1,
-				NumberOfWarn:  2,
+				NumberOfWarn:  3,
 				NumberOfInfo:  2,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -192,9 +192,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 2,
-				NumberOfWarn:  2,
+				NumberOfWarn:  3,
 				NumberOfInfo:  3,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -203,9 +203,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  2,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -214,9 +214,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  2,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -225,9 +225,9 @@ func TestGithubTokenPermissions(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{

--- a/checks/testdata/github-workflow-permissions-jobs-only.yaml
+++ b/checks/testdata/github-workflow-permissions-jobs-only.yaml
@@ -1,0 +1,34 @@
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: write-and-read workflow
+on: [push]
+
+jobs:
+  jobOne:
+    runs-on: ubuntu-latest
+    permissions:
+    steps:
+      - run: echo "write-and-read workflow"
+  jobTwo:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "write-and-read workflow"
+  jobThree:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - run: echo "write-and-read workflow"

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -528,7 +528,7 @@ information about a bug is not publicly visible.
 **Remediation steps**
 - Place a security policy file `SECURITY.md` in the root directory of your repository. This makes it easily discoverable by a vulnerability reporter.
 - The file should contain information on what constitutes a vulnerability and a way to report it securely (e.g. issue tracker with private issue support, encrypted email with a published public key).
-- For GitHub, see more information [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
+- For GitHub, see more information [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository.).
 
 ## Signed-Releases 
 
@@ -572,9 +572,9 @@ yaml file are set as read-only at the
 [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
 and the required write permissions are declared at the
 [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).
-One point is reduced from the score if all jobs have their permissions defined but the top level permissions are not. The reasoning
-is that even though this configuration is secure, there is a chance that when a new job is added to the workflow,
-job permissions are not defined because of human error.
+One point is reduced from the score if all jobs have their permissions defined but the top level permissions are not defined. 
+This configuration is secure, but there is a chance that when a new job is added to the workflow, its job permissions could be 
+left undefined because of human error.
         
 The check cannot detect if the "read-only" GitHub permission setting is
 enabled, as there is no API available.   

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -572,6 +572,9 @@ yaml file are set as read-only at the
 [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
 and the required write permissions are declared at the
 [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).
+One point is reduced from the score if all jobs have their permissions defined but the top level permissions are not. The reasoning
+is that even though this configuration is secure, there is a chance that when a new job is added to the workflow,
+job permissions are not defined because of human error.
         
 The check cannot detect if the "read-only" GitHub permission setting is
 enabled, as there is no API available.   

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -632,9 +632,9 @@ checks:
       [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
       and the required write permissions are declared at the
       [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).
-      A score of 9 is awarded if all jobs have their permissions defined but the top level permissions are not. The reasoning
+      One point is reduced from the score if all jobs have their permissions defined but the top level permissions are not. The reasoning
       is that even though this configuration is secure, there is a chance that when a new job is added to the workflow,
-      permissions are not defined because of human error.
+      job permissions are not defined because of human error.
               
       The check cannot detect if the "read-only" GitHub permission setting is
       enabled, as there is no API available.   

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -632,9 +632,9 @@ checks:
       [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
       and the required write permissions are declared at the
       [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).
-      One point is reduced from the score if all jobs have their permissions defined but the top level permissions are not. The reasoning
-      is that even though this configuration is secure, there is a chance that when a new job is added to the workflow,
-      job permissions are not defined because of human error.
+      One point is reduced from the score if all jobs have their permissions defined but the top level permissions are not defined. 
+      This configuration is secure, but there is a chance that when a new job is added to the workflow, its job permissions could be 
+      left undefined because of human error.
               
       The check cannot detect if the "read-only" GitHub permission setting is
       enabled, as there is no API available.   

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -632,6 +632,9 @@ checks:
       [top level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#permissions)
       and the required write permissions are declared at the
       [run-level](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idpermissions).
+      A score of 9 is awarded if all jobs have their permissions defined but the top level permissions are not. The reasoning
+      is that even though this configuration is secure, there is a chance that when a new job is added to the workflow,
+      permissions are not defined because of human error.
               
       The check cannot detect if the "read-only" GitHub permission setting is
       enabled, as there is no API available.   

--- a/e2e/permissions_test.go
+++ b/e2e/permissions_test.go
@@ -43,9 +43,9 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  2,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			}
 			result := checks.TokenPermissions(&req)
 			// UPGRADEv2: to remove.

--- a/e2e/permissions_test.go
+++ b/e2e/permissions_test.go
@@ -43,9 +43,9 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  2,
+				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			}
 			result := checks.TokenPermissions(&req)
 			// UPGRADEv2: to remove.


### PR DESCRIPTION
We currently give a score of 0 if all job define their permissions but the top level is not.
This PR removes one point if the top level permissions are not defined but the run level ones are all defined.

See https://github.com/ossf/scorecard/issues/1128#issuecomment-973236716 for more details.

closes https://github.com/ossf/scorecard/issues/1128