### PR TITLE
:sparkles: Changed some funcs to public for actions

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,14 +121,14 @@ func scorecardCmd(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	policy, err := readPolicy()
+	policy, err := ReadPolicy()
 	if err != nil {
 		log.Panicf("readPolicy: %v", err)
 	}
 
 	ctx := context.Background()
 	logger := sclog.NewLogger(sclog.ParseLevel(flagLogLevel))
-	repoURI, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, err := getRepoAccessors(
+	repoURI, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, err := GetRepoAccessors(
 		ctx, flagRepo, flagLocal, logger)
 	if err != nil {
 		log.Panic(err)
@@ -151,7 +151,7 @@ func scorecardCmd(cmd *cobra.Command, args []string) {
 	if !strings.EqualFold(flagCommit, clients.HeadSHA) {
 		requiredRequestTypes = append(requiredRequestTypes, checker.CommitBased)
 	}
-	enabledChecks, err := getEnabledChecks(policy, flagChecksToRun, requiredRequestTypes)
+	enabledChecks, err := GetEnabledChecks(policy, flagChecksToRun, requiredRequestTypes)
 	if err != nil {
 		log.Panic(err)
 	}
@@ -273,7 +273,8 @@ func validateFormat(format string) bool {
 	}
 }
 
-func readPolicy() (*spol.ScorecardPolicy, error) {
+// ReadPolicy reads the policy file.
+func ReadPolicy() (*spol.ScorecardPolicy, error) {
 	if flagPolicyFile != "" {
 		data, err := os.ReadFile(flagPolicyFile)
 		if err != nil {
@@ -314,7 +315,8 @@ func getAllChecks() checker.CheckNameToFnMap {
 	return possibleChecks
 }
 
-func getEnabledChecks(sp *spol.ScorecardPolicy, argsChecks []string,
+// GetEnabledChecks returns the list of enabled checks.
+func GetEnabledChecks(sp *spol.ScorecardPolicy, argsChecks []string,
 	requiredRequestTypes []checker.RequestType) (checker.CheckNameToFnMap, error) {
 	enabledChecks := checker.CheckNameToFnMap{}
 
@@ -370,7 +372,8 @@ func getEnabledChecks(sp *spol.ScorecardPolicy, argsChecks []string,
 	return enabledChecks, nil
 }
 
-func getRepoAccessors(ctx context.Context, repoURI, localURI string, logger *sclog.Logger) (
+// GetRepoAccessors gets the repository accessors.
+func GetRepoAccessors(ctx context.Context, repoURI, localURI string, logger *sclog.Logger) (
 	clients.Repo, // repo
 	clients.RepoClient, // repoClient
 	clients.RepoClient, // ossFuzzClient


### PR DESCRIPTION

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- Changed some of the funcs to public for this implementing scorecard as a Go API for
https://github.com/ossf/scorecard-action/issues/107. By enabling this
makes it easier for the consumers of the API.

- [ ] Tests for the changes have been added (for bug fixes/features)


#### Which issue(s) this PR fixes

#### Special notes for your reviewer

With this change it will be easier to consume the Scorecard's Go API, especially to run scorecard instead of the Scorecard CLI.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

Changed some of the funcs to public to make it easier to consume the Scorecard Go API.

```
