### PR TITLE
Do not parse non-dockerfile

### DIFF
--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -264,12 +264,26 @@ func testValidateDockerfileIsFreeOfInsecureDownloads(pathfn string,
 	return createReturnForIsDockerfileFreeOfInsecureDownloads(r, dl, err)
 }
 
+func isDockerfile(pathfn string, content []byte) bool {
+	if strings.HasSuffix(pathfn, ".go") ||
+		strings.HasSuffix(pathfn, ".c") ||
+		strings.HasSuffix(pathfn, ".cpp") ||
+		strings.HasSuffix(pathfn, ".rs") ||
+		strings.HasSuffix(pathfn, ".js") ||
+		strings.HasSuffix(pathfn, ".py") ||
+		strings.HasSuffix(pathfn, ".java") ||
+		isShellScriptFile(pathfn, content) {
+		return false
+	}
+	return true
+}
+
 func validateDockerfileIsFreeOfInsecureDownloads(pathfn string, content []byte,
 	dl checker.DetailLogger, data fileparser.FileCbData) (bool, error) {
 	pdata := dataAsResultPointer(data)
 
-	// Return early if this is a script, e.g. script_dockerfile_something.sh
-	if isShellScriptFile(pathfn, content) {
+	// Return early if this is not a docker file.
+	if !isDockerfile(pathfn, content) {
 		addPinnedResult(pdata, true)
 		return true, nil
 	}
@@ -347,8 +361,8 @@ func validateDockerfileIsPinned(pathfn string, content []byte,
 	// Dockerfile.aarch64, Dockerfile.template, Dockerfile_template, dockerfile, Dockerfile-name.template
 
 	pdata := dataAsResultPointer(data)
-	// Return early if this is a script, e.g. script_dockerfile_something.sh
-	if isShellScriptFile(pathfn, content) {
+	// Return early if this is not a dockerfile.
+	if !isDockerfile(pathfn, content) {
 		addPinnedResult(pdata, true)
 		return true, nil
 	}

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -271,6 +271,7 @@ func isDockerfile(pathfn string, content []byte) bool {
 		strings.HasSuffix(pathfn, ".rs") ||
 		strings.HasSuffix(pathfn, ".js") ||
 		strings.HasSuffix(pathfn, ".py") ||
+		strings.HasSuffix(pathfn, ".pyc") ||
 		strings.HasSuffix(pathfn, ".java") ||
 		isShellScriptFile(pathfn, content) {
 		return false

--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -473,6 +473,74 @@ func TestDockerfilePinningFromLineNumber(t *testing.T) {
 }
 
 func TestDockerfileInvalidFiles(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		filename string
+		expected bool
+	}{
+		{
+			name:     "dockerfile go",
+			filename: "./testdata/Dockerfile.go",
+			expected: false,
+		},
+		{
+			name:     "dockerfile c",
+			filename: "./testdata/Dockerfile.c",
+			expected: false,
+		},
+		{
+			name:     "dockerfile cpp",
+			filename: "./testdata/Dockerfile.cpp",
+			expected: false,
+		},
+		{
+			name:     "dockerfile rust",
+			filename: "./testdata/Dockerfile.rs",
+			expected: false,
+		},
+		{
+			name:     "dockerfile js",
+			filename: "./testdata/Dockerfile.js",
+			expected: false,
+		},
+		{
+			name:     "dockerfile sh",
+			filename: "./testdata/Dockerfile.sh",
+			expected: false,
+		},
+		{
+			name:     "dockerfile py",
+			filename: "./testdata/Dockerfile.py",
+			expected: false,
+		},
+		{
+			name:     "dockerfile pyc",
+			filename: "./testdata/Dockerfile.pyc",
+			expected: false,
+		},
+		{
+			name:     "dockerfile java",
+			filename: "./testdata/Dockerfile.java",
+			expected: false,
+		},
+		{
+			name:     "dockerfile ",
+			filename: "./testdata/Dockerfile.any",
+			expected: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var c []byte
+			r := isDockerfile(tt.filename, c)
+			if r != tt.expected {
+				t.Errorf("test failed: %s. Expected %v. Got %v", tt.filename, r, tt.expected)
+			}
+		})
+	}
 }
 
 func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {

--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -472,6 +472,9 @@ func TestDockerfilePinningFromLineNumber(t *testing.T) {
 	}
 }
 
+func TestDockerfileInvalidFiles(t *testing.T) {
+}
+
 func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -483,26 +486,26 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 			endLine   uint
 		}
 	}{
-		// {
-		// 	name:     "dockerfile downloads",
-		// 	filename: "./testdata/Dockerfile-download-lines",
-		// 	expected: []struct {
-		// 		snippet   string
-		// 		startLine uint
-		// 		endLine   uint
-		// 	}{
-		// 		{
-		// 			snippet:   "curl bla | bash",
-		// 			startLine: 35,
-		// 			endLine:   36,
-		// 		},
-		// 		{
-		// 			snippet:   "pip install -r requirements.txt",
-		// 			startLine: 41,
-		// 			endLine:   42,
-		// 		},
-		// 	},
-		// },
+		{
+			name:     "dockerfile downloads",
+			filename: "./testdata/Dockerfile-download-lines",
+			expected: []struct {
+				snippet   string
+				startLine uint
+				endLine   uint
+			}{
+				{
+					snippet:   "curl bla | bash",
+					startLine: 35,
+					endLine:   36,
+				},
+				{
+					snippet:   "pip install -r requirements.txt",
+					startLine: 41,
+					endLine:   42,
+				},
+			},
+		},
 		{
 			name:     "dockerfile downloads multi-run",
 			filename: "./testdata/Dockerfile-download-multi-runs",

--- a/checks/sast.go
+++ b/checks/sast.go
@@ -78,8 +78,7 @@ func SAST(c *checker.CheckRequest) checker.CheckResult {
 			const sastWeight = 3
 			const codeQlWeight = 7
 			score := checker.AggregateScoresWithWeight(map[int]int{sastScore: sastWeight, codeQlScore: codeQlWeight})
-			return checker.CreateResultWithScore(CheckSAST,
-				fmt.Sprintf("SAST tool (CodeQL) detected but not run on all commits"), score)
+			return checker.CreateResultWithScore(CheckSAST, "SAST tool detected but not run on all commmits", score)
 		default:
 			return checker.CreateRuntimeErrorResult(CheckSAST, sce.WithMessage(sce.ErrScorecardInternal, "contact team"))
 		}
@@ -88,7 +87,7 @@ func SAST(c *checker.CheckRequest) checker.CheckResult {
 	// Sast inconclusive.
 	if codeQlScore != checker.InconclusiveResultScore {
 		if codeQlScore == checker.MaxResultScore {
-			return checker.CreateMaxScoreResult(CheckSAST, "SAST tool (CodeQL) detected")
+			return checker.CreateMaxScoreResult(CheckSAST, "SAST tool detected")
 		}
 		return checker.CreateMinScoreResult(CheckSAST, "no SAST tool detected")
 	}

--- a/checks/sast.go
+++ b/checks/sast.go
@@ -78,7 +78,8 @@ func SAST(c *checker.CheckRequest) checker.CheckResult {
 			const sastWeight = 3
 			const codeQlWeight = 7
 			score := checker.AggregateScoresWithWeight(map[int]int{sastScore: sastWeight, codeQlScore: codeQlWeight})
-			return checker.CreateResultWithScore(CheckSAST, "SAST tool detected but not run on all commmits", score)
+			return checker.CreateResultWithScore(CheckSAST,
+				fmt.Sprintf("SAST tool (CodeQL) detected but not run on all commits"), score)
 		default:
 			return checker.CreateRuntimeErrorResult(CheckSAST, sce.WithMessage(sce.ErrScorecardInternal, "contact team"))
 		}
@@ -87,7 +88,7 @@ func SAST(c *checker.CheckRequest) checker.CheckResult {
 	// Sast inconclusive.
 	if codeQlScore != checker.InconclusiveResultScore {
 		if codeQlScore == checker.MaxResultScore {
-			return checker.CreateMaxScoreResult(CheckSAST, "SAST tool detected")
+			return checker.CreateMaxScoreResult(CheckSAST, "SAST tool (CodeQL) detected")
 		}
 		return checker.CreateMinScoreResult(CheckSAST, "no SAST tool detected")
 	}


### PR DESCRIPTION
Avoid parsing dockerfiles based on their extension.
No breaking changes.

closes https://github.com/ossf/scorecard/issues/1573