### PR TITLE
✨ Check for secrets in pull_request_target

### DIFF
--- a/checks/dangerous_workflow.go
+++ b/checks/dangerous_workflow.go
@@ -299,7 +299,6 @@ func jobUsesCodeCheckout(job *actionlint.Job) (bool, string) {
 			}
 			return true, ref.Value.Value
 		}
-
 	}
 	return hasCheckout, ""
 }

--- a/checks/dangerous_workflow_test.go
+++ b/checks/dangerous_workflow_test.go
@@ -49,7 +49,7 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			},
@@ -208,6 +208,61 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 				NumberOfDebug: 0,
 			},
 		},
+		{
+			name:     "secret with environment protection pull request target",
+			filename: "./testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-environment-prt.yml",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultConfidence,
+				NumberOfWarn:  1,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+		{
+			name:     "secret in env pull request target",
+			filename: "./testdata/.github/workflows/github-workflow-dangerous-pattern-secret-run-prt.yml",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultConfidence,
+				NumberOfWarn:  2,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+		{
+			name:     "secret in env pull request target",
+			filename: "./testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-prt.yml",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MinResultConfidence,
+				NumberOfWarn:  4,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+		{
+			name:     "secret in top env no checkout pull request target",
+			filename: "./testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-no-checkout-prt.yml",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultConfidence,
+				NumberOfWarn:  0,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
+		{
+			name:     "secret in top env checkout no ref pull request target",
+			filename: "./testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-checkout-noref-prt.yml",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultConfidence,
+				NumberOfWarn:  0,
+				NumberOfInfo:  0,
+				NumberOfDebug: 0,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
@@ -225,7 +280,6 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 			}
 			dl := scut.TestDetailLogger{}
 			p := strings.Replace(tt.filename, "./testdata/", "", 1)
-
 			r := testValidateGitHubActionDangerousWorkflow(p, content, &dl)
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &r, &dl) {
 				t.Fail()

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-checkout-noref-prt.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-checkout-noref-prt.yml
@@ -1,0 +1,52 @@
+name: Close issue on Jira
+
+on:
+  pull_request_target
+
+env:
+  BLA: ${{ secrets.SE00 }}
+
+jobs:
+  test1:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in with toJson
+        uses: some/action@main
+        with:
+          some-args: ${{ toJson(secrets.SE12) }}
+
+      - name: Use in run toJson
+        run: echo "${{ toJson(secrets.SE13) }}"
+  test2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in env toJson
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE21 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in with toJson
+        uses: some/action@v1.2.3
+        with:
+          some-args: ${{ secrets.SE22 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in run toJson
+        run: echo "${{ secrets.SE23 }}"
+  test3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in env toJson
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE31 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in with toJson
+        uses: some/action@v1.2.3
+        with:
+          some-args: ${{ secrets.SE32 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in run toJson
+        run: echo "${{ secrets.SE33 }}"
+      

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-environment-prt.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-environment-prt.yml
@@ -1,0 +1,63 @@
+name: Close issue on Jira
+
+on:
+  pull_request_target
+
+env:
+  BLA: ${{ secrets.SE00 }}
+
+jobs:
+  test1:
+    runs-on: ubuntu-latest
+    environment: protected
+    steps:
+      - name: Use in with toJson
+        uses: some/action@main
+        with:
+          some-args: ${{ toJson(secrets.SE12) }}
+
+      - name: Use in run toJson
+        run: echo "${{ toJson(secrets.SE13) }}"
+      
+      - uses: actions/checkout@v1.2.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+  test2:
+    runs-on: ubuntu-latest
+    environment: protected
+    steps:
+      - name: Use in env toJson
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE21 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in with toJson
+        uses: some/action@v1.2.3
+        with:
+          some-args: ${{ secrets.SE22 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in run toJson
+        run: echo "${{ secrets.SE23 }}"
+
+      - uses: actions/checkout@v1.2.3
+  test3:
+    runs-on: ubuntu-latest
+    environment: protected
+    steps:
+      - name: Use in env toJson
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE31 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in with toJson
+        uses: some/action@v1.2.3
+        with:
+          some-args: ${{ secrets.SE32 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in run toJson
+        run: echo "${{ secrets.SE33 }}"
+
+      - uses: actions/checkout@v1.2.3
+      

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-no-checkout-prt.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-no-checkout-prt.yml
@@ -1,0 +1,52 @@
+name: Close issue on Jira
+
+on:
+  pull_request
+
+env:
+  BLA: ${{ secrets.SE00 }}
+
+jobs:
+  test1:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in with toJson
+        uses: some/action@main
+        with:
+          some-args: ${{ toJson(secrets.SE12) }}
+
+      - name: Use in run toJson
+        run: echo "${{ toJson(secrets.SE13) }}"
+  test2:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in env toJson
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE21 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in with toJson
+        uses: some/action@v1.2.3
+        with:
+          some-args: ${{ secrets.SE22 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in run toJson
+        run: echo "${{ secrets.SE23 }}"
+  test3:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use in env toJson
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE31 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in with toJson
+        uses: some/action@v1.2.3
+        with:
+          some-args: ${{ secrets.SE32 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in run toJson
+        run: echo "${{ secrets.SE33 }}"
+      

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-prt.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-env-prt.yml
@@ -1,0 +1,27 @@
+name: Close issue on Jira
+
+on:
+  pull_request_target
+
+env:
+  BLA: ${{ secrets.SE00 }}
+
+jobs:
+  test1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1.2.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+        name: Use in env toJson
+       
+      - name: Use in with toJson
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE21 }}
+        run: echo "$GITHUB_CONTEXT"
+
+      - name: Use in with toJson
+        uses: some/action@v1.2.3
+        env:
+          GITHUB_CONTEXT: ${{ secrets.SE22 }}
+        run: echo "$GITHUB_CONTEXT"

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-run-prt.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-secret-run-prt.yml
@@ -1,0 +1,14 @@
+name: Close issue on Jira
+
+on:
+  pull_request_target
+
+jobs:
+  test1:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1.2.3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Use in run toJson
+        run: echo "${{ toJson(secrets.SE13) }}"

--- a/e2e/dangerous_workflow_test.go
+++ b/e2e/dangerous_workflow_test.go
@@ -43,7 +43,7 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}
@@ -72,7 +72,7 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}


### PR DESCRIPTION
Check for secrets in pull_request_target in dangerous workflow check.
Today this is handled by the fact that the check looks for pull_request_target. But once https://github.com/ossf/scorecard/issues/1311 is resolved, only cases where permissions are sensitive will be reported.

This PR adds support for checking for secrets regardless of permissions used. Until https://github.com/ossf/scorecard/issues/1311 is resolved, users will see 2 alerts instead of one: one for the secret, and one for the "generic" pull_request_target usage.

closes https://github.com/ossf/scorecard/issues/1633