### PR TITLE
✨ Don't use the policy filename in SARIF results

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -377,8 +377,7 @@ var rootCmd = &cobra.Command{
 			err = repoResult.AsString(showDetails, *logLevel, checkDocs, os.Stdout)
 		case formatSarif:
 			// TODO: support config files and update checker.MaxResultScore.
-			err = repoResult.AsSARIF(showDetails, *logLevel, os.Stdout, checkDocs, policy,
-				policyFile)
+			err = repoResult.AsSARIF(showDetails, *logLevel, os.Stdout, checkDocs, policy)
 		case formatJSON:
 			// UPGRADEv2: rename.
 			err = repoResult.AsJSON2(showDetails, *logLevel, checkDocs, os.Stdout)

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -560,7 +560,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		// so it's the last position for us.
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
-			locs = addDefaultLocation(locs, "no-source-file")
+			locs = addDefaultLocation(locs, "no file available")
 			// Use the `reason` as message.
 			cr := createSARIFCheckResult(RuleIndex, checkID, check.Reason, &locs[0])
 			run.Results = append(run.Results, cr)

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -491,8 +491,7 @@ func createSARIFRuns(runs map[string]*run) []run {
 
 // AsSARIF outputs ScorecardResult in SARIF 2.1.0 format.
 func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
-	writer io.Writer, checkDocs docs.Doc, policy *spol.ScorecardPolicy,
-	policyFile string) error {
+	writer io.Writer, checkDocs docs.Doc, policy *spol.ScorecardPolicy) error {
 	//nolint
 	// https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html.
 	// We only support GitHub-supported properties:
@@ -561,7 +560,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		// so it's the last position for us.
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
-			locs = addDefaultLocation(locs, policyFile)
+			locs = addDefaultLocation(locs, "no-source-file")
 			// Use the `reason` as message.
 			cr := createSARIFCheckResult(RuleIndex, checkID, check.Reason, &locs[0])
 			run.Results = append(run.Results, cr)

--- a/pkg/sarif_test.go
+++ b/pkg/sarif_test.go
@@ -790,7 +790,7 @@ func TestSARIFOutput(t *testing.T) {
 
 			var result bytes.Buffer
 			err = tt.result.AsSARIF(tt.showDetails, tt.logLevel, &result,
-				checkDocs, &tt.policy, "/path/to/policy.yml")
+				checkDocs, &tt.policy)
 			if err != nil {
 				t.Fatalf("%s: AsSARIF: %v", tt.name, err)
 			}

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -56,7 +56,7 @@
                            "startLine": 1
                         },
                         "artifactLocation": {
-                           "uri": "/path/to/policy.yml",
+                           "uri": "no-source-file",
                            "uriBaseId": "%SRCROOT%"
                         }
                      }

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -56,7 +56,7 @@
                            "startLine": 1
                         },
                         "artifactLocation": {
-                           "uri": "no-source-file",
+                           "uri": "no file available",
                            "uriBaseId": "%SRCROOT%"
                         }
                      }


### PR DESCRIPTION
This uses a default "no-source-file" for results that don't have explicit files to display.
Since we're removing policy files from the GH action, that makes it less confusing for users.