### PR TITLE
🐛 Remove inconclusive result from SAST

### DIFF
--- a/checks/sast.go
+++ b/checks/sast.go
@@ -124,12 +124,7 @@ func sastToolInCheckRuns(c *checker.CheckRequest) (int, error) {
 			return checker.InconclusiveResultScore,
 				sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("Client.Checks.ListCheckRunsForRef: %v", err))
 		}
-		if crs == nil {
-			c.Dlogger.Warn3(&checker.LogMessage{
-				Text: "no pull requests merged into dev branch",
-			})
-			return checker.InconclusiveResultScore, nil
-		}
+		// Note: crs may bi `nil`.
 		for _, cr := range crs {
 			if cr.Status != "completed" {
 				continue

--- a/checks/sast.go
+++ b/checks/sast.go
@@ -124,7 +124,8 @@ func sastToolInCheckRuns(c *checker.CheckRequest) (int, error) {
 			return checker.InconclusiveResultScore,
 				sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("Client.Checks.ListCheckRunsForRef: %v", err))
 		}
-		// Note: crs may bi `nil`.
+		// Note: crs may be `nil`: in this case
+		// the loop below will be skipped.
 		for _, cr := range crs {
 			if cr.Status != "completed" {
 				continue


### PR DESCRIPTION
Details contains `no pull requests merged into dev branch` when no check runs are found for a PR. I think this is a mistake.
no breaking changes.