### PR TITLE
✨ Adding line numbers for rest of Token-Permissions (and by extension, Packaging)

### DIFF
--- a/checks/packaging.go
+++ b/checks/packaging.go
@@ -17,10 +17,12 @@ package checks
 import (
 	"fmt"
 	"path/filepath"
-	"regexp"
 	"strings"
 
+	"github.com/rhysd/actionlint"
+
 	"github.com/ossf/scorecard/v3/checker"
+	"github.com/ossf/scorecard/v3/checks/fileparser"
 	sce "github.com/ossf/scorecard/v3/errors"
 )
 
@@ -51,7 +53,12 @@ func Packaging(c *checker.CheckRequest) checker.CheckResult {
 			return checker.CreateRuntimeErrorResult(CheckPackaging, e)
 		}
 
-		if !isPackagingWorkflow(string(fc), fp, c.Dlogger) {
+		workflow, errs := actionlint.Parse(fc)
+		if len(errs) > 0 && workflow == nil {
+			e := fileparser.FormatActionlintError(errs)
+			return checker.CreateRuntimeErrorResult(CheckPackaging, e)
+		}
+		if !isPackagingWorkflow(workflow, fp, c.Dlogger) {
 			continue
 		}
 
@@ -87,147 +94,135 @@ func Packaging(c *checker.CheckRequest) checker.CheckResult {
 }
 
 // A packaging workflow.
-func isPackagingWorkflow(s, fp string, dl checker.DetailLogger) bool {
-	// Nodejs packages.
-	if strings.Contains(s, "actions/setup-node@") {
-		r1 := regexp.MustCompile(`(?s)registry-url.*https://registry\.npmjs\.org`)
-		r2 := regexp.MustCompile(`(?s)npm.*publish`)
+func isPackagingWorkflow(workflow *actionlint.Workflow, fp string, dl checker.DetailLogger) bool {
+	jobMatchers := []fileparser.JobMatcher{
+		{
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Uses: "actions/setup-node",
+					With: map[string]string{"registry-url": "https://registry.npmjs.org"},
+				},
+				{
+					Run: "npm.*publish",
+				},
+			},
+			LogText: "candidate node publishing workflow using npm",
+		},
+		{
+			// Java packages with maven.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Uses: "actions/setup-java",
+				},
+				{
+					Run: "mvn.*deploy",
+				},
+			},
+			LogText: "candidate java publishing workflow using maven",
+		},
+		{
+			// Java packages with gradle.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Uses: "actions/setup-java",
+				},
+				{
+					Run: "gradle.*publish",
+				},
+			},
+			LogText: "candidate java publishing workflow using gradle",
+		},
+		{
+			// Ruby packages.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Run: "gem.*push",
+				},
+			},
+			LogText: "candidate ruby publishing workflow using gem",
+		},
+		{
+			// NuGet packages.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Run: "nuget.*push",
+				},
+			},
+			LogText: "candidate nuget publishing workflow",
+		},
+		{
+			// Docker packages.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Run: "docker.*push",
+				},
+			},
+			LogText: "candidate docker publishing workflow",
+		},
+		{
+			// Docker packages.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Uses: "docker/build-push-action",
+				},
+			},
+			LogText: "candidate docker publishing workflow",
+		},
+		{
+			// Python packages.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Uses: "actions/setup-python",
+				},
+				{
+					Uses: "pypa/gh-action-pypi-publish",
+				},
+			},
+			LogText: "candidate python publishing workflow using pypi",
+		},
+		{
+			// Go packages.
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Uses: "actions/setup-go",
+				},
+				{
+					Uses: "goreleaser/goreleaser-action",
+				},
+			},
+			LogText: "candidate golang publishing workflow",
+		},
+		{
+			// Rust packages. https://doc.rust-lang.org/cargo/reference/publishing.html
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Run: "cargo.*publish",
+				},
+			},
+			LogText: "candidate rust publishing workflow using cargo",
+		},
+	}
 
