### PR TITLE
🐛 last fix for e2e branch tests

### DIFF
--- a/clients/githubrepo/branches_e2e_test.go
+++ b/clients/githubrepo/branches_e2e_test.go
@@ -34,7 +34,7 @@ var _ = Describe("E2E TEST: githubrepo.branchesHandler", func() {
 
 	Context("E2E TEST: Validate query cost", func() {
 		It("Should not have increased for HEAD query", func() {
-			skipIfTokenIsNot(githubWorkflowDefaultTokenType, "GITHUB_TOKEN only")
+			skipIfTokenIsNot(patTokenType, "GITHUB_TOKEN only")
 
 			repourl := &repoURL{
 				owner:     "ossf",
@@ -48,7 +48,7 @@ var _ = Describe("E2E TEST: githubrepo.branchesHandler", func() {
 			Expect(*brancheshandler.data.RateLimit.Cost).Should(BeNumerically("<=", 1))
 		})
 		It("Should fail for non-HEAD query", func() {
-			skipIfTokenIsNot(githubWorkflowDefaultTokenType, "GITHUB_TOKEN only")
+			skipIfTokenIsNot(patTokenType, "GITHUB_TOKEN only")
 
 			repourl := &repoURL{
 				owner:     "ossf",


### PR DESCRIPTION
Fix the githubrepo e2e2 branch test. I used the wrong token type.

no breaking changes
```release-notes
Fix the githubrepo e2e2 branch test
```