### PR TITLE
✨ Return inconclusive result if no fuzzing is detected

### DIFF
--- a/checks/fuzzing.go
+++ b/checks/fuzzing.go
@@ -86,5 +86,5 @@ func Fuzzing(c *checker.CheckRequest) checker.CheckResult {
 			"project is fuzzed in OSS-Fuzz")
 	}
 
-	return checker.CreateMinScoreResult(CheckFuzzing, "project is not fuzzed")
+	return checker.CreateInconclusiveResult(CheckFuzzing, "could not determine if project is fuzzed")
 }

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -374,9 +374,9 @@ checks:
       Risk: `Medium` (possible vulnerabilities in code)
 
       This check tries to determine if the project uses
-      [fuzzing](https://owasp.org/www-community/Fuzzing) by checking if the repository
-      name is included in the [OSS-Fuzz](https://github.com/google/oss-fuzz) project
-      list.
+      [fuzzing](https://owasp.org/www-community/Fuzzing). The current implementation
+      check if the repository name is included in the [OSS-Fuzz](https://github.com/google/oss-fuzz) project
+      list or if [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) is enabled.
 
       Fuzzing, or fuzz testing, is the practice of feeding unexpected or random data
       into a program to expose bugs. Regular fuzzing is important to detect


### PR DESCRIPTION
Return inconclusive result if no fuzzing is detected
No breaking changes
```release-notes
Return inconclusive result if no fuzzing is detected
```