### PR TITLE
✨ Do not expose sarif and policy command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -147,10 +147,6 @@ func scorecardCmd(cmd *cobra.Command, args []string) {
 		log.Panic("policy not supported yet")
 	}
 
-	if local != "" && !sarifEnabled {
-		log.Panic("--local option not supported yet")
-	}
-
 	var v6 bool
 	_, v6 = os.LookupEnv("SCORECARD_V6")
 	if raw && !v6 {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -75,8 +75,8 @@ const (
 
 	scorecardLong = "A program that shows security scorecard for an open source software."
 	scorecardUse  = `./scorecard [--repo=<repo_url>] [--local=folder] [--checks=check1,...]
-	 [--show-details] [--policy=file] or ./scorecard --{npm,pypi,rubygems}=<package_name> 
-	 [--checks=check1,...] [--show-details] [--policy=file]`
+	 [--show-details] or ./scorecard --{npm,pypi,rubygems}=<package_name> 
+	 [--checks=check1,...] [--show-details]`
 	scorecardShort = "Security Scorecards"
 )
 
@@ -95,8 +95,6 @@ func init() {
 	rootCmd.Flags().StringVar(
 		&rubygems, "rubygems", "",
 		"rubygems package to check, given that the rubygems package has a GitHub repository")
-	rootCmd.Flags().StringVar(&format, "format", formatDefault,
-		"output format. allowed values are [default, sarif, json]")
 	rootCmd.Flags().StringSliceVar(
 		&metaData, "metadata", []string{}, "metadata for the project. It can be multiple separated by commas")
 	rootCmd.Flags().BoolVar(&showDetails, "show-details", false, "show extra details about each check")
@@ -106,7 +104,17 @@ func init() {
 	}
 	rootCmd.Flags().StringSliceVar(&checksToRun, "checks", []string{},
 		fmt.Sprintf("Checks to run. Possible values are: %s", strings.Join(checkNames, ",")))
-	rootCmd.Flags().StringVar(&policyFile, "policy", "", "policy to enforce")
+
+	var sarifEnabled bool
+	_, sarifEnabled = os.LookupEnv("ENABLE_SARIF")
+	if sarifEnabled {
+		rootCmd.Flags().StringVar(&policyFile, "policy", "", "policy to enforce")
+		rootCmd.Flags().StringVar(&format, "format", formatDefault,
+			"output format. allowed values are [default, sarif, json]")
+	} else {
+		rootCmd.Flags().StringVar(&format, "format", formatDefault,
+			"output format. allowed values are [default, json]")
+	}
 
 	var v6 bool
 	_, v6 = os.LookupEnv("SCORECARD_V6")
@@ -126,18 +134,18 @@ func Execute() {
 // nolint: gocognit, gocyclo
 func scorecardCmd(cmd *cobra.Command, args []string) {
 	// UPGRADEv4: remove.
-	var v4 bool
-	_, v4 = os.LookupEnv("SCORECARD_V4")
+	var sarifEnabled bool
+	_, sarifEnabled = os.LookupEnv("ENABLE_SARIF")
 
-	if format == formatSarif && !v4 {
+	if format == formatSarif && !sarifEnabled {
 		log.Panic("sarif not supported yet")
 	}
 
-	if policyFile != "" && !v4 {
+	if policyFile != "" && !sarifEnabled {
 		log.Panic("policy not supported yet")
 	}
 
-	if local != "" && !v4 {
+	if local != "" && !sarifEnabled {
 		log.Panic("--local option not supported yet")
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,10 +112,10 @@ func init() {
 	if sarifEnabled {
 		rootCmd.Flags().StringVar(&policyFile, "policy", "", "policy to enforce")
 		rootCmd.Flags().StringVar(&format, "format", formatDefault,
-			"output format. allowed values are [default, sarif, json]")
+			"output format allowed values are [default, sarif, json]")
 	} else {
 		rootCmd.Flags().StringVar(&format, "format", formatDefault,
-			"output format. allowed values are [default, json]")
+			"output format allowed values are [default, json]")
 	}
 
 	var v6 bool

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,6 +80,8 @@ const (
 	scorecardShort = "Security Scorecards"
 )
 
+const cliEnableSarif = "ENABLE_SARIF"
+
 //nolint:gochecknoinits
 func init() {
 	// Add the zap flag manually
@@ -106,7 +108,7 @@ func init() {
 		fmt.Sprintf("Checks to run. Possible values are: %s", strings.Join(checkNames, ",")))
 
 	var sarifEnabled bool
-	_, sarifEnabled = os.LookupEnv("ENABLE_SARIF")
+	_, sarifEnabled = os.LookupEnv(cliEnableSarif)
 	if sarifEnabled {
 		rootCmd.Flags().StringVar(&policyFile, "policy", "", "policy to enforce")
 		rootCmd.Flags().StringVar(&format, "format", formatDefault,
@@ -135,7 +137,7 @@ func Execute() {
 func scorecardCmd(cmd *cobra.Command, args []string) {
 	// UPGRADEv4: remove.
 	var sarifEnabled bool
-	_, sarifEnabled = os.LookupEnv("ENABLE_SARIF")
+	_, sarifEnabled = os.LookupEnv(cliEnableSarif)
 
 	if format == formatSarif && !sarifEnabled {
 		log.Panic("sarif not supported yet")


### PR DESCRIPTION
In order to simplify maintenance and support, we won't publicly advertise support for sarif and the score-based policy file. 
1. sarif will be used internally for the action. Currently, we run the scorecard CLI; but long-term we may have a dedicated CLI for the action. 
2. The policy file will be replaced by a setting-based policy file once we have finished separating checks from policy score-based policy calculation.