### PR TITLE
✨ Add startLine to sarif for binary files

### DIFF
--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -244,8 +244,10 @@ func detailToRegion(details *checker.CheckDetail) region {
 	case checker.FileTypeBinary:
 		// Offset of 0 is acceptable here.
 		reg = region{
-			// Note: GitHub does not support this.
+			// Note: GitHub does not support ByteOffset, so we also set
+			// StartLine.
 			ByteOffset: &details.Msg.Offset,
+			StartLine:  &details.Msg.Offset,
 		}
 	}
 	return reg

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -236,13 +236,11 @@ func detailToRegion(details *checker.CheckDetail) region {
 			Snippet:   snippet,
 		}
 	case checker.FileTypeText:
-		// Offset of 0 is acceptable here.
 		reg = region{
 			CharOffset: &details.Msg.Offset,
 			Snippet:    snippet,
 		}
 	case checker.FileTypeBinary:
-		// Offset of 0 is acceptable here.
 		reg = region{
 			// Note: GitHub does not support ByteOffset, so we also set
 			// StartLine.

--- a/pkg/testdata/check2.sarif
+++ b/pkg/testdata/check2.sarif
@@ -53,6 +53,7 @@
                   {
                      "physicalLocation": {
                         "region": {
+                           "startLine": 0,
                            "byteOffset": 0
                         },
                         "artifactLocation": {

--- a/pkg/testdata/check3.sarif
+++ b/pkg/testdata/check3.sarif
@@ -110,6 +110,7 @@
                   {
                      "physicalLocation": {
                         "region": {
+                           "startLine": 0,
                            "byteOffset": 0
                         },
                         "artifactLocation": {

--- a/pkg/testdata/check4.sarif
+++ b/pkg/testdata/check4.sarif
@@ -110,6 +110,7 @@
                   {
                      "physicalLocation": {
                         "region": {
+                           "startLine": 0,
                            "byteOffset": 0
                         },
                         "artifactLocation": {

--- a/pkg/testdata/check7.sarif
+++ b/pkg/testdata/check7.sarif
@@ -110,6 +110,7 @@
                   {
                      "physicalLocation": {
                         "region": {
+                           "startLine": 0,
                            "byteOffset": 0
                         },
                         "artifactLocation": {


### PR DESCRIPTION
GitHub does not support `ByteOffset`, and this prevents GitHub from displaying the message to display.
This PR adds `startLine` in this case.
No breaking changes