### PR TITLE
✨ CI-Tests: look for test-related strings in target urls as well

### DIFF
--- a/checks/ci_tests.go
+++ b/checks/ci_tests.go
@@ -100,7 +100,7 @@ func prHasSuccessStatus(pr *clients.PullRequest, c *checker.CheckRequest) (bool,
 		if status.State != success {
 			continue
 		}
-		if isTest(status.Context) {
+		if isTest(status.Context) || isTest(status.TargetURL) {
 			c.Dlogger.Debug3(&checker.LogMessage{
 				Path: status.URL,
 				Type: checker.FileTypeURL,

--- a/clients/githubrepo/statuses.go
+++ b/clients/githubrepo/statuses.go
@@ -50,9 +50,10 @@ func statusesFrom(data []*github.RepoStatus) []clients.Status {
 	var statuses []clients.Status
 	for _, status := range data {
 		statuses = append(statuses, clients.Status{
-			State:   status.GetState(),
-			Context: status.GetContext(),
-			URL:     status.GetURL(),
+			State:     status.GetState(),
+			Context:   status.GetContext(),
+			URL:       status.GetURL(),
+			TargetURL: status.GetTargetURL(),
 		})
 	}
 	return statuses

--- a/clients/statuses.go
+++ b/clients/statuses.go
@@ -16,7 +16,8 @@ package clients
 
 // Status for a Git object/ref.
 type Status struct {
-	State   string
-	Context string
-	URL     string
+	State     string
+	Context   string
+	URL       string
+	TargetURL string
 }


### PR DESCRIPTION
Apparently some projects like systemd and bcc put links (containing
the word "Jenkins") to their Jenkins instances in target urls.

https://buildbot.iovisor.org/jenkins/job/bcc-pr/1157/
https://jenkins-systemd.apps.ocp.ci.centos.org/job/upstream-vagrant-archlinux-sanitizers/8288/

It's a follow-up to https://github.com/ossf/scorecard/pull/1293#issuecomment-976384882