### PR TITLE
:seedling: Remove building ko to speed up builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(PROTOC):
 ##@ Build
 ################################## make all ###################################
 all:  ## Runs build, test and verify
-all-targets = build check-linter check-osv unit-test validate-docs add-projects validate-projects ko-build-everything
+all-targets = build check-linter check-osv unit-test validate-docs add-projects validate-projects 
 .PHONY: all all-targets-update-dependencies $(all-targets) update-dependencies tree-status
 all-targets-update-dependencies: $(all-targets) | update-dependencies
 all: update-dependencies all-targets-update-dependencies tree-status


### PR DESCRIPTION

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] PR title follows the guidelines defined in  https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**

    - Remove building ko as we aren't using `ko` yet.
    - Every build of `ko` slows down the build time.
    - When we enable `ko` which will replace `docker` then we can enable `ko` builds


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)



* **Other information**:
