### PR TITLE
🐛 Fix a few links in the doc

### DIFF
--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -136,9 +136,8 @@ checks:
       Risk: `High` (vulnerable to intentional malicious code injection)  
       
       This check determines whether a project's default and release branches are
-      protected with GitHub's
-      [branch protection](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches)
-      settings. Branch protection allows maintainers to define rules that enforce
+      protected with GitHub's [branch protection](https://docs.github.com/en/github/administering-a-repository/defining-the-mergeability-of-pull-requests/about-protected-branches) settings. 
+      Branch protection allows maintainers to define rules that enforce
       certain workflows for branches, such as requiring review or passing certain
       status checks before acceptance into a main branch, or preventing rewriting of
       public history.
@@ -160,15 +159,13 @@ checks:
           branches, which overwrites code irrevocably. This protection prevents the
           rewriting of public history without external notice.
 
-        - Require
-          [status checks](https://docs.github.com/en/github/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks):
+        - Require [status checks](https://docs.github.com/en/github/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks):
           ensures that all required CI tests are met before a change is accepted. 
 
       Although requiring code review can greatly reduce the chance that
       unintentional or malicious code enters the "main" branch, it is not feasible for
       all projects, such as those that don't have many active participants. For more
-      discussion, see
-      [Code Reviews](https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-reviews).
+      discussion, see [Code Reviews](https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-reviews).
 
       Additionally, in some cases these rules will need to be suspended. For example,
       if a past commit includes illegal content such as child pornography, it may be
@@ -202,8 +199,7 @@ checks:
         Enable branch protection settings in your source hosting provider to
         avoid force pushes or deletion of your important branches.
       - >-
-        For GitHub, check out the steps
-        [here](https://docs.github.com/en/github/administering-a-repository/managing-a-branch-protection-rule).
+        For GitHub, check out the steps [here](https://docs.github.com/en/github/administering-a-repository/managing-a-branch-protection-rule).
   CI-Tests:
     risk: Low
     tags: supply-chain, testing
@@ -235,8 +231,7 @@ checks:
       - Check-in scripts that run all the tests in your repository.
       - >-
         Integrate those scripts with a CI/CD platform that runs it on every pull
-        request (e.g. if hosted on GitHub, [GitHub
-        Actions](https://docs.github.com/en/actions/learn-github-actions/introduction-to-github-actions),
+        request (e.g. if hosted on GitHub, [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/introduction-to-github-actions),
         [Prow](https://github.com/kubernetes/test-infra/tree/master/prow), etc).
   CII-Best-Practices:
     risk: Low
@@ -246,14 +241,12 @@ checks:
     description: |
       Risk: `Low` (possibly not following security best practices)
 
-      This check determines whether the project has earned a [CII Best Practices
-      Badge](https://bestpractices.coreinfrastructure.org/), which indicates that the
-      project uses a set of security-focused best development practices for open
+      This check determines whether the project has earned a [CII Best Practices Badge](https://bestpractices.coreinfrastructure.org/), 
+      which indicates that the project uses a set of security-focused best development practices for open
       source software. The check uses the URL for the Git repo and the CII API.
 
       The CII Best Practices badge has 3 tiers: passing, silver, and gold. We give
-      full credit to projects that meet the [passing
-      criteria](https://bestpractices.coreinfrastructure.org/criteria/0), which is a
+      full credit to projects that meet the [passing criteria](https://bestpractices.coreinfrastructure.org/criteria/0), which is a
       significant achievement for many projects. Lower scores represent a project that
       is at least working to achieve a badge, with increasingly more points awarded as
       more criteria are met.
@@ -276,8 +269,7 @@ checks:
       Some of these criteria overlap with other Scorecards checks.
     remediation:
       - >-
-        Sign up for the [CII Best Practices
-        program](https://bestpractices.coreinfrastructure.org/en).
+        Sign up for the [CII Best Practices program](https://bestpractices.coreinfrastructure.org/en).
   Code-Review:
     risk: High
     tags: supply-chain, security, source-code, code-reviews
@@ -501,8 +493,7 @@ checks:
         for examples.
       - >-
         To help update your dependencies after pinning them, use tools such as
-         Github's
-        [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)
+         Github's [dependabot](https://github.blog/2020-06-01-keep-all-your-packages-up-to-date-with-dependabot/)
         or [renovate bot](https://github.com/renovatebot/renovate).
   SAST:
     risk: Medium
@@ -513,8 +504,7 @@ checks:
       Risk: `Medium` (possible unknown bugs)
 
       This check tries to determine if the project uses Static Application Security
-      Testing (SAST), also known as
-      [static code analysis](https://owasp.org/www-community/controls/Static_Code_Analysis).
+      Testing (SAST), also known as [static code analysis](https://owasp.org/www-community/controls/Static_Code_Analysis).
       It is currently limited to repositories hosted on GitHub, and does not support
       other source hosting repositories (i.e., Forges).
 
@@ -577,7 +567,7 @@ checks:
       Signed releases attest to the provenance of the artifact.
 
       This check looks for the following filenames in the project's last five
-      releases: [*.minisig ](https://github.com/jedisct1/minisign), *.asc (pgp),
+      releases: [*.minisig](https://github.com/jedisct1/minisign), *.asc (pgp),
       *.sig, *.sign.
 
       Note: The check does not verify the signatures. 


### PR DESCRIPTION
Some links don't render properly in the GitHub scanning dashboard, in particular those that span multiple lines.
This PR fixes it/
no breaking changes