### PR TITLE
✨ Update messages for pinning warning

### DIFF
--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -378,7 +378,7 @@ func isExecuteFiles(startLine, endLine uint, node syntax.Node, cmd, pathfn strin
 				Offset:    startLine,
 				EndOffset: endLine,
 				Snippet:   cmd,
-				Text:      "insecure (not pinned by hash) download detected",
+				Text:      "insecure (not pinned by hash) download-then-run detected",
 			})
 			ok = true
 		}

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -378,7 +378,7 @@ func isExecuteFiles(startLine, endLine uint, node syntax.Node, cmd, pathfn strin
 				Offset:    startLine,
 				EndOffset: endLine,
 				Snippet:   cmd,
-				Text:      "insecure (not pinned by hash) download-then-run detected",
+				Text:      "insecure (not pinned by hash) download-then-run",
 			})
 			ok = true
 		}
@@ -714,7 +714,7 @@ func isFetchProcSubsExecute(startLine, endLine uint, node syntax.Node, cmd, path
 		Offset:    startLine,
 		EndOffset: endLine,
 		Snippet:   cmd,
-		Text:      "insecure (not pinned by hash) download",
+		Text:      "insecure (not pinned by hash) download-then-run",
 	})
 	return true
 }


### PR DESCRIPTION
Update messages for pinning warning `"insecure (not pinned by hash) download"` -> `"insecure (not pinned by hash) download-then-run"`. This is better in cases where the highlighted line only executes a file, and the download is many lines before and not shown to user.
no braking changes