### PR TITLE
🐛 Fix ko build workflows in Makefile

### DIFF
--- a/.ko.yaml
+++ b/.ko.yaml
@@ -1,9 +1,7 @@
 builds:
 - id: scorecard
-  main: ./
   flags:
     - -tags
     - -netgo
-  dir: ./
   ldflags:
   - "{{.Env.LDFLAGS}}"

--- a/Makefile
+++ b/Makefile
@@ -197,36 +197,43 @@ ko-build-everything: $(ko-targets)
 scorecard-ko:
 	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/scorecard LDFLAGS="$(LDFLAGS)" \
 	ko publish -B \
+			   --push=false \
 			   --platform=$(PLATFORM)\
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3
 cron-controller-ko:
 	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-batch-controller LDFLAGS="$(LDFLAGS)" \
 	ko publish -B \
+			   --push=false \
 			   --platform=$(PLATFORM)\
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/controller
 cron-worker-ko:
 	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-batch-worker LDFLAGS="$(LDFLAGS)" \
 	ko publish -B \
+			   --push=false \
 			   --platform=$(PLATFORM)\
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/worker
 cron-cii-worker-ko:
 	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-cii-worker LDFLAGS="$(LDFLAGS)" \
 	ko publish -B \
+			   --push=false \
 			   --platform=$(PLATFORM)\
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/cii
 cron-bq-transfer-ko:
 	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-bq-transfer LDFLAGS="$(LDFLAGS)" \
 	ko publish -B \
+			   --push=false \
 			   --platform=$(PLATFORM)\
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/bq
 cron-webhook-ko:
 	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-cron-webhook LDFLAGS="$(LDFLAGS)" \
 	ko publish -B \
+			   --push=false \
 			   --platform=$(PLATFORM)\
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/webhook
 cron-github-server-ko:
 	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-github-server LDFLAGS="$(LDFLAGS)" \
 	ko publish -B \
+			   --push=false \
 			   --platform=$(PLATFORM)\
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/clients/githubrepo/roundtripper/tokens/server
 

--- a/Makefile
+++ b/Makefile
@@ -195,46 +195,39 @@ ko-targets = scorecard-ko cron-controller-ko cron-worker-ko cron-cii-worker-ko c
 ko-build-everything: $(ko-targets)
 
 scorecard-ko:
-	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/scorecard CGO_ENABLED=0 LDFLAGS="$(LDFLAGS)" \
-	ko publish -B --bare --local \
+	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/scorecard LDFLAGS="$(LDFLAGS)" \
+	ko publish -B \
 			   --platform=$(PLATFORM)\
-			   --push=false \
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3
 cron-controller-ko:
-	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-batch-controller CGO_ENABLED=0 LDFLAGS="$(LDFLAGS)" \
-	ko publish -B --bare --local \
+	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-batch-controller LDFLAGS="$(LDFLAGS)" \
+	ko publish -B \
 			   --platform=$(PLATFORM)\
-			   --push=false \
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/controller
 cron-worker-ko:
-	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-batch-worker
-	ko publish -B --bare --local \
+	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-batch-worker LDFLAGS="$(LDFLAGS)" \
+	ko publish -B \
 			   --platform=$(PLATFORM)\
-			   --push=false \
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/worker
 cron-cii-worker-ko:
-	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-cii-worker
-	ko publish -B --bare --local \
+	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-cii-worker LDFLAGS="$(LDFLAGS)" \
+	ko publish -B \
 			   --platform=$(PLATFORM)\
-			   --push=false \
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/cii
 cron-bq-transfer-ko:
-	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-bq-transfer
-	ko publish -B --bare --local \
+	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-bq-transfer LDFLAGS="$(LDFLAGS)" \
+	ko publish -B \
 			   --platform=$(PLATFORM)\
-			   --push=false \
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/bq
 cron-webhook-ko:
-	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-cron-webhook
-	ko publish -B --bare --local \
+	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-cron-webhook LDFLAGS="$(LDFLAGS)" \
+	ko publish -B \
 			   --platform=$(PLATFORM)\
-			   --push=false \
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/cron/webhook
 cron-github-server-ko:
-	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-github-server
-	ko publish -B --bare --local \
+	KO_DATA_DATE_EPOCH=$(SOURCE_DATE_EPOCH) KO_DOCKER_REPO=${KO_PREFIX}/$(IMAGE_NAME)-github-server LDFLAGS="$(LDFLAGS)" \
+	ko publish -B \
 			   --platform=$(PLATFORM)\
-			   --push=false \
 			   --tags latest,$(GIT_VERSION),$(GIT_HASH) github.com/ossf/scorecard/v3/clients/githubrepo/roundtripper/tokens/server
 
 docker-targets = scorecard-docker cron-controller-docker cron-worker-docker cron-cii-worker-docker cron-bq-transfer-docker cron-webhook-docker cron-github-server-docker

--- a/cloudbuild/scorecard.yaml
+++ b/cloudbuild/scorecard.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 steps:
-- name: ghcr.io/google/ko
-  env:
-  - KO_PREFIX=gcr.io/${PROJECT_ID}
-  entrypoint: make
-  args:
-  - make ko-build-everything
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '.',
+    '-t', 'gcr.io/openssf/scorecard:latest',
+    '-t', 'gcr.io/openssf/scorecard:$COMMIT_SHA',
+    '-f', 'Dockerfile']
+images: ['gcr.io/openssf/scorecard']

--- a/cloudbuild/scorecard.yaml
+++ b/cloudbuild/scorecard.yaml
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 steps:
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '.',
-    '-t', 'gcr.io/openssf/scorecard:latest',
-    '-t', 'gcr.io/openssf/scorecard:$COMMIT_SHA',
-    '-f', 'Dockerfile']
-images: ['gcr.io/openssf/scorecard']
+- name: ghcr.io/google/ko
+  env:
+  - KO_PREFIX=gcr.io/${PROJECT_ID}
+  entrypoint: make
+  args:
+  - make ko-build-everything


### PR DESCRIPTION
Progress toward https://github.com/ossf/scorecard/issues/1366

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Bugfixes

* **What is the current behavior?** (You can also link to an open issue here)

`make ko-build-everything` fails for me.

* **What is the new behavior (if this is a feature change)?**

`make ko-build-everything` builds images, but does not push them.

Images are built for all binaries, not just `scorecard`, and (if `--push=false` is removed) are pushed to, e.g.:

```
gcr.io/imjasonh/scorecard-github-server/server@sha256:a142bd9ad872d94fc55e3b6b92b24d862f0ebfd044fec1154d1e6872544e0a1a
```

SBOMs are also attached to each platform-specific image:

```
gcr.io/imjasonh/scorecard-github-server/server:sha256-3bf12ae036f73fa4d93f3dd16b5be8ee6f9ba2a8796ada98e1d8c9a545b41304.sbom
```

Binaries inside images are built using Go 1.17 (as it's the base for the `ko` image).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

It's possible, but I doubt it, especially since images aren't pushed in this PR.

* **Other information**:

cc @developer-guy @naveensrinivasan 