### PR TITLE
✨ Add score to SARIF alerts

### DIFF
--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -510,14 +510,14 @@ func filterOutDetailType(details []checker.CheckDetail, t checker.DetailType) []
 	return ret
 }
 
-func createDefaultLocationMessage(check *checker.CheckResult) string {
+func createDefaultLocationMessage(check *checker.CheckResult, score int) string {
 	details := filterOutDetailType(check.Details2, checker.DetailInfo)
 	s, b := detailsToString(details, log.WarnLevel)
 	if b {
 		// Warning: GitHub UX needs a single `\n` to turn it into a `<br>`.
-		return fmt.Sprintf("%s:\n%s", check.Reason, s)
+		return fmt.Sprintf("score is %d: %s:\n%s", score, check.Reason, s)
 	}
-	return check.Reason
+	return fmt.Sprintf("score is %d: %s", score, check.Reason)
 }
 
 // AsSARIF outputs ScorecardResult in SARIF 2.1.0 format.
@@ -597,7 +597,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 			// Note: this is not a valid URI but GitHub still accepts it.
 			// See https://sarifweb.azurewebsites.net/Validation to test verification.
 			locs = addDefaultLocation(locs, "no file associated with this alert")
-			msg := createDefaultLocationMessage(&check)
+			msg := createDefaultLocationMessage(&check, check.Score)
 			cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &locs[0])
 			run.Results = append(run.Results, cr)
 		} else {

--- a/pkg/testdata/check6.sarif
+++ b/pkg/testdata/check6.sarif
@@ -47,7 +47,7 @@
                "ruleId": "CheckNameID",
                "ruleIndex": 0,
                "message": {
-                  "text": "six score reason:\nWarn: warn message\nClick Remediation section below to solve this issue"
+                  "text": "score is 6: six score reason:\nWarn: warn message\nClick Remediation section below to solve this issue"
                },
                "locations": [
                   {


### PR DESCRIPTION
pkg/testdata/check6.sarif: Update message
pkg/sarif.go: Add score to message

Add score information to message displayed in SARIF alerts if the alert packs multiple settings, such as branch protection.

No breaking changes. 

closes https://github.com/ossf/scorecard/issues/1592
