### PR TITLE
⚠️ log: Initial `logr`/`logrusr` implementation

### DIFF
--- a/checks/binary_artifact_test.go
+++ b/checks/binary_artifact_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/ossf/scorecard/v4/checker"
-	"github.com/ossf/scorecard/v4/clients/githubrepo"
 	"github.com/ossf/scorecard/v4/clients/localdir"
 	"github.com/ossf/scorecard/v4/log"
 	scut "github.com/ossf/scorecard/v4/utests"
@@ -60,10 +59,7 @@ func TestBinaryArtifacts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger, err := githubrepo.NewLogger(log.DebugLevel)
-			if err != nil {
-				t.Errorf("githubrepo.NewLogger: %v", err)
-			}
+			logger := log.NewLogger(log.DebugLevel)
 
 			ctrl := gomock.NewController(t)
 			repo, err := localdir.MakeLocalDirRepo(tt.inputFolder)

--- a/checks/binary_artifact_test.go
+++ b/checks/binary_artifact_test.go
@@ -65,9 +65,6 @@ func TestBinaryArtifacts(t *testing.T) {
 				t.Errorf("githubrepo.NewLogger: %v", err)
 			}
 
-			// nolint
-			defer logger.Zap.Sync()
-
 			ctrl := gomock.NewController(t)
 			repo, err := localdir.MakeLocalDirRepo(tt.inputFolder)
 

--- a/checks/license_test.go
+++ b/checks/license_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/golang/mock/gomock"
 
 	"github.com/ossf/scorecard/v4/checker"
-	"github.com/ossf/scorecard/v4/clients/githubrepo"
 	"github.com/ossf/scorecard/v4/clients/localdir"
 	"github.com/ossf/scorecard/v4/log"
 	scut "github.com/ossf/scorecard/v4/utests"
@@ -142,10 +141,7 @@ func TestLicenseFileSubdirectory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger, err := githubrepo.NewLogger(log.DebugLevel)
-			if err != nil {
-				t.Errorf("githubrepo.NewLogger: %v", err)
-			}
+			logger := log.NewLogger(log.DebugLevel)
 
 			ctrl := gomock.NewController(t)
 			repo, err := localdir.MakeLocalDirRepo(tt.inputFolder)

--- a/checks/license_test.go
+++ b/checks/license_test.go
@@ -147,9 +147,6 @@ func TestLicenseFileSubdirectory(t *testing.T) {
 				t.Errorf("githubrepo.NewLogger: %v", err)
 			}
 
-			// nolint
-			defer logger.Zap.Sync()
-
 			ctrl := gomock.NewController(t)
 			repo, err := localdir.MakeLocalDirRepo(tt.inputFolder)
 

--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -16,7 +16,6 @@ package raw
 
 import (
 	"errors"
-	"fmt"
 	"strings"
 
 	"github.com/ossf/scorecard/v4/checker"
@@ -70,10 +69,7 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 	}
 
 	// https://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file.
-	logger, err := githubrepo.NewLogger(log.InfoLevel)
-	if err != nil {
-		return checker.SecurityPolicyData{}, fmt.Errorf("%w", err)
-	}
+	logger := log.NewLogger(log.InfoLevel)
 	dotGitHub := &checker.CheckRequest{
 		Ctx:        c.Ctx,
 		Dlogger:    c.Dlogger,

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -219,18 +219,6 @@ func CreateGithubRepoClient(ctx context.Context, logger *log.Logger) clients.Rep
 	}
 }
 
