### PR TITLE
:book: Fix command Usage

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -37,8 +37,7 @@ import (
 
 const (
 	scorecardLong = "A program that shows security scorecard for an open source software."
-	scorecardUse  = `./scorecard [--repo=<repo_url>] [--local=folder] [--checks=check1,...]
-	 [--show-details] or ./scorecard --{npm,pypi,rubygems}=<package_name> 
+	scorecardUse  = `./scorecard (--repo=<repo> | --local=<folder> | --{npm,pypi,rubygems}=<package_name>)
 	 [--checks=check1,...] [--show-details]`
 	scorecardShort = "Security Scorecards"
 )

--- a/options/flags.go
+++ b/options/flags.go
@@ -73,7 +73,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		&o.Repo,
 		FlagRepo,
 		o.Repo,
-		"repository to check",
+		"repository to check (valid inputs: \"owner/repo\", \"github.com/owner/repo\", \"https://github.com/repo\")",
 	)
 
 	cmd.Flags().StringVar(


### PR DESCRIPTION
This changes the cmd Usage text to accurately represents the
supported syntax:

Usage:
  ./scorecard (--repo=\<repo> | --local=\<folder> | --{npm,pypi,rubygems}=<package_name> ) [--checks=check1,...]
	 [--show-details] [flags]
...
      --repo string        repository to check (valid inputs: "owner/repo", "github.com/owner/repo", "https://github.com/owner/repo")
...

Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

#### What kind of change does this PR introduce?

Improvement

- [x ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

NA

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

I'm not sure whether to categorize this change as a "Documentation" change given that it is in the code, or a "Bug Fix" given that it is merely changing the Usage text of the command... :-)

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

Yes, command Usage is more accurate and makes it easier for user to understand what is supported.

```release-note
Improved command Usage
```
