### PR TITLE
✨ Change filename when no file is available

### DIFF
--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -591,7 +591,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
 			// Use an "empty" filename to avoid confusing users.
-			locs = addDefaultLocation(locs, "no file associated with this results")
+			locs = addDefaultLocation(locs, "no file associated with this alert")
 			msg := createDefaultLocationMessage(&check)
 			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &locs[0])
 			run.Results = append(run.Results, cr)

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -590,7 +590,8 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		// so it's the last position for us.
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
-			// Use an "empty" filename to avoid confusing users.
+			// Note: this is not a valid URI but GitHub still accepts it.
+			// See https://sarifweb.azurewebsites.net/Validation to test verification.
 			locs = addDefaultLocation(locs, "no file associated with this alert")
 			msg := createDefaultLocationMessage(&check)
 			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &locs[0])

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -391,7 +391,7 @@ func generateRemediationMarkdown(remediation []string) string {
 func generateMarkdownText(longDesc, risk string, remediation []string) string {
 	rSev := fmt.Sprintf("**Severity**: %s", risk)
 	rDesc := fmt.Sprintf("**Details**:\n%s", longDesc)
-	rRem := fmt.Sprintf("**Remediation**:\n%s", generateRemediationMarkdown(remediation))
+	rRem := fmt.Sprintf("**Remediation (click \"Show more\" below)**:\n%s", generateRemediationMarkdown(remediation))
 	return textToMarkdown(fmt.Sprintf("%s\n\n%s\n\n%s", rRem, rSev, rDesc))
 }
 
@@ -426,7 +426,7 @@ func createSARIFCheckResult(pos int, checkID, message string, loc *location) res
 		// https://github.com/microsoft/sarif-tutorials/blob/main/docs/2-Basics.md#level
 		// Level:     scoreToLevel(minScore, score),
 		RuleIndex: pos,
-		Message:   text{Text: message},
+		Message:   text{Text: fmt.Sprintf("%s\nClick Remediation section below to solve this issue", message)},
 		Locations: []location{*loc},
 	}
 }
@@ -593,7 +593,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
 			// Use an "empty" filename to avoid confusing users.
-			locs = addDefaultLocation(locs, " ")
+			locs = addDefaultLocation(locs, "no file associated with this results")
 			msg := createDefaultLocationMessage(&check)
 			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &locs[0])
 			run.Results = append(run.Results, cr)

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -592,7 +592,8 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel zapcore.Level,
 		// so it's the last position for us.
 		RuleIndex := len(run.Tool.Driver.Rules) - 1
 		if len(locs) == 0 {
-			locs = addDefaultLocation(locs, "no file available")
+			// Use an "empty" filename to avoid confusing users.
+			locs = addDefaultLocation(locs, " ")
 			msg := createDefaultLocationMessage(&check)
 			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &locs[0])
 			run.Results = append(run.Results, cr)

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -62,8 +62,6 @@ type location struct {
 	PhysicalLocation physicalLocation `json:"physicalLocation"`
 	//nolint
 	// This is optional https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#location-object.
-	// We may populate it later if we can indicate which config file
-	// line was violated by the failing check.
 	Message *text `json:"message,omitempty"`
 }
 