-// NewLogger creates an instance of *log.Logger.
-// TODO(log): Consider removing this function, as it only serves to wrap
-//            `log.NewLogger` for convenience.
-func NewLogger(logLevel log.Level) (*log.Logger, error) {
-	logger, err := log.NewLogger(logLevel)
-	if err != nil {
-		return nil, fmt.Errorf("creating GitHub repo client logger: %w", err)
-	}
-
-	return logger, nil
-}
-
 // CreateOssFuzzRepoClient returns a RepoClient implementation
 // intialized to `google/oss-fuzz` GitHub repository.
 func CreateOssFuzzRepoClient(ctx context.Context, logger *log.Logger) (clients.RepoClient, error) {

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -181,7 +181,7 @@ func (client *Client) Close() error {
 // CreateGithubRepoClient returns a Client which implements RepoClient interface.
 func CreateGithubRepoClient(ctx context.Context, logger *log.Logger) clients.RepoClient {
 	// Use our custom roundtripper
-	rt := roundtripper.NewTransport(ctx, logger.Zap.Sugar())
+	rt := roundtripper.NewTransport(ctx, logger)
 	httpClient := &http.Client{
 		Transport: rt,
 	}

--- a/clients/githubrepo/roundtripper/rate_limit.go
+++ b/clients/githubrepo/roundtripper/rate_limit.go
@@ -63,7 +63,7 @@ func (gh *rateLimitTransport) RoundTrip(r *http.Request) (*http.Response, error)
 		// Retry
 		time.Sleep(duration)
 		// TODO(log): Previously Warn. Consider logging an error here.
-		gh.logger.Info(fmt.Sprintf("Rate limit exceeded. Retrying..."))
+		gh.logger.Info("Rate limit exceeded. Retrying...")
 		return gh.RoundTrip(r)
 	}
 

--- a/clients/localdir/client_test.go
+++ b/clients/localdir/client_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 
-	"github.com/ossf/scorecard/v4/clients/githubrepo"
 	"github.com/ossf/scorecard/v4/log"
 )
 
@@ -63,10 +62,7 @@ func TestClient_CreationAndCaching(t *testing.T) {
 			t.Parallel()
 
 			ctx := context.Background()
-			logger, err := githubrepo.NewLogger(log.DebugLevel)
-			if err != nil {
-				t.Errorf("githubrepo.NewLogger: %v", err)
-			}
+			logger := log.NewLogger(log.DebugLevel)
 
 			// Create repo.
 			repo, err := MakeLocalDirRepo(tt.inputFolder)

--- a/clients/localdir/client_test.go
+++ b/clients/localdir/client_test.go
@@ -67,8 +67,6 @@ func TestClient_CreationAndCaching(t *testing.T) {
 			if err != nil {
 				t.Errorf("githubrepo.NewLogger: %v", err)
 			}
-			// nolint
-			defer logger.Zap.Sync() // Flushes buffer, if any.
 
 			// Create repo.
 			repo, err := MakeLocalDirRepo(tt.inputFolder)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -188,11 +188,7 @@ func scorecardCmd(cmd *cobra.Command, args []string) {
 	}
 
 	ctx := context.Background()
-	logger, err := githubrepo.NewLogger(sclog.Level(logLevel))
-	if err != nil {
-		log.Panic(err)
-	}
-
+	logger := sclog.NewLogger(sclog.Level(logLevel))
 	repoURI, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, repoType, err := getRepoAccessors(ctx, uri, logger)
 	if err != nil {
 		log.Panic(err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -192,8 +192,6 @@ func scorecardCmd(cmd *cobra.Command, args []string) {
 	if err != nil {
 		log.Panic(err)
 	}
-	// nolint: errcheck
-	defer logger.Zap.Sync() // Flushes buffer, if any.
 
 	repoURI, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, repoType, err := getRepoAccessors(ctx, uri, logger)
 	if err != nil {

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -17,7 +17,6 @@ package cmd
 import (
 	"fmt"
 	"html/template"
-	"log"
 	"net/http"
 	"os"
 	"strings"
@@ -27,7 +26,7 @@ import (
 	"github.com/ossf/scorecard/v4/checks"
 	"github.com/ossf/scorecard/v4/clients"
 	"github.com/ossf/scorecard/v4/clients/githubrepo"
-	sclog "github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/log"
 	"github.com/ossf/scorecard/v4/pkg"
 )
 
@@ -41,11 +40,7 @@ var serveCmd = &cobra.Command{
 	Short: "Serve the scorecard program over http",
 	Long:  ``,
 	Run: func(cmd *cobra.Command, args []string) {
-		logger, err := githubrepo.NewLogger(sclog.Level(logLevel))
-		if err != nil {
-			// TODO(log): Drop stdlib log
-			log.Fatalf("unable to construct logger: %v", err)
-		}
+		logger := log.NewLogger(log.Level(logLevel))
 
 		t, err := template.New("webpage").Parse(tpl)
 		if err != nil {
@@ -83,7 +78,7 @@ var serveCmd = &cobra.Command{
 			}
 
 			if r.Header.Get("Content-Type") == "application/json" {
-				if err := repoResult.AsJSON(showDetails, sclog.Level(logLevel), rw); err != nil {
+				if err := repoResult.AsJSON(showDetails, log.Level(logLevel), rw); err != nil {
 					// TODO(log): Improve error message
 					logger.Error(err, "")
 					rw.WriteHeader(http.StatusInternalServerError)

--- a/cron/worker/main.go
+++ b/cron/worker/main.go
@@ -187,10 +187,7 @@ func main() {
 		panic(err)
 	}
 
-	logger, err := githubrepo.NewLogger(log.InfoLevel)
-	if err != nil {
-		panic(err)
-	}
+	logger := log.NewLogger(log.InfoLevel)
 	repoClient := githubrepo.CreateGithubRepoClient(ctx, logger)
 	ciiClient := clients.BlobCIIBestPracticesClient(ciiDataBucketURL)
 	ossFuzzRepoClient, err := githubrepo.CreateOssFuzzRepoClient(ctx, logger)

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -21,7 +21,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/ossf/scorecard/v4/clients/githubrepo"
 	"github.com/ossf/scorecard/v4/log"
 )
 
@@ -41,8 +40,7 @@ var _ = BeforeSuite(func() {
 		"GITHUB_AUTH_TOKEN env variable is not set.The GITHUB_AUTH_TOKEN env variable has to be set to run e2e test.")
 	Expect(len(token)).ShouldNot(BeZero(), "Length of the GITHUB_AUTH_TOKEN env variable is zero.")
 
-	l, err := githubrepo.NewLogger(log.InfoLevel)
-	Expect(err).Should(BeNil())
+	l := log.NewLogger(log.InfoLevel)
 	logger = l
 })
 

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,10 @@ require (
 	cloud.google.com/go/pubsub v1.17.0
 	cloud.google.com/go/trace v0.1.0 // indirect
 	contrib.go.opencensus.io/exporter/stackdriver v0.13.8
+	github.com/bombsimon/logrusr/v2 v2.0.1
 	github.com/bradleyfalzon/ghinstallation/v2 v2.0.4
 	github.com/go-git/go-git/v5 v5.4.2
+	github.com/go-logr/logr v1.2.2
 	github.com/golang/mock v1.6.0
 	github.com/google/go-cmp v0.5.7
 	github.com/google/go-containerregistry v0.8.0
@@ -22,6 +24,7 @@ require (
 	github.com/onsi/gomega v1.18.0
 	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a // indirect
+	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f
 	go.opencensus.io v0.23.0
@@ -34,11 +37,10 @@ require (
 	mvdan.cc/sh/v3 v3.4.2
 )
 
+// TODO(go.mod): Is there a reason these deps are kept separately from the
+//               other `require`s?
 require (
-	github.com/bombsimon/logrusr/v2 v2.0.1
-	github.com/go-logr/logr v1.0.0
 	github.com/rhysd/actionlint v1.6.8
-	github.com/sirupsen/logrus v1.8.1
 	gotest.tools v2.2.0+incompatible
 )
 

--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,6 @@ require (
 	github.com/spf13/cobra v1.3.0
 	github.com/xeipuuv/gojsonschema v0.0.0-20180618132009-1d523034197f
 	go.opencensus.io v0.23.0
-	go.uber.org/zap v1.20.0
 	gocloud.dev v0.24.0
 	golang.org/x/tools v0.1.8
 	google.golang.org/genproto v0.0.0-20220111164026-67b88f271998
@@ -36,7 +35,10 @@ require (
 )
 
 require (
+	github.com/bombsimon/logrusr/v2 v2.0.1
+	github.com/go-logr/logr v1.0.0
 	github.com/rhysd/actionlint v1.6.8
+	github.com/sirupsen/logrus v1.8.1
 	gotest.tools v2.2.0+incompatible
 )
 
@@ -86,14 +88,11 @@ require (
 	github.com/rivo/uniseg v0.2.0 // indirect
 	github.com/robfig/cron v1.2.0 // indirect
 	github.com/sergi/go-diff v1.1.0 // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/vbatts/tar-split v0.11.2 // indirect
 	github.com/xanzy/ssh-agent v0.3.0 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
-	go.uber.org/atomic v1.9.0 // indirect
-	go.uber.org/multierr v1.7.0 // indirect
 	golang.org/x/crypto v0.0.0-20210817164053-32db794688a5 // indirect
 	golang.org/x/net v0.0.0-20211216030914-fe4d6282115f // indirect
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8 // indirect

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,13 @@ module github.com/ossf/scorecard/v4
 
 go 1.17
 
+// TODO(go.mod): Is there a reason these deps are kept separately from the
+//               other `require`s?
+require (
+	github.com/rhysd/actionlint v1.6.8
+	gotest.tools v2.2.0+incompatible
+)
+
 require (
 	cloud.google.com/go/bigquery v1.27.0
 	cloud.google.com/go/monitoring v0.1.0 // indirect
@@ -35,13 +42,6 @@ require (
 	gopkg.in/yaml.v2 v2.4.0
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	mvdan.cc/sh/v3 v3.4.2
-)
-
-// TODO(go.mod): Is there a reason these deps are kept separately from the
-//               other `require`s?
-require (
-	github.com/rhysd/actionlint v1.6.8
-	gotest.tools v2.2.0+incompatible
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -283,7 +283,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.7.0/go.mod h1:0qcSMCyASQPN2sk/1KQLQ2
 github.com/aws/smithy-go v1.8.0 h1:AEwwwXQZtUwP5Mz506FeXXrKBe0jA8gVM+1gEcSRooc=
 github.com/aws/smithy-go v1.8.0/go.mod h1:SObp3lf9smib00L/v3U2eAKG8FyQ7iLrJnQiAmR5n+E=
 github.com/aybabtme/rgbterm v0.0.0-20170906152045-cc83f3b3ce59/go.mod h1:q/89r3U2H7sSsE2t6Kca0lfwTK8JdoNGS/yzM/4iH5I=
-github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
 github.com/benbjohnson/clock v1.1.0/go.mod h1:J11/hYXuz8f4ySSvYwY0FKfm+ezbsZBKZxNJlLklBHA=
 github.com/beorn7/perks v0.0.0-20160804104726-4c0e84591b9a/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
@@ -298,6 +297,8 @@ github.com/blang/semver v3.1.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnweb
 github.com/blang/semver v3.5.0+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
+github.com/bombsimon/logrusr/v2 v2.0.1 h1:1VgxVNQMCvjirZIYaT9JYn6sAVGVEcNtRE0y4mvaOAM=
+github.com/bombsimon/logrusr/v2 v2.0.1/go.mod h1:ByVAX+vHdLGAfdroiMg6q0zgq2FODY2lc5YJvzmOJio=
 github.com/bombsimon/wsl/v2 v2.0.0/go.mod h1:mf25kr/SqFEPhhcxW1+7pxzGlW+hIl/hYTKY95VwV8U=
 github.com/bombsimon/wsl/v2 v2.2.0/go.mod h1:Azh8c3XGEJl9LyX0/sFC+CKMc7Ssgua0g+6abzXN4Pg=
 github.com/bombsimon/wsl/v3 v3.0.0/go.mod h1:st10JtZYLE4D5sC7b8xV4zTKZwAQjCH/Hy2Pm1FNZIc=
@@ -584,6 +585,8 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
+github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
+github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=
@@ -1414,21 +1417,15 @@ go.opentelemetry.io/proto/otlp v0.7.0/go.mod h1:PqfVotwruBrMGOCsRd/89rSnXhoiJIqe
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.4.0/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
 go.uber.org/atomic v1.7.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
-go.uber.org/atomic v1.9.0 h1:ECmE8Bn/WFTYwEW/bpKD3M8VtR/zQVbavAoalC1PYyE=
 go.uber.org/atomic v1.9.0/go.mod h1:fEN4uk6kAWBTFdckzkM89CLk9XfWZrxpCo0nPH17wJc=
 go.uber.org/goleak v1.1.10/go.mod h1:8a7PlsEVH3e/a/GLqe5IIrQx6GzcnRmZEufDUTk4A7A=
-go.uber.org/goleak v1.1.11 h1:wy28qYRKZgnJTxGxvye5/wgWr1EKjmUDGYox5mGlRlI=
-go.uber.org/goleak v1.1.11/go.mod h1:cwTWslyiVhfpKIDGSZEM2HlOvcqm+tG4zioyIeLoqMQ=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.6.0/go.mod h1:cdWPpRnG4AhwMwsgIHip0KRBQjJy5kYEpYjJxpXp9iU=
-go.uber.org/multierr v1.7.0 h1:zaiO/rmgFjbmCXdSYJWQcdvOCsthmdaHfr3Gm2Kx4Ec=
 go.uber.org/multierr v1.7.0/go.mod h1:7EAYxJLBy9rStEaz58O2t4Uvip6FSURkq8/ppBp95ak=
 go.uber.org/zap v1.10.0/go.mod h1:vwi/ZaCAaUcBkycHslxD9B2zi4UTXhF60s6SWpuDF0Q=
 go.uber.org/zap v1.17.0/go.mod h1:MXVU+bhUf/A7Xi2HNOnopQOrmycQ5Ih87HtOu4q5SSo=
 go.uber.org/zap v1.18.1/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
 go.uber.org/zap v1.19.0/go.mod h1:xg/QME4nWcxGxrpdeYfq7UvYrLh66cuVKdrbD1XF/NI=
-go.uber.org/zap v1.20.0 h1:N4oPlghZwYG55MlU6LXk/Zp00FVNE9X9wrYO8CEs4lc=
-go.uber.org/zap v1.20.0/go.mod h1:wjWOCqI0f2ZZrJF/UufIOkiC8ii6tm1iqIsLo76RfJw=
 go4.org v0.0.0-20180809161055-417644f6feb5/go.mod h1:MkTOUMDaeVYJUOUsaDXIhWPZYa1yOyC1qaOBpL57BhE=
 gocloud.dev v0.19.0/go.mod h1:SmKwiR8YwIMMJvQBKLsC3fHNyMwXLw3PMDO+VVteJMI=
 gocloud.dev v0.24.0 h1:cNtHD07zQQiv02OiwwDyVMuHmR7iQt2RLkzoAgz7wBs=
@@ -1714,6 +1711,7 @@ golang.org/x/sys v0.0.0-20210503080704-8803ae5d1324/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210608053332-aa57babbf139/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/go.sum
+++ b/go.sum
@@ -585,8 +585,9 @@ github.com/go-logfmt/logfmt v0.3.0/go.mod h1:Qt1PoO58o5twSAckw1HlFXLmHsOX5/0LbT9
 github.com/go-logfmt/logfmt v0.4.0/go.mod h1:3RMwSq7FuexP4Kalkev3ejPJsZTpXXBr9+V4qmtdjCk=
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
-github.com/go-logr/logr v1.0.0 h1:kH951GinvFVaQgy/ki/B3YYmQtRpExGigSJg6O8z5jo=
 github.com/go-logr/logr v1.0.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.2 h1:ahHml/yUpnlb96Rp8HCvtYVPY8ZYpxq3g7UYchIYwbs=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-ole/go-ole v1.2.1/go.mod h1:7FAglXiTm7HKlQRDeOQ6ZNUHidzCWXuZWq/1dTyBNF8=
 github.com/go-openapi/jsonpointer v0.0.0-20160704185906-46af16f9f7b1/go.mod h1:+35s3my2LFTysnkMfxsJBAMHj/DoqoB9knIWoYG/Vk0=
 github.com/go-openapi/jsonpointer v0.19.2/go.mod h1:3akKfEdA7DF1sugOqz1dVQHBcuDBPKZGEoHC/NkiQRg=


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Continues https://github.com/ossf/scorecard/pull/1502.
ref: https://github.com/ossf/scorecard/issues/1273

Signed-off-by: Stephen Augustus <foo@auggie.dev>

* **What is the current behavior?** (You can also link to an open issue here)

https://github.com/ossf/scorecard/pull/1502 implemented a generic logger that wrapped `zap`. Create a new logger is done by calling `log.Logger(log.Level)`.

* **What is the new behavior (if this is a feature change)?**

`log.Logger` now uses `logr`, which provides a sane interface and has multiple popular implementations.

From @thockin in https://github.com/ossf/scorecard/issues/1273#issuecomment-1018822830:

> Stephen pinged me for a consult, so here I am :)
> 
> Opinion: About 1% of apps can actually justify writing logging abstractions, but 90% of us end up doing it because there isn't a (literal or de facto) standard.
> 
> I offer you [http://github.com/go-logr/logr](https://github.com/go-logr/logr) as that standard. logr defines an API, but not an impl. There are many implementations available (including glog, klog, zap, logrus, and zerolog). Your main package can have full knowledge of the impl, set it up as it likes, and then pass it down to the rest of the app.
> 
> EVERYTHING ELSE only needs to know the logr API. The logr package has no external dependencies (and will not grow them, scout's honor), so it is a "safe" thing to depend on. And it's TINY (500 LOC, 3/4 of that is comments). And it has testing implementations and trivial "give me a func() to call" implementations.
> 
> The more of us that use it (klog already uses it internally, for example :) the more inertia we build.
> 
> Writing log wrappers is a nerd-snipe.

While [`zapr`](https://github.com/go-logr/zapr) exists, I opted to choose [`logrusr`](https://github.com/bombsimon/logrusr) as [`logrus`](https://github.com/sirupsen/logrus) just happens to be used by a few more projects in the ecosystem that I'm familiar with (including [Kubernetes Release Engineering logging](https://github.com/kubernetes-sigs/release-utils/blob/main/log/log.go))

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Yes!

  Consumers of functions like:

  ```go
  func CreateGithubRepoClient(ctx context.Context, logger *zap.Logger) clients.RepoClient { ... }
  ```

  will need to use `log.Logger` as an argument:

  ```go
  func CreateGithubRepoClient(ctx context.Context, logger *log.Logger) clients.RepoClient { ... }
  ```

  as well as update log calls from:

  ```go
  ghClient := CreateGithubRepoClient(ctx, logger)
  logger.Info(...)
  ```

  to:

  ```go
  ghClient := CreateGithubRepoClient(ctx, logger)
  logger.Zap.Info(...)
  ```

* **Other information**:
