### PR TITLE
🐛 Add GitHub committer verification

### DIFF
--- a/clients/githubrepo/graphql.go
+++ b/clients/githubrepo/graphql.go
@@ -208,7 +208,7 @@ func commitsFrom(data *graphqlData, repoOwner, repoName string) ([]clients.Commi
 			committer = *commit.Committer.User.Login
 		} else if commit.Committer.Name != nil &&
 			// Username "GitHub" may indicate the commit was committed by GitHub.
-			// We verify the signature on the commit, because the name can be spoofed.
+			// We verify that the commit is signed by GitHub, because the name can be spoofed.
 			*commit.Committer.Name == "GitHub" &&
 			commit.Signature.IsValid &&
 			commit.Signature.WasSignedByGitHub {

--- a/clients/githubrepo/graphql.go
+++ b/clients/githubrepo/graphql.go
@@ -242,12 +242,11 @@ func commitsFrom(data *graphqlData, repoOwner, repoName string) ([]clients.Commi
 				})
 			}
 			for _, review := range pr.Reviews.Nodes {
-				author := clients.User{
-					Login: string(review.Author.Login),
-				}
 				associatedPR.Reviews = append(associatedPR.Reviews, clients.Review{
-					State:  string(review.State),
-					Author: &author,
+					State: string(review.State),
+					Author: &clients.User{
+						Login: string(review.Author.Login),
+					},
 				})
 			}
 			break

--- a/clients/githubrepo/graphql.go
+++ b/clients/githubrepo/graphql.go
@@ -198,7 +198,6 @@ func (handler *graphqlHandler) isArchived() (bool, error) {
 	return handler.archived, nil
 }
 
-// nolint: unparam
 func commitsFrom(data *graphqlData, repoOwner, repoName string) ([]clients.Commit, error) {
 	ret := make([]clients.Commit, 0)
 	for _, commit := range data.Repository.Object.Commit.History.Nodes {


### PR DESCRIPTION
PR verifies the commit's signature when the committer's name is "GitHub" and the committer's login for a merged PR is `""`.
See https://github.com/ossf/scorecard/issues/1543 for more details

In addition, it fixes reviewer names that were not populated( I caught this problem when using `--format raw`)

closes https://github.com/ossf/scorecard/issues/1543

```release-notes
Verify merged commits by GitHub are genuine
```