### PR TITLE
:sparkles: githubrepo: Allow providing an already authenticated transport

### DIFF
--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -177,10 +177,8 @@ func (client *Client) Close() error {
 	return client.tarball.cleanup()
 }
 
-// CreateGithubRepoClient returns a Client which implements RepoClient interface.
-func CreateGithubRepoClient(ctx context.Context, logger *log.Logger) clients.RepoClient {
-	// Use our custom roundtripper
-	rt := roundtripper.NewTransport(ctx, logger)
+// CreateGithubRepoClientWithTransport returns a Client which implements RepoClient interface.
+func CreateGithubRepoClientWithTransport(ctx context.Context, rt http.RoundTripper) clients.RepoClient {
 	httpClient := &http.Client{
 		Transport: rt,
 	}
@@ -216,6 +214,13 @@ func CreateGithubRepoClient(ctx context.Context, logger *log.Logger) clients.Rep
 			ghClient: client,
 		},
 	}
+}
+
+// CreateGithubRepoClient returns a Client which implements RepoClient interface.
+func CreateGithubRepoClient(ctx context.Context, logger *log.Logger) clients.RepoClient {
+	// Use our custom roundtripper
+	rt := roundtripper.NewTransport(ctx, logger)
+	return CreateGithubRepoClientWithTransport(ctx, rt)
 }
 
 // CreateOssFuzzRepoClient returns a RepoClient implementation


### PR DESCRIPTION
Way back in 2.0 the constructor took a github.Client directly, which is what Allstar instantiated to then run scorecard checks. With the current code, there is no way to override the built-in roundtripper.NewTransport which uses its own methods to authenticate.

To allow Allstar to use the current code, we need to create this client and provide a pre-authenticated transport (or http client, or github client).

cc @justaugustus 