--- a/pkg/testdata/check1.sarif
+++ b/pkg/testdata/check1.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -47,7 +47,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {

--- a/pkg/testdata/check2.sarif
+++ b/pkg/testdata/check2.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -47,7 +47,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {

--- a/pkg/testdata/check3.sarif
+++ b/pkg/testdata/check3.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -51,7 +51,7 @@
                      },
                      "help": {
                         "text": "short description 2",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nlong description\n\n other line 2"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nlong description\n\n other line 2"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -79,7 +79,7 @@
                      },
                      "help": {
                         "text": "short description 3",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 3"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 3"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -104,7 +104,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -128,7 +128,7 @@
                "ruleId": "CheckName2ID",
                "ruleIndex": 1,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {

--- a/pkg/testdata/check4.sarif
+++ b/pkg/testdata/check4.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -51,7 +51,7 @@
                      },
                      "help": {
                         "text": "short description 2",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nlong description\n\n other line 2"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nlong description\n\n other line 2"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -79,7 +79,7 @@
                      },
                      "help": {
                         "text": "short description 3",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 3"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 3"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -104,7 +104,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -128,7 +128,7 @@
                "ruleId": "CheckName2ID",
                "ruleIndex": 1,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {

--- a/pkg/testdata/check5.sarif
+++ b/pkg/testdata/check5.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -47,7 +47,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "six score reason:\nWarn: warn message"
+                  "text": "six score reason:\nWarn: warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -56,7 +56,7 @@
                            "startLine": 1
                         },
                         "artifactLocation": {
-                           "uri": " ",
+                           "uri": "no file associated with this results",
                            "uriBaseId": "%SRCROOT%"
                         }
                      }

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -56,7 +56,7 @@
                            "startLine": 1
                         },
                         "artifactLocation": {
-                           "uri": "no file associated with this results",
+                           "uri": "no file associated with this alert",
                            "uriBaseId": "%SRCROOT%"
                         }
                      }

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -56,7 +56,7 @@
                            "startLine": 1
                         },
                         "artifactLocation": {
-                           "uri": "no file available",
+                           "uri": " ",
                            "uriBaseId": "%SRCROOT%"
                         }
                      }

--- a/pkg/testdata/check7.sarif
+++ b/pkg/testdata/check7.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -51,7 +51,7 @@
                      },
                      "help": {
                         "text": "short description 2",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nlong description\n\n other line 2"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Medium\n\n\n\n**Details**:\n\nlong description\n\n other line 2"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -79,7 +79,7 @@
                      },
                      "help": {
                         "text": "short description 3",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 3"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 3"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -104,7 +104,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {

--- a/pkg/testdata/check8.sarif
+++ b/pkg/testdata/check8.sarif
@@ -24,7 +24,7 @@
                      },
                      "help": {
                         "text": "short description",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: High\n\n\n\n**Details**:\n\nlong description\n\n other line"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -51,7 +51,7 @@
                      },
                      "help": {
                         "text": "short description 5",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 5"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 5"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -76,7 +76,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -103,7 +103,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -130,7 +130,7 @@
                "ruleId": "CheckName5ID",
                "ruleIndex": 1,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -157,7 +157,7 @@
                "ruleId": "CheckName5ID",
                "ruleIndex": 1,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -204,7 +204,7 @@
                      },
                      "help": {
                         "text": "short description 6",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 6"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 6"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -229,7 +229,7 @@
                "ruleId": "CheckName6ID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {
@@ -276,7 +276,7 @@
                      },
                      "help": {
                         "text": "short description 4",
-                        "markdown": "**Remediation**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 4"
+                        "markdown": "**Remediation (click \"Show more\" below)**:\n\n- not-used1\n\n- not-used2\n\n\n\n**Severity**: Low\n\n\n\n**Details**:\n\nlong description\n\n other line 4"
                      },
                      "defaultConfiguration": {
                         "level": "error"
@@ -301,7 +301,7 @@
                "ruleId": "CheckName4ID",
                "ruleIndex": 0,
                "message": {
-                  "text": "warn message"
+                  "text": "warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {


### PR DESCRIPTION
We currently display "on file available" when no file in the repo can be pointed to in the SARIF report. We use this, for example, for branch-Protection, Code-Review, Security-Policy. It's been reported to be confusing for users.
This PR changes the filename to be empty as " ". "" is not a valid name, which is why I provide a single space.

List of alerts:

![Screen Shot 2022-01-06 at 1 42 42 PM](https://user-images.githubusercontent.com/64505099/148456354-bc69e44c-e6c6-4391-8cf3-58de35164668.png)

When clicking on the alert, no name is shown as:

![Screen Shot 2022-01-06 at 1 45 24 PM](https://user-images.githubusercontent.com/64505099/148456536-d8c6257b-6fc7-4a25-8692-960ae7b02c01.png)
