### PR TITLE
✨ Code-Review: show PRs merged without code review

### DIFF
--- a/checks/code_review.go
+++ b/checks/code_review.go
@@ -126,6 +126,13 @@ func githubCodeReview(c *checker.CheckRequest) (int, string, error) {
 					pr.Number, pr.Author.Login, pr.MergeCommit.Committer.Login),
 			})
 			totalReviewed++
+			foundApprovedReview = true
+		}
+
+		if !foundApprovedReview {
+			c.Dlogger.Debug3(&checker.LogMessage{
+				Text: fmt.Sprintf("merged PR without code review: %d", pr.Number),
+			})
 		}
 
 	}


### PR DESCRIPTION
to make it easier to figure out whether those PRs are really merged
without code review or whether there is a bug in scorecard like
https://github.com/ossf/scorecard/issues/1260 that prevents it
from finding reviewed PRs. Other than that, the "CI-Tests" check
already shows "untested" PRs so it seems the "Code-Review" check
should follow suit.