### PR TITLE
🐛 Make enum start at 0

### DIFF
--- a/checker/check_result.go
+++ b/checker/check_result.go
@@ -47,13 +47,21 @@ const (
 	// InconclusiveResultScore is returned when no reliable information can be retrieved by a check.
 	InconclusiveResultScore = -1
 
+	// OffsetDefault is used if we can't determine the offset, for example when referencing a file but not a
+	// specific location in the file.
+	OffsetDefault = 1
+)
+
+const (
 	// DetailInfo is info-level log.
 	DetailInfo DetailType = iota
 	// DetailWarn is warn log.
 	DetailWarn
 	// DetailDebug is debug log.
 	DetailDebug
+)
 
+const (
 	// FileTypeNone is a default, not defined.
 	FileTypeNone FileType = iota
 	// FileTypeSource is for source code files.
@@ -64,10 +72,6 @@ const (
 	FileTypeText
 	// FileTypeURL for URLs.
 	FileTypeURL
-
-	// OffsetDefault is used if we can't determine the offset, for example when referencing a file but not a
-	// specific location in the file.
-	OffsetDefault = 1
 )
 
 // CheckResult captures result from a check run.

--- a/checker/check_result.go
+++ b/checker/check_result.go
@@ -63,6 +63,7 @@ const (
 
 const (
 	// FileTypeNone is a default, not defined.
+	// FileTypeNone must be `0`.
 	FileTypeNone FileType = iota
 	// FileTypeSource is for source code files.
 	FileTypeSource


### PR DESCRIPTION
There's a hidden assumption that LogMessage enums start at 0: this way if none is provided when calling `Warn()`, it defaults to None = 0. This is, for example, needed for FileTypeNone.

This assumption was recently violated thru refactoring. My bad because there was no comment about it :/