### PR TITLE
:bug: Fix Dependabot check to accept .yaml file extension

### DIFF
--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -43,7 +43,7 @@ func checkDependencyFileExists(name string, data fileparser.FileCbData) (bool, e
 	}
 
 	switch strings.ToLower(name) {
-	case ".github/dependabot.yml":
+	case ".github/dependabot.yml", ".github/dependabot.yaml":
 		*ptools = append(*ptools, checker.Tool{
 			Name: "Dependabot",
 			URL:  "https://github.com/dependabot",

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -145,6 +145,14 @@ func TestDependencyUpdateTool(t *testing.T) {
 			},
 		},
 		{
+			name:    "dependency update tool",
+			wantErr: false,
+			want:    1,
+			files: []string{
+				".github/dependabot.yaml",
+			},
+		},
+		{
 			name:    "foo bar",
 			wantErr: false,
 			want:    0,


### PR DESCRIPTION
The Dependabot check does not consider `.github/dependabot.yaml` file, however both `.yml` and `.yaml` extensions should be accepted according to the [documentation](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions).

This PR fixes this bug by adding `.github/dependabot.yaml` to the files checked in the dependency update tool check, and provides a test to check for `.github/dependabot.yaml` file.

Closes #1600 