### PR TITLE
✨ Add details to message for default location in SARIF

### DIFF
--- a/checks/evaluation/binary_artifacts.go
+++ b/checks/evaluation/binary_artifacts.go
@@ -36,7 +36,8 @@ func BinaryArtifacts(name string, dl checker.DetailLogger,
 	for _, f := range r.Files {
 		dl.Warn3(&checker.LogMessage{
 			Path: f.Path, Type: checker.FileTypeBinary,
-			Text: "binary detected",
+			Offset: f.Offset,
+			Text:   "binary detected",
 		})
 		// We remove one point for each binary.
 		score--

--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -116,7 +116,7 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 	}
 
 	// Return raw results.
-	return checker.SecurityPolicyData{Files: files}, err
+	return checker.SecurityPolicyData{Files: files}, nil
 }
 
 func isSecurityRstFound(name string) bool {

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -501,6 +501,28 @@ func createCheckIdentifiers(name string) (string, string) {
 	return name, fmt.Sprintf("%sID", n)
 }
 
+func removeDetailType(details []checker.CheckDetail, t checker.DetailType) []checker.CheckDetail {
+	ret := make([]checker.CheckDetail, 0)
+	for i := range details {
+		d := details[i]
+		if d.Type == t {
+			continue
+		}
+		ret = append(ret, d)
+	}
+	return ret
+}
+
+func createDefaultLocationMessage(check *checker.CheckResult) string {
+	details := removeDetailType(check.Details2, checker.DetailInfo)
+	s, b := detailsToString(details, zapcore.WarnLevel)
+	if b {
+		// Warning: GitHub UX needs a single `\n` to turn it into a `<br>`.
+		return fmt.Sprintf("%s:\n%s", check.Reason, s)
+	}
+	return check.Reason
+}
+
 // AsSARIF outputs ScorecardResult in SARIF 2.1.0 format.
 func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 	writer io.Writer, checkDocs docs.Doc, policy *spol.ScorecardPolicy) error {
@@ -576,8 +598,9 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
 			locs = addDefaultLocation(locs, "no file available")
-			// Use the `reason` as message.
-			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, check.Reason, &locs[0])
+			// Use the `reason` as message, and append the detailed to it.
+			msg := createDefaultLocationMessage(&check)
+			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &locs[0])
 			run.Results = append(run.Results, cr)
 		} else {
 			for _, loc := range locs {

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -501,7 +501,7 @@ func createCheckIdentifiers(name string) (string, string) {
 	return name, fmt.Sprintf("%sID", n)
 }
 
-func removeDetailType(details []checker.CheckDetail, t checker.DetailType) []checker.CheckDetail {
+func filterOutDetailType(details []checker.CheckDetail, t checker.DetailType) []checker.CheckDetail {
 	ret := make([]checker.CheckDetail, 0)
 	for i := range details {
 		d := details[i]
@@ -514,7 +514,7 @@ func removeDetailType(details []checker.CheckDetail, t checker.DetailType) []che
 }
 
 func createDefaultLocationMessage(check *checker.CheckResult) string {
-	details := removeDetailType(check.Details2, checker.DetailInfo)
+	details := filterOutDetailType(check.Details2, checker.DetailInfo)
 	s, b := detailsToString(details, zapcore.WarnLevel)
 	if b {
 		// Warning: GitHub UX needs a single `\n` to turn it into a `<br>`.
@@ -598,7 +598,6 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
 			locs = addDefaultLocation(locs, "no file available")
-			// Use the `reason` as message, and append the detailed to it.
 			msg := createDefaultLocationMessage(&check)
 			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &locs[0])
 			run.Results = append(run.Results, cr)

--- a/pkg/sarif_test.go
+++ b/pkg/sarif_test.go
@@ -794,7 +794,7 @@ func TestSARIFOutput(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: AsSARIF: %v", tt.name, err)
 			}
-
+			fmt.Println(string(result.Bytes()))
 			r := bytes.Compare(expected.Bytes(), result.Bytes())
 			if r != 0 {
 				t.Fatalf("%s: invalid result: %d", tt.name, r)

--- a/pkg/sarif_test.go
+++ b/pkg/sarif_test.go
@@ -794,7 +794,7 @@ func TestSARIFOutput(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: AsSARIF: %v", tt.name, err)
 			}
-			fmt.Println(string(result.Bytes()))
+
 			r := bytes.Compare(expected.Bytes(), result.Bytes())
 			if r != 0 {
 				t.Fatalf("%s: invalid result: %d", tt.name, r)

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -47,7 +47,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "six score reason"
+                  "text": "six score reason:\nWarn: warn message"
                },
                "locations": [
                   {


### PR DESCRIPTION
we add details for additional information to SARIF when there is no file path to point to: branch protection, code reviews, etc.
Example, users will see
```
branch protection is not maximal on development and all release branches:
Warn: settings do not apply to administrators on branch 'main'
Warn: no status checks found to merge onto branch 'main'
Warn: number of required reviewers is 0 on branch 'main'
Warn: Stale review dismissal disabled on branch 'main'
```

instead of only:
```
branch protection is not maximal on development and all release branches
```