### PR TITLE
:book: Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ This data is available in the public BigQuery dataset
 `openssf:scorecardcron.scorecard-v2`. The latest results are available in the
 BigQuery view `openssf:scorecardcron.scorecard-v2_latest`.
 
+You can query the data using [BigQuery Explorer](http://console.cloud.google.com/bigquery) by navigating to Add Data > Pin a Project > Enter Project Name > 'openssf'
+
 You can extract the latest results to Google Cloud storage in JSON format using
 the [`bq`](https://cloud.google.com/bigquery/docs/bq-command-line-tool) tool:
 


### PR DESCRIPTION
Updated instructions on how to access public BigQuery dataset in section: https://github.com/ossf/scorecard/edit/main/README.md#public-data

#### What kind of change does this PR introduce?

Docs update

- [:book: ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The steps describing how to access the public project and dataset are missing in the Readme.md

#### What is the new behavior (if this is a feature change)?**
Added steps describing how to access the public project and dataset to the Readme.md

#### Which issue(s) this PR fixes
Fixes #1715 

#### Special notes for your reviewer
N/A

#### Does this PR introduce a user-facing change?
Update of Readme.md


```release-note
Updated instructions on how to access public BigQuery dataset.
```
