### PR TITLE
✨ cmd: Allow new scorecard to be instantiated with options

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -27,17 +27,18 @@ import (
 	"github.com/ossf/scorecard/v4/clients"
 	"github.com/ossf/scorecard/v4/clients/githubrepo"
 	"github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/options"
 	"github.com/ossf/scorecard/v4/pkg"
 )
 
 // TODO(cmd): Determine if this should be exported.
-func serveCmd() *cobra.Command {
+func serveCmd(o *options.Options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "serve",
 		Short: "Serve the scorecard program over http",
 		Long:  ``,
 		Run: func(cmd *cobra.Command, args []string) {
-			logger := log.NewLogger(log.ParseLevel(opts.LogLevel))
+			logger := log.NewLogger(log.ParseLevel(o.LogLevel))
 
 			t, err := template.New("webpage").Parse(tpl)
 			if err != nil {
@@ -76,7 +77,7 @@ func serveCmd() *cobra.Command {
 				}
 
 				if r.Header.Get("Content-Type") == "application/json" {
-					if err := repoResult.AsJSON(opts.ShowDetails, log.ParseLevel(opts.LogLevel), rw); err != nil {
+					if err := repoResult.AsJSON(o.ShowDetails, log.ParseLevel(o.LogLevel), rw); err != nil {
 						// TODO(log): Improve error message
 						logger.Error(err, "")
 						rw.WriteHeader(http.StatusInternalServerError)

--- a/main.go
+++ b/main.go
@@ -19,10 +19,12 @@ import (
 	"log"
 
 	"github.com/ossf/scorecard/v4/cmd"
+	"github.com/ossf/scorecard/v4/options"
 )
 
 func main() {
-	if err := cmd.New().Execute(); err != nil {
+	opts := options.New()
+	if err := cmd.New(opts).Execute(); err != nil {
 		log.Fatalf("error during command execution: %v", err)
 	}
 }

--- a/options/flags.go
+++ b/options/flags.go
@@ -23,6 +23,44 @@ import (
 	"github.com/ossf/scorecard/v4/checks"
 )
 
+const (
+	// FlagRepo is the flag name for specifying a repository.
+	FlagRepo = "repo"
+
+	// FlagLocal is the flag name for specifying a local run.
+	FlagLocal = "local"
+
+	// FlagCommit is the flag name for specifying a commit.
+	FlagCommit = "commit"
+
+	// FlagLogLevel is the flag name for specifying the log level.
+	FlagLogLevel = "verbosity"
+
+	// FlagNPM is the flag name for specifying a NPM repository.
+	FlagNPM = "npm"
+
+	// FlagPyPI is the flag name for specifying a PyPI repository.
+	FlagPyPI = "pypi"
+
+	// FlagRubyGems is the flag name for specifying a RubyGems repository.
+	FlagRubyGems = "rubygems"
+
+	// FlagMetadata is the flag name for specifying metadata for the project.
+	FlagMetadata = "metadata"
+
+	// FlagShowDetails is the flag name for outputting additional check info.
+	FlagShowDetails = "show-details"
+
+	// FlagChecks is the flag name for specifying which checks to run.
+	FlagChecks = "checks"
+
+	// FlagPolicyFile is the flag name for specifying a policy file.
+	FlagPolicyFile = "policy"
+
+	// FlagFormat is the flag name for specifying output format.
+	FlagFormat = "format"
+)
+
 // Command is an interface for handling options for command-line utilities.
 type Command interface {
 	// AddFlags adds this options' flags to the cobra command.
@@ -33,14 +71,14 @@ type Command interface {
 func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.Repo,
-		"repo",
+		FlagRepo,
 		o.Repo,
 		"repository to check",
 	)
 
 	cmd.Flags().StringVar(
 		&o.Local,
-		"local",
+		FlagLocal,
 		o.Local,
 		"local folder to check",
 	)
@@ -48,49 +86,49 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	// TODO(v5): Should this be behind a feature flag?
 	cmd.Flags().StringVar(
 		&o.Commit,
-		"commit",
+		FlagCommit,
 		o.Commit,
 		"commit to analyze",
 	)
 
 	cmd.Flags().StringVar(
 		&o.LogLevel,
-		"verbosity",
+		FlagLogLevel,
 		o.LogLevel,
 		"set the log level",
 	)
 
 	cmd.Flags().StringVar(
 		&o.NPM,
-		"npm",
+		FlagNPM,
 		o.NPM,
 		"npm package to check, given that the npm package has a GitHub repository",
 	)
 
 	cmd.Flags().StringVar(
 		&o.PyPI,
-		"pypi",
+		FlagPyPI,
 		o.PyPI,
 		"pypi package to check, given that the pypi package has a GitHub repository",
 	)
 
 	cmd.Flags().StringVar(
 		&o.RubyGems,
-		"rubygems",
+		FlagRubyGems,
 		o.RubyGems,
 		"rubygems package to check, given that the rubygems package has a GitHub repository",
 	)
 
 	cmd.Flags().StringSliceVar(
 		&o.Metadata,
-		"metadata",
+		FlagMetadata,
 		o.Metadata,
 		"metadata for the project. It can be multiple separated by commas",
 	)
 
 	cmd.Flags().BoolVar(
 		&o.ShowDetails,
-		"show-details",
+		FlagShowDetails,
 		o.ShowDetails,
 		"show extra details about each check",
 	)
@@ -101,7 +139,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	}
 	cmd.Flags().StringSliceVar(
 		&o.ChecksToRun,
-		"checks",
+		FlagChecks,
 		o.ChecksToRun,
 		fmt.Sprintf("Checks to run. Possible values are: %s", strings.Join(checkNames, ",")),
 	)
@@ -110,21 +148,21 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	if o.isSarifEnabled() {
 		cmd.Flags().StringVar(
 			&o.PolicyFile,
-			"policy",
+			FlagPolicyFile,
 			o.PolicyFile,
 			"policy to enforce",
 		)
 
 		cmd.Flags().StringVar(
 			&o.Format,
-			"format",
+			FlagFormat,
 			o.Format,
 			"output format allowed values are [default, sarif, json]",
 		)
 	} else {
 		cmd.Flags().StringVar(
 			&o.Format,
-			"format",
+			FlagFormat,
 			o.Format,
 			"output format allowed values are [default, json]",
 		)

--- a/options/flags.go
+++ b/options/flags.go
@@ -145,6 +145,11 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	)
 
 	// TODO(options): Extract logic
+	allowedFormats := []string{
+		FormatDefault,
+		FormatJSON,
+	}
+
 	if o.isSarifEnabled() {
 		cmd.Flags().StringVar(
 			&o.PolicyFile,
@@ -153,18 +158,16 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 			"policy to enforce",
 		)
 
-		cmd.Flags().StringVar(
-			&o.Format,
-			FlagFormat,
-			o.Format,
-			"output format allowed values are [default, sarif, json]",
-		)
-	} else {
-		cmd.Flags().StringVar(
-			&o.Format,
-			FlagFormat,
-			o.Format,
-			"output format allowed values are [default, json]",
-		)
+		allowedFormats = append(allowedFormats, FormatSarif)
 	}
+
+	cmd.Flags().StringVar(
+		&o.Format,
+		FlagFormat,
+		o.Format,
+		fmt.Sprintf(
+			"output format. Possible values are: %s",
+			strings.Join(allowedFormats, ", "),
+		),
+	)
 }

--- a/options/flags.go
+++ b/options/flags.go
@@ -34,14 +34,14 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.Repo,
 		"repo",
-		"",
+		o.Repo,
 		"repository to check",
 	)
 
 	cmd.Flags().StringVar(
 		&o.Local,
 		"local",
-		"",
+		o.Local,
 		"local folder to check",
 	)
 
@@ -49,49 +49,49 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVar(
 		&o.Commit,
 		"commit",
-		DefaultCommit,
+		o.Commit,
 		"commit to analyze",
 	)
 
 	cmd.Flags().StringVar(
 		&o.LogLevel,
 		"verbosity",
-		DefaultLogLevel,
+		o.LogLevel,
 		"set the log level",
 	)
 
 	cmd.Flags().StringVar(
 		&o.NPM,
 		"npm",
-		"",
+		o.NPM,
 		"npm package to check, given that the npm package has a GitHub repository",
 	)
 
 	cmd.Flags().StringVar(
 		&o.PyPI,
 		"pypi",
-		"",
+		o.PyPI,
 		"pypi package to check, given that the pypi package has a GitHub repository",
 	)
 
 	cmd.Flags().StringVar(
 		&o.RubyGems,
 		"rubygems",
-		"",
+		o.RubyGems,
 		"rubygems package to check, given that the rubygems package has a GitHub repository",
 	)
 
 	cmd.Flags().StringSliceVar(
 		&o.Metadata,
 		"metadata",
-		[]string{},
+		o.Metadata,
 		"metadata for the project. It can be multiple separated by commas",
 	)
 
 	cmd.Flags().BoolVar(
 		&o.ShowDetails,
 		"show-details",
-		false,
+		o.ShowDetails,
 		"show extra details about each check",
 	)
 
@@ -102,7 +102,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	cmd.Flags().StringSliceVar(
 		&o.ChecksToRun,
 		"checks",
-		[]string{},
+		o.ChecksToRun,
 		fmt.Sprintf("Checks to run. Possible values are: %s", strings.Join(checkNames, ",")),
 	)
 
@@ -111,21 +111,21 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		cmd.Flags().StringVar(
 			&o.PolicyFile,
 			"policy",
-			"",
+			o.PolicyFile,
 			"policy to enforce",
 		)
 
 		cmd.Flags().StringVar(
 			&o.Format,
 			"format",
-			FormatDefault,
+			o.Format,
 			"output format allowed values are [default, sarif, json]",
 		)
 	} else {
 		cmd.Flags().StringVar(
 			&o.Format,
 			"format",
-			FormatDefault,
+			o.Format,
 			"output format allowed values are [default, json]",
 		)
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -58,6 +58,18 @@ func New() *Options {
 		fmt.Printf("could not parse env vars, using default options: %v", err)
 	}
 
+	// Defaulting.
+	// TODO(options): Consider moving this to a separate function/method.
+	if opts.Commit == "" {
+		opts.Commit = DefaultCommit
+	}
+	if opts.Format == "" {
+		opts.Format = FormatDefault
+	}
+	if opts.LogLevel == "" {
+		opts.LogLevel = DefaultLogLevel
+	}
+
 	return opts
 }
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)
One part feature, one part bug fix?

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

- cmd: Allow new scorecard commands to be instantiated with options
- options: Default flags to struct field values
- options: Use constants for flag names
- options: Simplify SARIF check

Signed-off-by: Stephen Augustus <foo@auggie.dev>

#### What is the current behavior?

With https://github.com/ossf/scorecard/pull/1696, we enabled the ability to import the scorecard cobra command to support use cases like https://github.com/ossf/scorecard-action/pull/122.

Unfortunately, because of the way we're currently handling defaulting for the flags, it means any initialization of the scorecard options gets discarded in favor of the flag defaults.

Where this comes up is when we attempt to build an options set via environment variables.

#### What is the new behavior (if this is a feature change)?**

- [x] (N/A) Tests for the changes have been added (for bug fixes/features)

First off, we allow the scorecard command to be initialized with options, which means a downstream consumer can now choose the way they build the options (ideally with `o := options.New()` + additional logic).

After that, we change how the flags default.
Instead of defaulting to empty values, we now use whatever value was initially set within `Options`.

BEFORE:

```go
	cmd.Flags().StringVar(
		&o.Repo,
		FlagRepo,
		"repo",
		"repository to check",
	)
```

AFTER:

```go
	cmd.Flags().StringVar(
		&o.Repo,
		FlagRepo,
		o.Repo,
		"repository to check",
	)
```

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

h/t to @n3wscott for rubber-ducking with me!

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
- cmd: Allow new scorecard commands to be instantiated with options
- options: Default flags to struct field values
- options: Use constants for flag names
- options: Simplify SARIF check
```
