### PR TITLE
✨ Support for detecting choco installer without required hash

### DIFF
--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -245,7 +245,7 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         checker.MinResultScore,
-				NumberOfWarn:  26,
+				NumberOfWarn:  27,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			},

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -575,6 +575,42 @@ func isPipUnpinnedDownload(cmd []string) bool {
 	return false
 }
 
+func isChocoUnpinnedDownload(cmd []string) bool {
+	// Install command is in the form 'choco install ...'
+	if len(cmd) < 2 {
+		return false
+	}
+
+	if !isBinaryName("choco", cmd[0]) && !isBinaryName("choco.exe", cmd[0]) {
+		return false
+	}
+
+	if !strings.EqualFold(cmd[1], "install") {
+		return false
+	}
+
+	// If this is an install command, then some variant of requirechecksum must be present.
+	for i := 1; i < len(cmd); i++ {
+		parts := strings.Split(cmd[i], "=")
+		if len(parts) == 0 {
+			continue
+		}
+
+		str := parts[0]
+
+		switch {
+		case strings.EqualFold(str, "--requirechecksum"):
+			return false
+		case strings.EqualFold(str, "--requirechecksums"):
+			return false
+		case strings.EqualFold(str, "--require-checksums"):
+			return false
+		}
+	}
+
+	return true
+}
+
 func isUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.Node,
 	cmd, pathfn string, dl checker.DetailLogger,
 ) bool {
@@ -629,6 +665,18 @@ func isUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.Node,
 		return true
 	}
 
+	// Choco install.
+	if isChocoUnpinnedDownload(c) {
+		dl.Warn(&checker.LogMessage{
+			Path:      pathfn,
+			Type:      checker.FileTypeSource,
+			Offset:    startLine,
+			EndOffset: endLine,
+			Snippet:   cmd,
+			Text:      "choco installation not pinned by hash",
+		})
+		return true
+	}
 	// TODO(laurent): add other package managers.
 
 	return false

--- a/checks/testdata/.github/workflows/github-workflow-pkg-managers.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-pkg-managers.yaml
@@ -98,3 +98,11 @@ jobs:
         run: python -m pip install 'some-pkg>1.2.3'
       - name:
         run: pip3 install -r bla-requirements.txt --require-hashes && pip3 install --require-hashes -r bla-requirements.txt
+      - name:
+        run: choco install 'some-package'
+      - name:
+        run: choco install --requirechecksum 'some-package'
+      - name:
+        run: choco install --requirechecksums 'some-package'
+      - name:
+        run: choco install --require-checksums 'some-package'


### PR DESCRIPTION
Signed-off-by: Alan Jowett <alanjo@microsoft.com>

#### What kind of change does this PR introduce?

Add support for detecting unpinned install using https://chocolatey.org/

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Scorecard ignores choco installs.

#### What is the new behavior (if this is a feature change)?**
Scorecard warns for choco installs with out required hash.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes: #1807 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Scorecard will issue a warning when installing packages using the Chocolatey installer but not pinning the install with a hash.
```
