### PR TITLE
:seedling: Split NewLogger into two so we can use a custom logrus instance.

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -38,11 +38,16 @@ func NewLogger(logLevel Level) *Logger {
 	logrusLevel := parseLogrusLevel(logLevel)
 	logrusLog.SetLevel(logrusLevel)
 
+	return NewLogrusLogger(logrusLog)
+}
+
+// NewLogrusLogger creates an instance of *Logger backed by the supplied
+// logrusLog instance.
+func NewLogrusLogger(logrusLog *logrus.Logger) *Logger {
 	logrLogger := logrusr.New(logrusLog)
 	logger := &Logger{
 		&logrLogger,
 	}
-
 	return logger
 }
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This is a minor tweak to the implementation of `log.NewLogger` to make reuse of scorecard components in ossf/criticality_score easier.

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`log.NewLogger()` takes a log level, creates the logrus instance, creates a logr instance and returns a new instance of `log.Logger`.

#### What is the new behavior (if this is a feature change)?**

`log.NewLogrusLogger()` splits the behavior of `log.NewLogger()`, so an external logrus instance can be used to create the logger required for scorecard packages.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

N/A

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
