### PR TITLE
🐛 Use Debug. instead of Info

### DIFF
--- a/checks/packaging.go
+++ b/checks/packaging.go
@@ -77,7 +77,7 @@ func Packaging(c *checker.CheckRequest) checker.CheckResult {
 			return checker.CreateMaxScoreResult(CheckPackaging,
 				"publishing workflow detected")
 		}
-		c.Dlogger.Info3(&checker.LogMessage{
+		c.Dlogger.Debug3(&checker.LogMessage{
 			Path:   fp,
 			Type:   checker.FileTypeSource,
 			Offset: checker.OffsetDefault,

--- a/e2e/packaging_test.go
+++ b/e2e/packaging_test.go
@@ -45,8 +45,8 @@ var _ = Describe("E2E TEST:"+checks.CheckPackaging, func() {
 				Error:         nil,
 				Score:         checker.InconclusiveResultScore,
 				NumberOfWarn:  1,
-				NumberOfInfo:  2,
-				NumberOfDebug: 2,
+				NumberOfInfo:  1,
+				NumberOfDebug: 3,
 			}
 			result := checks.Packaging(&req)
 			Expect(scut.ValidateTestReturn(nil, "use packaging", &expected, &result, &dl)).Should(BeTrue())


### PR DESCRIPTION
Simple fix in the Packaging check.
no breaking changes.