### PR TITLE
:book: Remove erroneous ref to CSV output

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,8 +384,7 @@ For example, `--checks=CI-Tests,Code-Review`.
 
 ##### Formatting Results
 
-There are three formats currently: `default`, `json`, and `csv`. Others may be
-added in the future.
+The currently supported formats are `default` (text) and `json`.
 
 These may be specified with the `--format` flag. For example, `--format=json`.
 


### PR DESCRIPTION
Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

#### What kind of change does this PR introduce?

docs update

- [ x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

README claims that CSV output format is supported.

#### What is the new behavior (if this is a feature change)?**

README only lists default and json as output formats.

- [ ] Tests for the changes have been added (for bug fixes/features)

NA.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

I actually happen to regret the drop of CSV output support but at least the documentation should be consistent with the code.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

Yes, the README no longer misleads the user.

```release-note
Update README to reflect actual list of supported output formats.
```
