### PR TITLE
🐛  Fix score calculation for multiple files

### DIFF
--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -65,6 +65,7 @@ type permissions struct {
 }
 
 type permissionCbData struct {
+	// map of filename to write permissions used.
 	workflows map[string]permissions
 }
 

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -355,25 +355,6 @@ func createResultForLeastPrivilegeTokens(result permissionCbData, err error) che
 		"tokens are read-only in GitHub workflows")
 }
 
-func testValidateGitHubActionTokenPermissions(files []struct {
-	pathfn  string
-	content []byte
-},
-	dl checker.DetailLogger) checker.CheckResult {
-	data := permissionCbData{
-		workflows: make(map[string]permissions),
-	}
-	var err error
-	for _, f := range files {
-		_, err = validateGitHubActionTokenPermissions(f.pathfn, f.content, dl, &data)
-		if err != nil {
-			break
-		}
-	}
-
-	return createResultForLeastPrivilegeTokens(data, err)
-}
-
 // Check file content.
 func validateGitHubActionTokenPermissions(path string, content []byte,
 	dl checker.DetailLogger, data fileparser.FileCbData) (bool, error) {

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -89,7 +89,7 @@ func validatePermission(permissionKey permission, permissionValue *actionlint.Pe
 	val := permissionValue.Value.Value
 	lineNumber := fileparser.GetLineNumber(permissionValue.Value.Pos)
 	if strings.EqualFold(val, "write") {
-		if isPermissionOfInterest(permission(permissionKey), ignoredPermissions) {
+		if isPermissionOfInterest(permissionKey, ignoredPermissions) {
 			dl.Warn3(&checker.LogMessage{
 				Path:   path,
 				Type:   checker.FileTypeSource,

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -355,12 +355,22 @@ func createResultForLeastPrivilegeTokens(result permissionCbData, err error) che
 		"tokens are read-only in GitHub workflows")
 }
 
-func testValidateGitHubActionTokenPermissions(pathfn string,
-	content []byte, dl checker.DetailLogger) checker.CheckResult {
+func testValidateGitHubActionTokenPermissions(files []struct {
+	pathfn  string
+	content []byte
+},
+	dl checker.DetailLogger) checker.CheckResult {
 	data := permissionCbData{
 		workflows: make(map[string]permissions),
 	}
-	_, err := validateGitHubActionTokenPermissions(pathfn, content, dl, &data)
+	var err error
+	for _, f := range files {
+		_, err = validateGitHubActionTokenPermissions(f.pathfn, f.content, dl, &data)
+		if err != nil {
+			break
+		}
+	}
+
 	return createResultForLeastPrivilegeTokens(data, err)
 }
 

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -28,13 +28,13 @@ func TestGithubTokenPermissions(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name     string
-		filename string
-		expected scut.TestReturn
+		name      string
+		filenames []string
+		expected  scut.TestReturn
 	}{
 		{
-			name:     "run workflow codeql write test",
-			filename: "./testdata/github-workflow-permissions-run-codeql-write.yaml",
+			name:      "run workflow codeql write test",
+			filenames: []string{"./testdata/github-workflow-permissions-run-codeql-write.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -44,8 +44,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "run workflow no codeql write test",
-			filename: "./testdata/github-workflow-permissions-run-no-codeql-write.yaml",
+			name:      "run workflow no codeql write test",
+			filenames: []string{"./testdata/github-workflow-permissions-run-no-codeql-write.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 1,
@@ -55,8 +55,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "run workflow write test",
-			filename: "./testdata/github-workflow-permissions-run-writes-2.yaml",
+			name:      "run workflow write test",
+			filenames: []string{"./testdata/github-workflow-permissions-run-writes-2.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
@@ -66,8 +66,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "run package workflow write test",
-			filename: "./testdata/github-workflow-permissions-run-package-workflow-write.yaml",
+			name:      "run package workflow write test",
+			filenames: []string{"./testdata/github-workflow-permissions-run-package-workflow-write.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -77,8 +77,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "run package write test",
-			filename: "./testdata/github-workflow-permissions-run-package-write.yaml",
+			name:      "run package write test",
+			filenames: []string{"./testdata/github-workflow-permissions-run-package-write.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
@@ -88,8 +88,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "run writes test",
-			filename: "./testdata/github-workflow-permissions-run-writes.yaml",
+			name:      "run writes test",
+			filenames: []string{"./testdata/github-workflow-permissions-run-writes.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -99,8 +99,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "write all test",
-			filename: "./testdata/github-workflow-permissions-writeall.yaml",
+			name:      "write all test",
+			filenames: []string{"./testdata/github-workflow-permissions-writeall.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
@@ -110,8 +110,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "read all test",
-			filename: "./testdata/github-workflow-permissions-readall.yaml",
+			name:      "read all test",
+			filenames: []string{"./testdata/github-workflow-permissions-readall.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -121,8 +121,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "no permission test",
-			filename: "./testdata/github-workflow-permissions-absent.yaml",
+			name:      "no permission test",
+			filenames: []string{"./testdata/github-workflow-permissions-absent.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
@@ -132,8 +132,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "writes test",
-			filename: "./testdata/github-workflow-permissions-writes.yaml",
+			name:      "writes test",
+			filenames: []string{"./testdata/github-workflow-permissions-writes.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -143,8 +143,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "reads test",
-			filename: "./testdata/github-workflow-permissions-reads.yaml",
+			name:      "reads test",
+			filenames: []string{"./testdata/github-workflow-permissions-reads.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -154,8 +154,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "nones test",
-			filename: "./testdata/github-workflow-permissions-nones.yaml",
+			name:      "nones test",
+			filenames: []string{"./testdata/github-workflow-permissions-nones.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -165,8 +165,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "none test",
-			filename: "./testdata/github-workflow-permissions-none.yaml",
+			name:      "none test",
+			filenames: []string{"./testdata/github-workflow-permissions-none.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -176,8 +176,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "status/checks write",
-			filename: "./testdata/github-workflow-permissions-status-checks.yaml",
+			name:      "status/checks write",
+			filenames: []string{"./testdata/github-workflow-permissions-status-checks.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 1,
@@ -187,8 +187,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "sec-events/deployments write",
-			filename: "./testdata/github-workflow-permissions-secevent-deployments.yaml",
+			name:      "sec-events/deployments write",
+			filenames: []string{"./testdata/github-workflow-permissions-secevent-deployments.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 2,
@@ -198,8 +198,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "contents write",
-			filename: "./testdata/github-workflow-permissions-contents.yaml",
+			name:      "contents write",
+			filenames: []string{"./testdata/github-workflow-permissions-contents.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
@@ -209,8 +209,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "actions write",
-			filename: "./testdata/github-workflow-permissions-actions.yaml",
+			name:      "actions write",
+			filenames: []string{"./testdata/github-workflow-permissions-actions.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
@@ -220,8 +220,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "packages write",
-			filename: "./testdata/github-workflow-permissions-packages.yaml",
+			name:      "packages write",
+			filenames: []string{"./testdata/github-workflow-permissions-packages.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
@@ -231,8 +231,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "Non-yaml file",
-			filename: "./testdata/script.sh",
+			name:      "Non-yaml file",
+			filenames: []string{"./testdata/script.sh"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -242,8 +242,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "release workflow write",
-			filename: "./testdata/github-workflow-permissions-release-writes.yaml",
+			name:      "release workflow write",
+			filenames: []string{"./testdata/github-workflow-permissions-release-writes.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -253,8 +253,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "package workflow write",
-			filename: "./testdata/github-workflow-permissions-packages-writes.yaml",
+			name:      "package workflow write",
+			filenames: []string{"./testdata/github-workflow-permissions-packages-writes.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore,
@@ -264,8 +264,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "workflow jobs only",
-			filename: "./testdata/github-workflow-permissions-jobs-only.yaml",
+			name:      "workflow jobs only",
+			filenames: []string{"./testdata/github-workflow-permissions-jobs-only.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         9,
@@ -275,8 +275,8 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
-			name:     "security-events write, codeql comment",
-			filename: "./testdata/github-workflow-permissions-run-write-codeql-comment.yaml",
+			name:      "security-events write, codeql comment",
+			filenames: []string{"./testdata/github-workflow-permissions-run-write-codeql-comment.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MaxResultScore - 1,
@@ -285,23 +285,48 @@ func TestGithubTokenPermissions(t *testing.T) {
 				NumberOfDebug: 4,
 			},
 		},
+		{
+			name: "two files mix run-level and top-level",
+			filenames: []string{
+				"./testdata/github-workflow-permissions-top-level-only.yaml",
+				"./testdata/github-workflow-permissions-run-level-only.yaml",
+			},
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultScore - 1,
+				NumberOfWarn:  1,
+				NumberOfInfo:  2,
+				NumberOfDebug: 9,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+			var files []struct {
+				pathfn  string
+				content []byte
+			}
 			var content []byte
 			var err error
-			if tt.filename == "" {
-				content = make([]byte, 0)
-			} else {
-				content, err = os.ReadFile(tt.filename)
-				if err != nil {
-					panic(fmt.Errorf("cannot read file: %w", err))
+			for _, fn := range tt.filenames {
+				if fn == "" {
+					content = make([]byte, 0)
+				} else {
+					content, err = os.ReadFile(fn)
+					if err != nil {
+						panic(fmt.Errorf("cannot read file: %w", err))
+					}
 				}
+				files = append(files, struct {
+					pathfn  string
+					content []byte
+				}{pathfn: fn, content: content})
 			}
+
 			dl := scut.TestDetailLogger{}
-			r := testValidateGitHubActionTokenPermissions(tt.filename, content, &dl)
+			r := testValidateGitHubActionTokenPermissions(files, &dl)
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &r, &dl) {
 				t.Fail()
 			}
@@ -350,7 +375,11 @@ func TestGithubTokenPermissionsLineNumber(t *testing.T) {
 				t.Errorf("cannot read file: %v", err)
 			}
 			dl := scut.TestDetailLogger{}
-			testValidateGitHubActionTokenPermissions(tt.filename, content, &dl)
+			files := []struct {
+				pathfn  string
+				content []byte
+			}{{pathfn: tt.filename, content: content}}
+			testValidateGitHubActionTokenPermissions(files, &dl)
 			for _, expectedLog := range tt.expected {
 				isExpectedLog := func(logMessage checker.LogMessage, logType checker.DetailType) bool {
 					return logMessage.Offset == expectedLog.lineNumber && logMessage.Path == tt.filename &&

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -299,6 +299,34 @@ func TestGithubTokenPermissions(t *testing.T) {
 				NumberOfDebug: 9,
 			},
 		},
+		{
+			name: "two files mix run-level and absent",
+			filenames: []string{
+				"./testdata/github-workflow-permissions-run-level-only.yaml",
+				"./testdata/github-workflow-permissions-absent.yaml",
+			},
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultScore,
+				NumberOfWarn:  2,
+				NumberOfInfo:  1,
+				NumberOfDebug: 9,
+			},
+		},
+		{
+			name: "two files mix top-level and absent",
+			filenames: []string{
+				"./testdata/github-workflow-permissions-top-level-only.yaml",
+				"./testdata/github-workflow-permissions-absent.yaml",
+			},
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultScore,
+				NumberOfWarn:  1,
+				NumberOfInfo:  1,
+				NumberOfDebug: 10,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below

--- a/checks/testdata/github-workflow-permissions-run-level-only.yaml
+++ b/checks/testdata/github-workflow-permissions-run-level-only.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: top-level
+on: [push]
+
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    permissions: read-all
+    steps:
+      - run: echo "write all workflow"

--- a/checks/testdata/github-workflow-permissions-run-level-only.yaml
+++ b/checks/testdata/github-workflow-permissions-run-level-only.yaml
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-name: top-level
+name: run-level
 on: [push]
 
 jobs:

--- a/checks/testdata/github-workflow-permissions-top-level-only.yaml
+++ b/checks/testdata/github-workflow-permissions-top-level-only.yaml
@@ -1,0 +1,22 @@
+# Copyright 2021 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: top-level
+on: [push]
+permissions: read-all
+
+jobs:
+  Explore-GitHub-Actions:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "write all workflow"


### PR DESCRIPTION
Token permission check does not handle multiple files for score calculation, due to the fact that all workflows shared the same permission map. This is because the check used to only look for undefined top-level permissions, globally. Now we've switched to looking for both run-level and top-level permissions. We want to only flag when some files don't declare both of them; or if only the run-level permissions are declared.

closes https://github.com/ossf/scorecard/issues/1400