### PR TITLE
:seedling: e2e for pinned_dependencies for localrepoclient

### DIFF
--- a/e2e/pinned_dependencies_test.go
+++ b/e2e/pinned_dependencies_test.go
@@ -15,7 +15,10 @@ package e2e
 
 import (
 	"context"
+	"io/ioutil"
+	"os"
 
+	"github.com/go-git/go-git/v5"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -23,6 +26,7 @@ import (
 	"github.com/ossf/scorecard/v4/checks"
 	"github.com/ossf/scorecard/v4/clients"
 	"github.com/ossf/scorecard/v4/clients/githubrepo"
+	"github.com/ossf/scorecard/v4/clients/localdir"
 	scut "github.com/ossf/scorecard/v4/utests"
 )
 
@@ -79,6 +83,42 @@ var _ = Describe("E2E TEST:"+checks.CheckPinnedDependencies, func() {
 			result := checks.PinnedDependencies(&req)
 			Expect(scut.ValidateTestReturn(nil, "dependencies check", &expected, &result, &dl)).Should(BeTrue())
 			Expect(repoClient.Close()).Should(BeNil())
+		})
+		It("Should return dependencies check for a local repoClient", func() {
+			dl := scut.TestDetailLogger{}
+
+			tmpDir, err := ioutil.TempDir("", "")
+			Expect(err).Should(BeNil())
+			defer os.RemoveAll(tmpDir)
+
+			_, e := git.PlainClone(tmpDir, false, &git.CloneOptions{
+				URL: "http://github.com/ossf-tests/scorecard-check-pinned-dependencies-e2e",
+			})
+			Expect(e).Should(BeNil())
+
+			repo, err := localdir.MakeLocalDirRepo(tmpDir)
+			Expect(err).Should(BeNil())
+
+			x := localdir.CreateLocalDirClient(context.Background(), logger)
+			err = x.InitRepo(repo, clients.HeadSHA)
+			Expect(err).Should(BeNil())
+
+			req := checker.CheckRequest{
+				Ctx:        context.Background(),
+				RepoClient: x,
+				Repo:       repo,
+				Dlogger:    &dl,
+			}
+			expected := scut.TestReturn{
+				Error:         nil,
+				Score:         3,
+				NumberOfWarn:  139,
+				NumberOfInfo:  2,
+				NumberOfDebug: 0,
+			}
+			result := checks.PinnedDependencies(&req)
+			Expect(scut.ValidateTestReturn(nil, "dependencies check", &expected, &result, &dl)).Should(BeTrue())
+			Expect(x.Close()).Should(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
- e2e for pinned_dependencies for localrepoclient

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