-		if r1.MatchString(s) && r2.MatchString(s) {
+	for _, job := range workflow.Jobs {
+		for _, matcher := range jobMatchers {
+			if !matcher.Matches(job) {
+				continue
+			}
+
 			dl.Info3(&checker.LogMessage{
-				Path: fp,
-				Type: checker.FileTypeSource,
-				// Source file must have line number > 0.
-				Offset: 1,
-				Text:   "candidate node publishing workflow using npm",
+				Path:   fp,
+				Type:   checker.FileTypeSource,
+				Offset: fileparser.GetLineNumber(job.Pos),
+				Text:   matcher.LogText,
 			})
 			return true
 		}
-	}
-
-	// Java packages.
-	if strings.Contains(s, "actions/setup-java@") {
-		// Java packages with maven.
-		r1 := regexp.MustCompile(`(?s)mvn.*deploy`)
-		if r1.MatchString(s) {
-			dl.Info3(&checker.LogMessage{
-				Path: fp,
-				Type: checker.FileTypeSource,
-				// Source file must have line number > 0.
-				Offset: 1,
-				Text:   "candidate java publishing workflow using maven",
-			})
-			return true
-		}
-
-		// Java packages with gradle.
-		r2 := regexp.MustCompile(`(?s)gradle.*publish`)
-		if r2.MatchString(s) {
-			dl.Info3(&checker.LogMessage{
-				Path: fp,
-				Type: checker.FileTypeSource,
-				// Source file must have line number > 0.
-				Offset: 1,
-				Text:   "candidate java publishing workflow using gradle",
-			})
-			return true
-		}
-	}
-
-	// Ruby packages.
-	r := regexp.MustCompile(`(?s)gem.*push`)
-	if r.MatchString(s) {
-		dl.Info3(&checker.LogMessage{
-			Path: fp,
-			Type: checker.FileTypeSource,
-			// Source file must have line number > 0.
-			Offset: 1,
-			Text:   "candidate ruby publishing workflow using gem",
-		})
-		return true
-	}
-
-	// NuGet packages.
-	r = regexp.MustCompile(`(?s)nuget.*push`)
-	if r.MatchString(s) {
-		dl.Info3(&checker.LogMessage{
-			Path: fp,
-			Type: checker.FileTypeSource,
-			// Source file must have line number > 0.
-			Offset: 1,
-			Text:   "candidate nuget publishing workflow",
-		})
-		return true
-	}
-
-	// Docker packages.
-	if strings.Contains(s, "docker/build-push-action@") {
-		dl.Info3(&checker.LogMessage{
-			Path: fp,
-			Type: checker.FileTypeSource,
-			// Source file must have line number > 0.
-			Offset: 1,
-			Text:   "candidate docker publishing workflow",
-		})
-		return true
-	}
-
-	r = regexp.MustCompile(`(?s)docker.*push`)
-	if r.MatchString(s) {
-		dl.Info3(&checker.LogMessage{
-			Path: fp,
-			Type: checker.FileTypeSource,
-			// Source file must have line number > 0.
-			Offset: 1,
-			Text:   "candidate docker publishing workflow",
-		})
-		return true
-	}
-
-	// Python packages.
-	if strings.Contains(s, "actions/setup-python@") && strings.Contains(s, "pypa/gh-action-pypi-publish@master") {
-		dl.Info3(&checker.LogMessage{
-			Path: fp,
-			Type: checker.FileTypeSource,
-			// Source file must have line number > 0.
-			Offset: 1,
-			Text:   "candidate python publishing workflow using pypi",
-		})
-		return true
-	}
-
-	// Go packages.
-	if strings.Contains(s, "actions/setup-go") &&
-		strings.Contains(s, "goreleaser/goreleaser-action@") {
-		dl.Info3(&checker.LogMessage{
-			Path: fp,
-			Type: checker.FileTypeSource,
-			// Source file must have line number > 0.
-			Offset: 1,
-			Text:   "candidate golang publishing workflow",
-		})
-		return true
-	}
-
-	// Rust packages.
-	// https://doc.rust-lang.org/cargo/reference/publishing.html.
-	r = regexp.MustCompile(`(?s)cargo.*publish`)
-	if r.MatchString(s) {
-		dl.Info3(&checker.LogMessage{
-			Path: fp,
-			Type: checker.FileTypeSource,
-			// Source file must have line number > 0.
-			Offset: 1,
-			Text:   "candidate rust publishing workflow using cargo",
-		})
-		return true
 	}
 
 	dl.Debug3(&checker.LogMessage{
-		Path: fp,
-		Type: checker.FileTypeSource,
-		// Source file must have line number > 0.
-		Offset: 1,
+		Path:   fp,
+		Type:   checker.FileTypeSource,
+		Offset: checker.OffsetDefault,
 		Text:   "not a publishing workflow",
 	})
 	return false

--- a/checks/packaging_test.go
+++ b/checks/packaging_test.go
@@ -1,0 +1,110 @@
+// Copyright 2021 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/rhysd/actionlint"
+
+	scut "github.com/ossf/scorecard/v3/utests"
+)
+
+func TestIsPackagingWorkflow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		filename string
+		expected bool
+	}{
+		{
+			name:     "npmjs.org publish",
+			filename: "./testdata/github-workflow-packaging-npm.yaml",
+			expected: true,
+		},
+		{
+			name:     "npm github publish",
+			filename: "./testdata/github-workflow-packaging-npm-github.yaml",
+			expected: false, // Should this be false?
+		},
+		{
+			name:     "maven publish",
+			filename: "./testdata/github-workflow-packaging-maven.yaml",
+			expected: true,
+		},
+		{
+			name:     "gradle publish",
+			filename: "./testdata/github-workflow-packaging-gradle.yaml",
+			expected: true,
+		},
+		{
+			name:     "gem publish",
+			filename: "./testdata/github-workflow-packaging-gem.yaml",
+			expected: true,
+		},
+		{
+			name:     "nuget publish",
+			filename: "./testdata/github-workflow-packaging-nuget.yaml",
+			expected: true,
+		},
+		{
+			name:     "docker action publish",
+			filename: "./testdata/github-workflow-packaging-docker-action.yaml",
+			expected: true,
+		},
+		{
+			name:     "docker push publish",
+			filename: "./testdata/github-workflow-packaging-docker-push.yaml",
+			expected: true,
+		},
+		{
+			name:     "pypi publish",
+			filename: "./testdata/github-workflow-packaging-pypi.yaml",
+			expected: true,
+		},
+		{
+			name:     "go publish",
+			filename: "./testdata/github-workflow-packaging-go.yaml",
+			expected: true,
+		},
+		{
+			name:     "cargo publish",
+			filename: "./testdata/github-workflow-packaging-cargo.yaml",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			content, err := os.ReadFile(tt.filename)
+			if err != nil {
+				panic(fmt.Errorf("cannot read file: %w", err))
+			}
+			workflow, errs := actionlint.Parse(content)
+			if len(errs) > 0 && workflow == nil {
+				panic(fmt.Errorf("cannot parse file: %w", err))
+			}
+			dl := scut.TestDetailLogger{}
+			result := isPackagingWorkflow(workflow, tt.filename, &dl)
+			if result != tt.expected {
+				t.Errorf("isPackagingWorkflow() = %v, expected %v", result, tt.expected)
+			}
+		})
+	}
+}

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -274,6 +274,17 @@ func TestGithubTokenPermissions(t *testing.T) {
 				NumberOfDebug: 4,
 			},
 		},
