### PR TITLE
✨ Separate check from policies for the Vulnerabilities check

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -119,9 +119,11 @@ type File struct {
 	// TODO: add hash.
 }
 
+// Vulnerability defines a vulnerability
+// from a database.
 type Vulnerability struct {
 	// For OSV: OSV-2020-484
 	// For CVE: CVE-2022-23945
 	ID string
-	// TODO: additional information
+	// Note:: add fields here if needed.
 }

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -17,10 +17,17 @@ package checker
 // RawResults contains results before a policy
 // is applied.
 type RawResults struct {
+	VulnerabilitiesResults      VulnerabilitiesData
 	BinaryArtifactResults       BinaryArtifactData
 	SecurityPolicyResults       SecurityPolicyData
 	DependencyUpdateToolResults DependencyUpdateToolData
 	BranchProtectionResults     BranchProtectionsData
+}
+
+// VulnerabilitiesData contains the raw results
+// for the Vulnerabilities check.
+type VulnerabilitiesData struct {
+	Vulnerabilities []Vulnerability
 }
 
 // SecurityPolicyData contains the raw results
@@ -110,4 +117,11 @@ type File struct {
 	Offset  uint     // Offset in the file of Path (line for source/text files).
 	Type    FileType // Type of file.
 	// TODO: add hash.
+}
+
+type Vulnerability struct {
+	// For OSV: OSV-2020-484
+	// For CVE: CVE-2022-23945
+	ID string
+	// TODO: additional information
 }

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -125,5 +125,5 @@ type Vulnerability struct {
 	// For OSV: OSV-2020-484
 	// For CVE: CVE-2022-23945
 	ID string
-	// Note:: add fields here if needed.
+	// TODO(vuln): Add additional fields, if needed.
 }

--- a/checks/evaluation/vulnerabilities.go
+++ b/checks/evaluation/vulnerabilities.go
@@ -1,0 +1,53 @@
+// Copyright 2022 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evaluation
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ossf/scorecard/v4/checker"
+	sce "github.com/ossf/scorecard/v4/errors"
+)
+
+// Vulnerabilities applies the score policy for the Vulnerabilities check.
+func Vulnerabilities(name string, dl checker.DetailLogger,
+	r *checker.VulnerabilitiesData) checker.CheckResult {
+	if r == nil {
+		e := sce.WithMessage(sce.ErrScorecardInternal, "empty raw data")
+		return checker.CreateRuntimeErrorResult(name, e)
+	}
+
+	score := checker.MaxResultScore
+	IDs := []string{}
+	for _, vuln := range r.Vulnerabilities {
+		IDs = append(IDs, vuln.ID)
+		score--
+	}
+
+	if score < 0 {
+		score = 0
+	}
+
+	if len(IDs) > 0 {
+		dl.Warn3(&checker.LogMessage{
+			Text: fmt.Sprintf("HEAD is vulnerable to %s", strings.Join(IDs, ", ")),
+		})
+		return checker.CreateResultWithScore(name,
+			fmt.Sprintf("%v existing vulnerabilities detected", len(IDs)), score)
+	}
+
+	return checker.CreateMaxScoreResult(name, "no vulnerabilities detected")
+}

