### PR TITLE
🐛 Fix e2e tests for branch protection

### DIFF
--- a/clients/githubrepo/branches_e2e_test.go
+++ b/clients/githubrepo/branches_e2e_test.go
@@ -33,9 +33,9 @@ var _ = Describe("E2E TEST: githubrepo.branchesHandler", func() {
 	})
 
 	Context("E2E TEST: Validate query cost", func() {
-		skipIfTokenIsNot(githubWorkflowDefaultTokenType, "GITHUB_TOKEN only")
-
 		It("Should not have increased for HEAD query", func() {
+			skipIfTokenIsNot(githubWorkflowDefaultTokenType, "GITHUB_TOKEN only")
+
 			repourl := &repoURL{
 				owner:     "ossf",
 				repo:      "scorecard",
@@ -48,6 +48,8 @@ var _ = Describe("E2E TEST: githubrepo.branchesHandler", func() {
 			Expect(*brancheshandler.data.RateLimit.Cost).Should(BeNumerically("<=", 1))
 		})
 		It("Should fail for non-HEAD query", func() {
+			skipIfTokenIsNot(githubWorkflowDefaultTokenType, "GITHUB_TOKEN only")
+
 			repourl := &repoURL{
 				owner:     "ossf",
 				repo:      "scorecard",

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -29,9 +29,9 @@ import (
 
 var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 	Context("E2E TEST:Validating branch protection", func() {
-		skipIfTokenIsNot(patTokenType, "PAT only")
-
 		It("Should get non-admin branch protection on other repositories", func() {
+			skipIfTokenIsNot(patTokenType, "PAT only")
+
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-branch-protection-e2e")
 			Expect(err).Should(BeNil())
@@ -62,6 +62,8 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 			Expect(repoClient.Close()).Should(BeNil())
 		})
 		It("Should fail to return branch protection on other repositories", func() {
+			skipIfTokenIsNot(patTokenType, "PAT only")
+
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-branch-protection-e2e-none")
 			Expect(err).Should(BeNil())
@@ -92,6 +94,8 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 			Expect(repoClient.Close()).Should(BeNil())
 		})
 		It("Should fail to return branch protection on other repositories", func() {
+			skipIfTokenIsNot(patTokenType, "PAT only")
+
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-branch-protection-e2e-patch-1")
 			Expect(err).Should(BeNil())
@@ -126,9 +130,8 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 
 var _ = Describe("E2E TEST GITHUB_TOKEN:"+checks.CheckBranchProtection, func() {
 	Context("E2E TEST:Validating branch protection", func() {
-		skipIfTokenIsNot(githubWorkflowDefaultTokenType, "GITHUB_TOKEN only")
-
 		It("Should get errors with GITHUB_TOKEN", func() {
+			skipIfTokenIsNot(githubWorkflowDefaultTokenType, "GITHUB_TOKEN only")
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-branch-protection-e2e")
 			Expect(err).Should(BeNil())


### PR DESCRIPTION
I broke the unit tests, see https://github.com/ossf/scorecard/issues/1834
It turns out that the ginkgo's `Skip()` function only works in the `It()` function.

Fix e2e tests for branch protection
no breaking changes

```release-notes
Fix e2e tests for branch protection
```

