### PR TITLE
✨ Enable `CI-Tests` to run as commit-based check

### DIFF
--- a/clients/githubrepo/checkruns.go
+++ b/clients/githubrepo/checkruns.go
@@ -17,7 +17,6 @@ package githubrepo
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/google/go-github/v38/github"
 
@@ -37,9 +36,6 @@ func (handler *checkrunsHandler) init(ctx context.Context, repourl *repoURL) {
 }
 
 func (handler *checkrunsHandler) listCheckRunsForRef(ref string) ([]clients.CheckRun, error) {
-	if !strings.EqualFold(handler.repourl.commitSHA, clients.HeadSHA) {
-		return nil, fmt.Errorf("%w: ListCheckRuns only supported for HEAD queries", clients.ErrUnsupportedFeature)
-	}
 	checkRuns, _, err := handler.client.Checks.ListCheckRunsForRef(
 		handler.ctx, handler.repourl.owner, handler.repourl.repo, ref, &github.ListCheckRunsOptions{})
 	if err != nil {

--- a/clients/githubrepo/statuses.go
+++ b/clients/githubrepo/statuses.go
@@ -17,7 +17,6 @@ package githubrepo
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/google/go-github/v38/github"
 
@@ -37,9 +36,6 @@ func (handler *statusesHandler) init(ctx context.Context, repourl *repoURL) {
 }
 
 func (handler *statusesHandler) listStatuses(ref string) ([]clients.Status, error) {
-	if !strings.EqualFold(handler.repourl.commitSHA, clients.HeadSHA) {
-		return nil, fmt.Errorf("%w: ListStatuses only supported for HEAD queries", clients.ErrUnsupportedFeature)
-	}
 	statuses, _, err := handler.client.Repositories.ListStatuses(
 		handler.ctx, handler.repourl.owner, handler.repourl.repo, ref, &github.ListOptions{})
 	if err != nil {


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Enable `CI-Test` as a commit-based check. This is the final check needed to support a commit-specific Scorecard result.

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
No support for commit-specific Scorecard result.

#### What is the new behavior (if this is a feature change)?**
Adds support for `--commit=` option in Scorecard CLI.


- [ ] Tests for the changes have been added (for bug fixes/features)
Yes, `e2e/ci_tests_test.go` has tests for this.

#### Which issue(s) this PR fixes
Fixes #575 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.


or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Add support for commit-based Scorecard checks.
```