+		{
+			name:     "security-events write, codeql comment",
+			filename: "./testdata/github-workflow-permissions-run-write-codeql-comment.yaml",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultScore - 1,
+				NumberOfWarn:  1,
+				NumberOfInfo:  1,
+				NumberOfDebug: 4,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below

--- a/checks/testdata/github-workflow-packaging-cargo.yaml
+++ b/checks/testdata/github-workflow-packaging-cargo.yaml
@@ -11,15 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - run: cargo publish

--- a/checks/testdata/github-workflow-packaging-docker-action.yaml
+++ b/checks/testdata/github-workflow-packaging-docker-action.yaml
@@ -11,15 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - uses: docker/build-push-action@v2
+        with:
+          push: true
+          tags: user/app:latest

--- a/checks/testdata/github-workflow-packaging-docker-push.yaml
+++ b/checks/testdata/github-workflow-packaging-docker-push.yaml
@@ -11,15 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - run: docker push myapp/myimage:latest

--- a/checks/testdata/github-workflow-packaging-gem.yaml
+++ b/checks/testdata/github-workflow-packaging-gem.yaml
@@ -11,15 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - run: gem push *.gem

--- a/checks/testdata/github-workflow-packaging-go.yaml
+++ b/checks/testdata/github-workflow-packaging-go.yaml
@@ -11,15 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v2
+        with:
+         go-version: 1.17
+      - uses: goreleaser/goreleaser-action@v2
+        with:
+          distribution: goreleaser
+          version: latest
+          args: release --rm-dist
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/checks/testdata/github-workflow-packaging-gradle.yaml
+++ b/checks/testdata/github-workflow-packaging-gradle.yaml
@@ -11,15 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+      - run: gradle publish

--- a/checks/testdata/github-workflow-packaging-maven.yaml
+++ b/checks/testdata/github-workflow-packaging-maven.yaml
@@ -11,15 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+      - run: mvn deploy

--- a/checks/testdata/github-workflow-packaging-npm-github.yaml
+++ b/checks/testdata/github-workflow-packaging-npm-github.yaml
@@ -11,15 +11,15 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/checks/testdata/github-workflow-packaging-npm.yaml
+++ b/checks/testdata/github-workflow-packaging-npm.yaml
@@ -11,15 +11,24 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14.x'
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm install
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - uses: actions/setup-node@v2
+        with:
+          registry-url: 'https://npm.pkg.github.com'
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+

--- a/checks/testdata/github-workflow-packaging-nuget.yaml
+++ b/checks/testdata/github-workflow-packaging-nuget.yaml
@@ -11,15 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - run: nuget push **\*.nupkg -Source 'https://nuget.pkg.github.com/MyOrg/index.json' -ApiKey ${{secrets.NUGET_TOKEN}}

--- a/checks/testdata/github-workflow-packaging-pypi.yaml
+++ b/checks/testdata/github-workflow-packaging-pypi.yaml
@@ -11,15 +11,16 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: write-and-read workflow
-on: [push]
-permissions: read-all
 
 jobs:
-  Explore-GitHub-Actions:
+  publish:
     runs-on: ubuntu-latest
-    permissions:
-      packages: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v1
+        with:
+          python-version: 3.9
+      - uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          user: __token__
+          password: ${{ secrets.TEST_PYPI_API_TOKEN }}

--- a/checks/testdata/github-workflow-permissions-run-write-codeql-comment.yaml
+++ b/checks/testdata/github-workflow-permissions-run-write-codeql-comment.yaml
@@ -19,7 +19,9 @@ jobs:
   Explore-GitHub-Actions:
     runs-on: ubuntu-latest
     permissions:
-      packages: write
+      security-events: write
     steps:
-      - name: some name
-        uses: docker/build-push-action@1.2.3
+      - name: Perform CodeQL Analysis
+        uses: github/some-action/analyze@v1
+        run: echo "write-and-read workflow"
+        # Some comment about github/codeql-action/analyze@v1


### PR DESCRIPTION
Packaging)

* **Please check if the PR fulfills these requirements**
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature


* **What is the current behavior?** (You can also link to an open issue here)
When the Token-Permission check makes logs for packaging workflow, it does not set the line number. Same thing for the Packaging check.
Closes https://github.com/ossf/scorecard/issues/886


* **What is the new behavior (if this is a feature change)?**
All logs from the Token-Permission and Packaging checks will include line numbers. This PR also makes the check for packaging workflow more precise. Instead of doing a string search for an action name, it will parse the workflow file and check that a `uses` field on a step matches the action name.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No


* **Other information**:
