### PR TITLE
🐛 `Security-Policy` should not run on `--local`

### DIFF
--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -41,11 +41,6 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 	}
 
 	// Check if present in parent org.
-	parentOrg := c.Repo.Org()
-	if parentOrg == nil {
-		return checker.SecurityPolicyData{}, nil
-	}
-
 	// https#://docs.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file.
 	// TODO(1491): Make this non-GitHub specific.
 	logger := log.NewLogger(log.InfoLevel)

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -99,10 +99,6 @@ func TestSecurityPolicy(t *testing.T) {
 				"doc/security.rst",
 			},
 		},
-		{
-			name:  "early return if org is null",
-			files: []string{},
-		},
 	}
 	for _, tt := range tests {
 		tt := tt

--- a/checks/security_policy.go
+++ b/checks/security_policy.go
@@ -27,7 +27,6 @@ const CheckSecurityPolicy = "Security-Policy"
 //nolint:gochecknoinits
 func init() {
 	supportedRequestTypes := []checker.RequestType{
-		checker.FileBased,
 		checker.CommitBased,
 	}
 	if err := registerCheck(CheckSecurityPolicy, SecurityPolicy, supportedRequestTypes); err != nil {


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Fixes bug introduced in #1579. `Security-Policy` was never supposed to be run on `--local`.

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->
NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Remove `Security-Policy` from `--local`
```
