### PR TITLE
:book: remove inaccurate claim about github rendering emoji

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,8 +87,7 @@ Every PR should be annotated with an icon indicating whether it's a:
 Use :ghost: (no release note) only for the PRs that change or revert unreleased
 changes, which don't deserve a release note. Please don't abuse it.
 
-You can also use the equivalent emoji directly, since GitHub doesn't render the
-`:xyz:` aliases in PR titles.
+You are free to use the `:xyz:` aliases or to use the equivalent emoji directly.
 
 Individual commits should not be tagged separately, but will generally be
 assumed to match the PR. For instance, if you have a bugfix in with a breaking


### PR DESCRIPTION
GitHub renders `:xyz:` aliases in PR titles just fine nowadays.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

CONTRIBUTING.md docs update

* **What is the current behavior?** (You can also link to an open issue here)

CONTRIBUTING.md incorrectly claims GitHub doesn't render `:xyz:` aliases in PR titles.

* **What is the new behavior (if this is a feature change)?**

It no longer makes such a claim.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**: