### PR TITLE
🐛 Update scorecard action workflow

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -26,7 +26,6 @@ jobs:
       - name: "Run analysis"
         uses: ossf/scorecard-action@b614d455ee90608b5e36e3299cd50d457eb37d5f
         with:
-          policy_file: .github/scorecard-policy.yml
           results_file: results.sarif
           results_format: sarif
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
We're using an old `policy_file` arguments that's no longer used
no breaking changes