### PR TITLE
✨ Comply with GH-specific rules for SARIF

### DIFF
--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -496,8 +496,7 @@ func createSARIFRuns(runs map[string]*run) []run {
 
 func createCheckIdentifiers(name string) (string, string) {
 	// Identifier must be in Pascal case.
-	// We keep the check name the same as the on in the documentation
-	// to be consistent for users.
+	// We keep the check name the same as the one used in the documentation.
 	n := strings.ReplaceAll(name, "-", "")
 	return name, fmt.Sprintf("%sID", n)
 }

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -465,7 +465,7 @@ func computeCategory(checkName string, repos []string) (string, error) {
 		return "", sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("repo types not supported: %v", repos))
 	case checkName == checks.CheckBranchProtection:
 		// This is a special case to be give us more flexibility to move this check around
-		// and run it on differnet GitHub triggers.
+		// and run it on different GitHub triggers.
 		return strings.ToLower(checks.CheckBranchProtection), nil
 	case contains(repos, "local"):
 		return "local", nil
@@ -496,8 +496,10 @@ func createSARIFRuns(runs map[string]*run) []run {
 
 func createCheckIdentifiers(name string) (string, string) {
 	// Identifier must be in Pascal case.
+	// We keep the check name the same as the on in the documentation
+	// to be consistent for users.
 	n := strings.ReplaceAll(name, "-", "")
-	return n, fmt.Sprintf("%sID", n)
+	return name, fmt.Sprintf("%sID", n)
 }
 
 // AsSARIF outputs ScorecardResult in SARIF 2.1.0 format.

--- a/pkg/testdata/check1.sarif
+++ b/pkg/testdata/check1.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"

--- a/pkg/testdata/check1.sarif
+++ b/pkg/testdata/check1.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -44,7 +44,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"

--- a/pkg/testdata/check2.sarif
+++ b/pkg/testdata/check2.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"

--- a/pkg/testdata/check2.sarif
+++ b/pkg/testdata/check2.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -44,7 +44,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"

--- a/pkg/testdata/check3.sarif
+++ b/pkg/testdata/check3.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -40,11 +40,11 @@
                      }
                   },
                   {
-                     "id": "Check-Name2",
-                     "name": "Check-Name2",
+                     "id": "CheckName2ID",
+                     "name": "CheckName2",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name2",
                      "shortDescription": {
-                        "text": "Check-Name2"
+                        "text": "CheckName2"
                      },
                      "fullDescription": {
                         "text": "short description 2"
@@ -68,11 +68,11 @@
                      }
                   },
                   {
-                     "id": "Check-Name3",
-                     "name": "Check-Name3",
+                     "id": "CheckName3ID",
+                     "name": "CheckName3",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name3",
                      "shortDescription": {
-                        "text": "Check-Name3"
+                        "text": "CheckName3"
                      },
                      "fullDescription": {
                         "text": "short description 3"
@@ -101,7 +101,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"
@@ -124,7 +124,7 @@
                ]
             },
             {
-               "ruleId": "Check-Name2",
+               "ruleId": "CheckName2ID",
                "ruleIndex": 1,
                "message": {
                   "text": "warn message"
@@ -150,7 +150,7 @@
                ]
             },
             {
-               "ruleId": "Check-Name3",
+               "ruleId": "CheckName3ID",
                "ruleIndex": 2,
                "message": {
                   "text": "warn message"

--- a/pkg/testdata/check3.sarif
+++ b/pkg/testdata/check3.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -41,10 +41,10 @@
                   },
                   {
                      "id": "CheckName2ID",
-                     "name": "CheckName2",
+                     "name": "Check-Name2",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name2",
                      "shortDescription": {
-                        "text": "CheckName2"
+                        "text": "Check-Name2"
                      },
                      "fullDescription": {
                         "text": "short description 2"
@@ -69,10 +69,10 @@
                   },
                   {
                      "id": "CheckName3ID",
-                     "name": "CheckName3",
+                     "name": "Check-Name3",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name3",
                      "shortDescription": {
-                        "text": "CheckName3"
+                        "text": "Check-Name3"
                      },
                      "fullDescription": {
                         "text": "short description 3"

--- a/pkg/testdata/check4.sarif
+++ b/pkg/testdata/check4.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -40,11 +40,11 @@
                      }
                   },
                   {
-                     "id": "Check-Name2",
-                     "name": "Check-Name2",
+                     "id": "CheckName2ID",
+                     "name": "CheckName2",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name2",
                      "shortDescription": {
-                        "text": "Check-Name2"
+                        "text": "CheckName2"
                      },
                      "fullDescription": {
                         "text": "short description 2"
@@ -68,11 +68,11 @@
                      }
                   },
                   {
-                     "id": "Check-Name3",
-                     "name": "Check-Name3",
+                     "id": "CheckName3ID",
+                     "name": "CheckName3",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name3",
                      "shortDescription": {
-                        "text": "Check-Name3"
+                        "text": "CheckName3"
                      },
                      "fullDescription": {
                         "text": "short description 3"
@@ -101,7 +101,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"
@@ -124,7 +124,7 @@
                ]
             },
             {
-               "ruleId": "Check-Name2",
+               "ruleId": "CheckName2ID",
                "ruleIndex": 1,
                "message": {
                   "text": "warn message"
@@ -150,7 +150,7 @@
                ]
             },
             {
-               "ruleId": "Check-Name3",
+               "ruleId": "CheckName3ID",
                "ruleIndex": 2,
                "message": {
                   "text": "warn message"

--- a/pkg/testdata/check4.sarif
+++ b/pkg/testdata/check4.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -41,10 +41,10 @@
                   },
                   {
                      "id": "CheckName2ID",
-                     "name": "CheckName2",
+                     "name": "Check-Name2",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name2",
                      "shortDescription": {
-                        "text": "CheckName2"
+                        "text": "Check-Name2"
                      },
                      "fullDescription": {
                         "text": "short description 2"
@@ -69,10 +69,10 @@
                   },
                   {
                      "id": "CheckName3ID",
-                     "name": "CheckName3",
+                     "name": "Check-Name3",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name3",
                      "shortDescription": {
-                        "text": "CheckName3"
+                        "text": "Check-Name3"
                      },
                      "fullDescription": {
                         "text": "short description 3"

--- a/pkg/testdata/check5.sarif
+++ b/pkg/testdata/check5.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"

--- a/pkg/testdata/check5.sarif
+++ b/pkg/testdata/check5.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -44,7 +44,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "six score reason"

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"

--- a/pkg/testdata/check7.sarif
+++ b/pkg/testdata/check7.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -40,11 +40,11 @@
                      }
                   },
                   {
-                     "id": "Check-Name2",
-                     "name": "Check-Name2",
+                     "id": "CheckName2ID",
+                     "name": "CheckName2",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name2",
                      "shortDescription": {
-                        "text": "Check-Name2"
+                        "text": "CheckName2"
                      },
                      "fullDescription": {
                         "text": "short description 2"
@@ -68,11 +68,11 @@
                      }
                   },
                   {
-                     "id": "Check-Name3",
-                     "name": "Check-Name3",
+                     "id": "CheckName3ID",
+                     "name": "CheckName3",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name3",
                      "shortDescription": {
-                        "text": "Check-Name3"
+                        "text": "CheckName3"
                      },
                      "fullDescription": {
                         "text": "short description 3"
@@ -101,7 +101,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"

--- a/pkg/testdata/check7.sarif
+++ b/pkg/testdata/check7.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -41,10 +41,10 @@
                   },
                   {
                      "id": "CheckName2ID",
-                     "name": "CheckName2",
+                     "name": "Check-Name2",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name2",
                      "shortDescription": {
-                        "text": "CheckName2"
+                        "text": "Check-Name2"
                      },
                      "fullDescription": {
                         "text": "short description 2"
@@ -69,10 +69,10 @@
                   },
                   {
                      "id": "CheckName3ID",
-                     "name": "CheckName3",
+                     "name": "Check-Name3",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name3",
                      "shortDescription": {
-                        "text": "CheckName3"
+                        "text": "Check-Name3"
                      },
                      "fullDescription": {
                         "text": "short description 3"

--- a/pkg/testdata/check8.sarif
+++ b/pkg/testdata/check8.sarif
@@ -13,11 +13,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name",
-                     "name": "Check-Name",
+                     "id": "CheckNameID",
+                     "name": "CheckName",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "Check-Name"
+                        "text": "CheckName"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -40,11 +40,11 @@
                      }
                   },
                   {
-                     "id": "Check-Name5",
-                     "name": "Check-Name5",
+                     "id": "CheckName5ID",
+                     "name": "CheckName5",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name5",
                      "shortDescription": {
-                        "text": "Check-Name5"
+                        "text": "CheckName5"
                      },
                      "fullDescription": {
                         "text": "short description 5"
@@ -73,7 +73,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"
@@ -99,7 +99,7 @@
                ]
             },
             {
-               "ruleId": "Check-Name",
+               "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"
@@ -125,7 +125,7 @@
                ]
             },
             {
-               "ruleId": "Check-Name5",
+               "ruleId": "CheckName5ID",
                "ruleIndex": 1,
                "message": {
                   "text": "warn message"
@@ -151,7 +151,7 @@
                ]
             },
             {
-               "ruleId": "Check-Name5",
+               "ruleId": "CheckName5ID",
                "ruleIndex": 1,
                "message": {
                   "text": "warn message"
@@ -189,11 +189,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name6",
-                     "name": "Check-Name6",
+                     "id": "CheckName6ID",
+                     "name": "CheckName6",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name6",
                      "shortDescription": {
-                        "text": "Check-Name6"
+                        "text": "CheckName6"
                      },
                      "fullDescription": {
                         "text": "short description 6"
@@ -222,7 +222,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name6",
+               "ruleId": "CheckName6ID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"
@@ -260,11 +260,11 @@
                "semanticVersion": "1.2.3",
                "rules": [
                   {
-                     "id": "Check-Name4",
-                     "name": "Check-Name4",
+                     "id": "CheckName4ID",
+                     "name": "CheckName4",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name4",
                      "shortDescription": {
-                        "text": "Check-Name4"
+                        "text": "CheckName4"
                      },
                      "fullDescription": {
                         "text": "short description 4"
@@ -293,7 +293,7 @@
          },
          "results": [
             {
-               "ruleId": "Check-Name4",
+               "ruleId": "CheckName4ID",
                "ruleIndex": 0,
                "message": {
                   "text": "warn message"

--- a/pkg/testdata/check8.sarif
+++ b/pkg/testdata/check8.sarif
@@ -14,10 +14,10 @@
                "rules": [
                   {
                      "id": "CheckNameID",
-                     "name": "CheckName",
+                     "name": "Check-Name",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name",
                      "shortDescription": {
-                        "text": "CheckName"
+                        "text": "Check-Name"
                      },
                      "fullDescription": {
                         "text": "short description"
@@ -41,10 +41,10 @@
                   },
                   {
                      "id": "CheckName5ID",
-                     "name": "CheckName5",
+                     "name": "Check-Name5",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name5",
                      "shortDescription": {
-                        "text": "CheckName5"
+                        "text": "Check-Name5"
                      },
                      "fullDescription": {
                         "text": "short description 5"
@@ -190,10 +190,10 @@
                "rules": [
                   {
                      "id": "CheckName6ID",
-                     "name": "CheckName6",
+                     "name": "Check-Name6",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name6",
                      "shortDescription": {
-                        "text": "CheckName6"
+                        "text": "Check-Name6"
                      },
                      "fullDescription": {
                         "text": "short description 6"
@@ -261,10 +261,10 @@
                "rules": [
                   {
                      "id": "CheckName4ID",
-                     "name": "CheckName4",
+                     "name": "Check-Name4",
                      "helpUri": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#check-name4",
                      "shortDescription": {
-                        "text": "CheckName4"
+                        "text": "Check-Name4"
                      },
                      "fullDescription": {
                         "text": "short description 4"


### PR DESCRIPTION
This makes a few changes to comply with GH-specific rules:
1. rule ID should be different from rule name
2. rule ID should be pascal case

In addition, I've create a category for the branch protection check, to allow us to run it alone without running other checks - see https://github.com/ossf/scorecard-action/issues/19