### PR TITLE
⚠️ Remove ListMergedPRs API

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -14,6 +14,8 @@
 
 package checker
 
+import "time"
+
 // RawResults contains results before a policy
 // is applied.
 type RawResults struct {
@@ -123,12 +125,13 @@ type DefaultBranchCommit struct {
 }
 
 // MergeRequest represents a merge request.
-//nolint:govet
+// nolint:govet
 type MergeRequest struct {
-	Number  int
-	Labels  []string
-	Reviews []Review
-	Author  User
+	Number   int
+	Labels   []string
+	Reviews  []Review
+	Author   User
+	MergedAt time.Time
 }
 
 // Review represent a review using the built-in review system.

--- a/checks/ci_tests.go
+++ b/checks/ci_tests.go
@@ -39,16 +39,18 @@ func init() {
 
 // CITests runs CI-Tests check.
 func CITests(c *checker.CheckRequest) checker.CheckResult {
-	prs, err := c.RepoClient.ListMergedPRs()
+	commits, err := c.RepoClient.ListCommits()
 	if err != nil {
-		e := sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("RepoClient.ListMergedPRs: %v", err))
+		e := sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("RepoClient.ListCommits: %v", err))
 		return checker.CreateRuntimeErrorResult(CheckCITests, e)
 	}
 
 	totalMerged := 0
 	totalTested := 0
-	for index := range prs {
-		pr := &prs[index]
+	for i := range commits {
+		pr := &commits[i].AssociatedMergeRequest
+		// TODO(#575): We ignore associated PRs if Scorecard is being run on a fork
+		// but the PR was created in the original repo.
 		if pr.MergedAt.IsZero() {
 			continue
 		}

--- a/checks/evaluation/code_review.go
+++ b/checks/evaluation/code_review.go
@@ -126,7 +126,7 @@ func getApprovedReviewSystem(c *checker.DefaultBranchCommit, dl checker.DetailLo
 
 func isReviewedOnGitHub(c *checker.DefaultBranchCommit, dl checker.DetailLogger) bool {
 	mr := c.MergeRequest
-	if mr == nil {
+	if mr == nil || mr.MergedAt.IsZero() {
 		return false
 	}
 
@@ -163,7 +163,7 @@ func isReviewedOnProw(c *checker.DefaultBranchCommit, dl checker.DetailLogger) b
 		return true
 	}
 
-	if c.MergeRequest != nil {
+	if c.MergeRequest != nil && !c.MergeRequest.MergedAt.IsZero() {
 		for _, l := range c.MergeRequest.Labels {
 			if l == "lgtm" || l == "approved" {
 				dl.Debug3(&checker.LogMessage{

--- a/checks/maintained.go
+++ b/checks/maintained.go
@@ -59,8 +59,8 @@ func IsMaintained(c *checker.CheckRequest) checker.CheckResult {
 		return checker.CreateRuntimeErrorResult(CheckMaintained, e)
 	}
 	commitsWithinThreshold := 0
-	for _, commit := range commits {
-		if commit.CommittedDate.After(threshold) {
+	for i := range commits {
+		if commits[i].CommittedDate.After(threshold) {
 			commitsWithinThreshold++
 		}
 	}

--- a/checks/sast.go
+++ b/checks/sast.go
@@ -108,16 +108,19 @@ func SAST(c *checker.CheckRequest) checker.CheckResult {
 
 // nolint
 func sastToolInCheckRuns(c *checker.CheckRequest) (int, error) {
-	prs, err := c.RepoClient.ListMergedPRs()
+	commits, err := c.RepoClient.ListCommits()
 	if err != nil {
 		//nolint
 		return checker.InconclusiveResultScore,
-			sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("RepoClient.ListMergedPRs: %v", err))
+			sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("RepoClient.ListCommits: %v", err))
 	}
 
 	totalMerged := 0
 	totalTested := 0
-	for _, pr := range prs {
+	for _, commit := range commits {
+		pr := commit.AssociatedMergeRequest
+		// TODO(#575): We ignore associated PRs if Scorecard is being run on a fork
+		// but the PR was created in the original repo.
 		if pr.MergedAt.IsZero() {
 			continue
 		}

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -30,10 +30,11 @@ import (
 
 func TestSAST(t *testing.T) {
 	t.Parallel()
-	//nolint
+
+	// nolint: govet, goerr113
 	tests := []struct {
 		name          string
-		prs           []clients.PullRequest
+		commits       []clients.Commit
 		err           error
 		searchresult  clients.SearchResponse
 		checkRuns     []clients.CheckRun
@@ -42,23 +43,25 @@ func TestSAST(t *testing.T) {
 	}{
 		{
 			name:         "SAST checker should return failed status when no PRs are found",
-			prs:          []clients.PullRequest{},
+			commits:      []clients.Commit{},
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
 		},
 		{
 			name:         "SAST checker should return failed status when no PRs are found",
 			err:          errors.New("error"),
-			prs:          []clients.PullRequest{},
+			commits:      []clients.Commit{},
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
 			expected:     checker.CheckResult{Score: -1, Pass: false},
 		},
 		{
 			name: "Successful SAST checker should return success status",
-			prs: []clients.PullRequest{
+			commits: []clients.Commit{
 				{
-					MergedAt: time.Now().Add(time.Hour - 1),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 1),
+					},
 				},
 			},
 			searchresult: clients.SearchResponse{},
@@ -78,18 +81,26 @@ func TestSAST(t *testing.T) {
 		},
 		{
 			name: "Failed SAST checker should return success status",
-			prs: []clients.PullRequest{
+			commits: []clients.Commit{
 				{
-					MergedAt: time.Now().Add(time.Hour - 1),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 1),
+					},
 				},
 				{
-					MergedAt: time.Now().Add(time.Hour - 10),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 10),
+					},
 				},
 				{
-					MergedAt: time.Now().Add(time.Hour - 20),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 20),
+					},
 				},
 				{
-					MergedAt: time.Now().Add(time.Hour - 30),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 30),
+					},
 				},
 			},
 			searchresult: clients.SearchResponse{Hits: 1, Results: []clients.SearchResult{{
@@ -110,18 +121,26 @@ func TestSAST(t *testing.T) {
 		},
 		{
 			name: "Failed SAST checker with checkRuns not completed",
-			prs: []clients.PullRequest{
+			commits: []clients.Commit{
 				{
-					MergedAt: time.Now().Add(time.Hour - 1),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 1),
+					},
 				},
 				{
-					MergedAt: time.Now().Add(time.Hour - 10),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 10),
+					},
 				},
 				{
-					MergedAt: time.Now().Add(time.Hour - 20),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 20),
+					},
 				},
 				{
-					MergedAt: time.Now().Add(time.Hour - 30),
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 30),
+					},
 				},
 			},
 			searchresult: clients.SearchResponse{},
@@ -139,9 +158,34 @@ func TestSAST(t *testing.T) {
 		},
 		{
 			name: "Failed SAST with PullRequest not merged",
-			prs: []clients.PullRequest{
+			commits: []clients.Commit{
 				{
-					Number: 1,
+					AssociatedMergeRequest: clients.PullRequest{
+						Number: 1,
+					},
+				},
+			},
+			searchresult: clients.SearchResponse{},
+			checkRuns: []clients.CheckRun{
+				{
+					App: clients.CheckRunApp{
+						Slug: "lgtm-com",
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 0,
+				Pass:  false,
+			},
+		},
+		{
+			name: "Merged PullRequest in a different repo",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now(),
+						Number:   1,
+					},
 				},
 			},
 			searchresult: clients.SearchResponse{},
@@ -167,20 +211,19 @@ func TestSAST(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
-			mockRepo := mockrepo.NewMockRepoClient(ctrl)
-
-			mockRepo.EXPECT().ListMergedPRs().DoAndReturn(func() ([]clients.PullRequest, error) {
+			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+			mockRepoClient.EXPECT().ListCommits().DoAndReturn(func() ([]clients.Commit, error) {
 				if tt.err != nil {
 					return nil, tt.err
 				}
-				return tt.prs, tt.err
+				return tt.commits, tt.err
 			})
-			mockRepo.EXPECT().ListCheckRunsForRef("").Return(tt.checkRuns, nil).AnyTimes()
-			mockRepo.EXPECT().Search(searchRequest).Return(tt.searchresult, nil).AnyTimes()
+			mockRepoClient.EXPECT().ListCheckRunsForRef("").Return(tt.checkRuns, nil).AnyTimes()
+			mockRepoClient.EXPECT().Search(searchRequest).Return(tt.searchresult, nil).AnyTimes()
 
 			dl := scut.TestDetailLogger{}
 			req := checker.CheckRequest{
-				RepoClient: mockRepo,
+				RepoClient: mockRepoClient,
 				Ctx:        context.TODO(),
 				Dlogger:    &dl,
 			}

--- a/clients/commit.go
+++ b/clients/commit.go
@@ -18,8 +18,9 @@ import "time"
 
 // Commit represents a Git commit.
 type Commit struct {
-	CommittedDate time.Time
-	Message       string
-	SHA           string
-	Committer     User
+	CommittedDate          time.Time
+	Message                string
+	SHA                    string
+	Committer              User
+	AssociatedMergeRequest PullRequest
 }

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -113,11 +113,6 @@ func (client *Client) GetFileContent(filename string) ([]byte, error) {
 	return client.tarball.getFileContent(filename)
 }
 
-// ListMergedPRs implements RepoClient.ListMergedPRs.
-func (client *Client) ListMergedPRs() ([]clients.PullRequest, error) {
-	return client.graphClient.getMergedPRs()
-}
-
 // ListCommits implements RepoClient.ListCommits.
 func (client *Client) ListCommits() ([]clients.Commit, error) {
 	return client.graphClient.getCommits()

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -153,11 +153,6 @@ func (client *localDirClient) GetFileContent(filename string) ([]byte, error) {
 	return getFileContent(client.path, filename)
 }
 
-// ListMergedPRs implements RepoClient.ListMergedPRs.
-func (client *localDirClient) ListMergedPRs() ([]clients.PullRequest, error) {
-	return nil, fmt.Errorf("ListMergedPRs: %w", clients.ErrUnsupportedFeature)
-}
-
 // ListBranches implements RepoClient.ListBranches.
 func (client *localDirClient) ListBranches() ([]*clients.BranchRef, error) {
 	return nil, fmt.Errorf("ListBranches: %w", clients.ErrUnsupportedFeature)

--- a/clients/mockclients/repo_client.go
+++ b/clients/mockclients/repo_client.go
@@ -212,21 +212,6 @@ func (mr *MockRepoClientMockRecorder) ListIssues() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListIssues", reflect.TypeOf((*MockRepoClient)(nil).ListIssues))
 }
 
-// ListMergedPRs mocks base method.
-func (m *MockRepoClient) ListMergedPRs() ([]clients.PullRequest, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListMergedPRs")
-	ret0, _ := ret[0].([]clients.PullRequest)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListMergedPRs indicates an expected call of ListMergedPRs.
-func (mr *MockRepoClientMockRecorder) ListMergedPRs() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListMergedPRs", reflect.TypeOf((*MockRepoClient)(nil).ListMergedPRs))
-}
-
 // ListReleases mocks base method.
 func (m *MockRepoClient) ListReleases() ([]clients.Release, error) {
 	m.ctrl.T.Helper()

--- a/clients/pull_request.go
+++ b/clients/pull_request.go
@@ -21,13 +21,12 @@ import (
 // PullRequest struct represents a PR as returned by RepoClient.
 // nolint: govet
 type PullRequest struct {
-	MergedAt    time.Time
-	MergeCommit Commit
-	Number      int
-	HeadSHA     string
-	Labels      []Label
-	Reviews     []Review
-	Author      User
+	Number   int
+	MergedAt time.Time
+	HeadSHA  string
+	Author   User
+	Labels   []Label
+	Reviews  []Review
 }
 
 // Label represents a PR label.

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -27,7 +27,6 @@ type RepoClient interface {
 	IsArchived() (bool, error)
 	ListFiles(predicate func(string) (bool, error)) ([]string, error)
 	GetFileContent(filename string) ([]byte, error)
-	ListMergedPRs() ([]PullRequest, error)
 	ListBranches() ([]*BranchRef, error)
 	GetDefaultBranch() (*BranchRef, error)
 	ListCommits() ([]Commit, error)

--- a/docs/checks/internal/validate/main.go
+++ b/docs/checks/internal/validate/main.go
@@ -40,7 +40,6 @@ var (
 		"IsArchived":                 {"GitHub"},
 		"ListFiles":                  {"GitHub", "local"},
 		"GetFileContent":             {"GitHub", "local"},
-		"ListMergedPRs":              {"GitHub"},
 		"ListBranches":               {"GitHub"},
 		"GetDefaultBranch":           {"GitHub"},
 		"ListCommits":                {"GitHub"},
@@ -67,7 +66,8 @@ func listCheckFiles() (map[string]string, error) {
 	}
 
 	for _, file := range files {
-		if !strings.HasSuffix(file.Name(), ".go") || file.IsDir() {
+		if !strings.HasSuffix(file.Name(), ".go") ||
+			strings.HasSuffix(file.Name(), "_test.go") || file.IsDir() {
 			continue
 		}
 


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Instead of relying on 2 potentially divergent APIs - `ListCommits` and `ListMergedPRs`, reduce the API to only `ListCommits`. Any PRs associated with this commit will be return in the `associatedPR` field. It makes Scorecard more tightly tied to analyzing a repo's commits (part of #575) and helps avoid confusion in future implementations of `RepoClient` (long-term fix of #1524).

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
Yes.