--- a/checks/raw/vulnerabilities.go
+++ b/checks/raw/vulnerabilities.go
@@ -24,16 +24,19 @@ import (
 func Vulnerabilities(c *checker.CheckRequest) (checker.VulnerabilitiesData, error) {
 	commits, err := c.RepoClient.ListCommits()
 	if err != nil {
-		return checker.VulnerabilitiesData{}, sce.WithMessage(sce.ErrScorecardInternal, "Client.Repositories.ListCommits")
+		return checker.VulnerabilitiesData{},
+			sce.WithMessage(sce.ErrScorecardInternal, "Client.Repositories.ListCommits")
 	}
 
 	if len(commits) < 1 || commits[0].SHA == "" {
-		return checker.VulnerabilitiesData{}, sce.WithMessage(sce.ErrScorecardInternal, "no commits found")
+		return checker.VulnerabilitiesData{},
+			sce.WithMessage(sce.ErrScorecardInternal, "no commits found")
 	}
 
 	resp, err := c.VulnerabilitiesClient.HasUnfixedVulnerabilities(c.Ctx, commits[0].SHA)
 	if err != nil {
-		return checker.VulnerabilitiesData{}, sce.WithMessage(sce.ErrScorecardInternal, "VulnerabilitiesClient.HasUnfixedVulnerabilities")
+		return checker.VulnerabilitiesData{},
+			sce.WithMessage(sce.ErrScorecardInternal, "VulnerabilitiesClient.HasUnfixedVulnerabilities")
 	}
 
 	vulnIDs := getVulnerabilities(&resp)

--- a/checks/raw/vulnerabilities.go
+++ b/checks/raw/vulnerabilities.go
@@ -44,7 +44,7 @@ func Vulnerabilities(c *checker.CheckRequest) (checker.VulnerabilitiesData, erro
 	for _, id := range vulnIDs {
 		v := checker.Vulnerability{
 			ID: id,
-			// TODO: add fields.
+			// Note: add fields if needed.
 		}
 		vulns = append(vulns, v)
 	}

--- a/checks/raw/vulnerabilities.go
+++ b/checks/raw/vulnerabilities.go
@@ -1,0 +1,57 @@
+// Copyright 2022 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/clients"
+	sce "github.com/ossf/scorecard/v4/errors"
+)
+
+// Vulnerabilities retrieves the raw data for the Vulnerabilities check.
+func Vulnerabilities(c *checker.CheckRequest) (checker.VulnerabilitiesData, error) {
+	commits, err := c.RepoClient.ListCommits()
+	if err != nil {
+		return checker.VulnerabilitiesData{}, sce.WithMessage(sce.ErrScorecardInternal, "Client.Repositories.ListCommits")
+	}
+
+	if len(commits) < 1 || commits[0].SHA == "" {
+		return checker.VulnerabilitiesData{}, sce.WithMessage(sce.ErrScorecardInternal, "no commits found")
+	}
+
+	resp, err := c.VulnerabilitiesClient.HasUnfixedVulnerabilities(c.Ctx, commits[0].SHA)
+	if err != nil {
+		return checker.VulnerabilitiesData{}, sce.WithMessage(sce.ErrScorecardInternal, "VulnerabilitiesClient.HasUnfixedVulnerabilities")
+	}
+
+	vulnIDs := getVulnerabilities(&resp)
+	vulns := []checker.Vulnerability{}
+	for _, id := range vulnIDs {
+		v := checker.Vulnerability{
+			ID: id,
+			// TODO: add fields.
+		}
+		vulns = append(vulns, v)
+	}
+	return checker.VulnerabilitiesData{Vulnerabilities: vulns}, nil
+}
+
+func getVulnerabilities(resp *clients.VulnerabilitiesResponse) []string {
+	ids := make([]string, 0, len(resp.Vulns))
+	for _, vuln := range resp.Vulns {
+		ids = append(ids, vuln.ID)
+	}
+	return ids
+}

--- a/checks/vulnerabilities.go
+++ b/checks/vulnerabilities.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Security Scorecard Authors
+// Copyright 2022 Security Scorecard Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/checks/vulnerabilities_test.go
+++ b/checks/vulnerabilities_test.go
@@ -66,7 +66,7 @@ func TestVulnerabilities(t *testing.T) {
 				Ctx:                   context.TODO(),
 				VulnerabilitiesClient: mockVulnClient,
 			}
-			res := HasUnfixedVulnerabilities(&req)
+			res := Vulnerabilities(&req)
 			if !tt.isError && res.Error != nil {
 				t.Fail()
 			} else if tt.isError && res.Error == nil {

--- a/e2e/vulnerabilities_test.go
+++ b/e2e/vulnerabilities_test.go
@@ -52,7 +52,7 @@ var _ = Describe("E2E TEST:Vulnerabilities", func() {
 				NumberOfDebug: 0,
 			}
 
-			result := checks.HasUnfixedVulnerabilities(&req)
+			result := checks.Vulnerabilities(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
 			Expect(result.Error).Should(BeNil())
@@ -84,7 +84,7 @@ var _ = Describe("E2E TEST:Vulnerabilities", func() {
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}
-			result := checks.HasUnfixedVulnerabilities(&checkRequest)
+			result := checks.Vulnerabilities(&checkRequest)
 			// UPGRADEv2: to remove.
 			// Old version.
 			Expect(result.Error).Should(BeNil())

--- a/e2e/vulnerabilities_test.go
+++ b/e2e/vulnerabilities_test.go
@@ -79,7 +79,7 @@ var _ = Describe("E2E TEST:Vulnerabilities", func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         checker.MinResultScore,
+				Score:         checker.MaxResultScore - 3, // 3 vulnerabilities remove 3 points.
 				NumberOfWarn:  1,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -65,6 +65,7 @@ type jsonBranchProtection struct {
 }
 
 type jsonRawResults struct {
+	DatabaseVulnerabilities []jsonDatabaseVulnerability `json:"database-vulnerabilities"`
 	// List of binaries found in the repo.
 	Binaries []jsonFile `json:"binaries"`
 	// List of security policy files found in the repo.
@@ -75,6 +76,25 @@ type jsonRawResults struct {
 	DependencyUpdateTools []jsonTool `json:"dependency-update-tools"`
 	// Branch protection settings for development and release branches.
 	BranchProtections []jsonBranchProtection `json:"branch-protections"`
+}
+
+type jsonDatabaseVulnerability struct {
+	// For OSV: OSV-2020-484
+	// For CVE: CVE-2022-23945
+	ID string
+	// TODO: additional information
+}
+
+//nolint:unparam
+func (r *jsonScorecardRawResult) addVulnerbilitiesRawResults(vd *checker.VulnerabilitiesData) error {
+	r.Results.DatabaseVulnerabilities = []jsonDatabaseVulnerability{}
+	for _, v := range vd.Vulnerabilities {
+		r.Results.DatabaseVulnerabilities = append(r.Results.DatabaseVulnerabilities,
+			jsonDatabaseVulnerability{
+				ID: v.ID,
+			})
+	}
+	return nil
 }
 
 //nolint:unparam
@@ -148,6 +168,11 @@ func (r *jsonScorecardRawResult) addBranchProtectionRawResults(bp *checker.Branc
 }
 
 func (r *jsonScorecardRawResult) fillJSONRawResults(raw *checker.RawResults) error {
+	// Vulnerabiliries.
+	if err := r.addVulnerbilitiesRawResults(&raw.VulnerabilitiesResults); err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, err.Error())
+	}
+
 	// Binary-Artifacts.
 	if err := r.addBinaryArtifactRawResults(&raw.BinaryArtifactResults); err != nil {
 		return sce.WithMessage(sce.ErrScorecardInternal, err.Error())


### PR DESCRIPTION
checker/raw_results.go: add structure for results
checks/vulnerabilities.go: rewrite fr policy seperation
checks/raw/vulnerabilities.go: data retrieval 
checks/evaluation/vulnerabilities.go: score calculation
pkg/json_raw_results.go: displays the results.

Refactor the Vulnerabilities check by separating the data retrieval and policy (score) evaluation.
This will allow users to create their own policies based on the raw (more structured) results, see ttps://github.com/ossf/scorecard/issues/1245

No breaking changes.