### PR TITLE
✨ Add support for .adoc files for security policies

### DIFF
--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -39,7 +39,10 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 		}
 		if strings.EqualFold(name, "security.md") ||
 			strings.EqualFold(name, ".github/security.md") ||
-			strings.EqualFold(name, "docs/security.md") {
+			strings.EqualFold(name, "docs/security.md") ||
+			strings.EqualFold(name, "security.adoc") ||
+			strings.EqualFold(name, ".github/security.adoc") ||
+			strings.EqualFold(name, "docs/security.adoc") {
 			*pfiles = append(*pfiles, checker.File{
 				Path:   name,
 				Type:   checker.FileTypeSource,
@@ -89,7 +92,10 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 			}
 			if strings.EqualFold(name, "security.md") ||
 				strings.EqualFold(name, ".github/security.md") ||
-				strings.EqualFold(name, "docs/security.md") {
+				strings.EqualFold(name, "docs/security.md") ||
+				strings.EqualFold(name, "security.adoc") ||
+				strings.EqualFold(name, ".github/security.adoc") ||
+				strings.EqualFold(name, "docs/security.adoc") {
 				*pfiles = append(*pfiles, checker.File{
 					Path:   name,
 					Type:   checker.FileTypeURL,

--- a/checks/security_policy_test.go
+++ b/checks/security_policy_test.go
@@ -83,6 +83,36 @@ func TestSecurityPolicy(t *testing.T) {
 				NumberOfInfo: 1,
 			},
 		},
+		{
+			name: "security.adoc",
+			files: []string{
+				"security.adoc",
+			},
+			want: scut.TestReturn{
+				Score:        10,
+				NumberOfInfo: 1,
+			},
+		},
+		{
+			name: ".github/security.adoc",
+			files: []string{
+				".github/security.adoc",
+			},
+			want: scut.TestReturn{
+				Score:        10,
+				NumberOfInfo: 1,
+			},
+		},
+		{
+			name: "docs/security.adoc",
+			files: []string{
+				"docs/security.adoc",
+			},
+			want: scut.TestReturn{
+				Score:        10,
+				NumberOfInfo: 1,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
checks/security_policy_test.go: updated unit tests
checks/raw/security_policy.go: add support for .adoc policies

Add support for .adoc files.

No breaking changes

closes https://github.com/ossf/scorecard/issues/1347