### PR TITLE
:warning: Removing the error field from `CheckResult` struct

### DIFF
--- a/checker/check_result.go
+++ b/checker/check_result.go
@@ -79,7 +79,6 @@ const (
 // nolint:govet
 type CheckResult struct {
 	// TODO(#1393): Remove old structure after deprecation.
-	Error      error `json:"-"`
 	Name       string
 	Details    []string
 	Confidence int
@@ -88,7 +87,7 @@ type CheckResult struct {
 	// UPGRADEv2: New structure. Omitting unchanged Name field
 	// for simplicity.
 	Version  int           `json:"-"` // Default value of 0 indicates old structure.
-	Error2   error         `json:"-"` // Runtime error indicate a filure to run the check.
+	Error    error         `json:"-"` // Runtime error indicate a filure to run the check.
 	Details2 []CheckDetail `json:"-"` // Details of tests and sub-checks
 	Score    int           `json:"-"` // {[-1,0...10], -1 = Inconclusive}
 	Reason   string        `json:"-"` // A sentence describing the check result (score, etc)
@@ -161,12 +160,11 @@ func CreateResultWithScore(name, reason string, score int) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Error:      nil,
 		Confidence: MaxResultScore,
 		Pass:       pass,
 		// New structure.
 		Version: 2,
-		Error2:  nil,
+		Error:   nil,
 		Score:   score,
 		Reason:  reason,
 	}
@@ -186,12 +184,11 @@ func CreateProportionalScoreResult(name, reason string, b, t int) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Error:      nil,
 		Confidence: MaxResultConfidence,
 		Pass:       pass,
 		// New structure.
 		Version: 2,
-		Error2:  nil,
+		Error:   nil,
 		Score:   score,
 		Reason:  NormalizeReason(reason, score),
 	}
@@ -232,12 +229,11 @@ func CreateRuntimeErrorResult(name string, e error) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Error:      e,
 		Confidence: 0,
 		Pass:       false,
 		// New structure.
 		Version: 2,
-		Error2:  e,
+		Error:   e,
 		Score:   InconclusiveResultScore,
 		Reason:  e.Error(), // Note: message already accessible by caller thru `Error`.
 	}

--- a/checker/check_runner.go
+++ b/checker/check_runner.go
@@ -77,7 +77,7 @@ func logStats(ctx context.Context, startTime time.Time, result *CheckResult) err
 	opencensusstats.Record(ctx, stats.CheckRuntimeInSec.M(runTimeInSecs))
 
 	if result.Error != nil {
-		ctx, err := tag.New(ctx, tag.Upsert(stats.ErrorName, sce.GetName(result.Error2)))
+		ctx, err := tag.New(ctx, tag.Upsert(stats.ErrorName, sce.GetName(result.Error)))
 		if err != nil {
 			return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("tag.New: %v", err))
 		}
@@ -109,9 +109,9 @@ func (r *Runner) Run(ctx context.Context, c Check) CheckResult {
 		checkRequest.Ctx = ctx
 		checkRequest.Dlogger = l
 		res = c.Fn(&checkRequest)
-		if res.Error2 != nil && errors.Is(res.Error2, sce.ErrRepoUnreachable) {
+		if res.Error != nil && errors.Is(res.Error, sce.ErrRepoUnreachable) {
 			checkRequest.Dlogger.Warn(&LogMessage{
-				Text: fmt.Sprintf("%v", res.Error2),
+				Text: fmt.Sprintf("%v", res.Error),
 			})
 			continue
 		}

--- a/checks/code_review_test.go
+++ b/checks/code_review_test.go
@@ -207,7 +207,7 @@ func TestCodereview(t *testing.T) {
 			res := CodeReview(&req)
 
 			if tt.err != nil {
-				if res.Error2 == nil {
+				if res.Error == nil {
 					t.Errorf("Expected error %v, got nil", tt.err)
 				}
 				// return as we don't need to check the rest of the fields.

--- a/checks/contributors_test.go
+++ b/checks/contributors_test.go
@@ -175,7 +175,7 @@ func TestContributors(t *testing.T) {
 			res := Contributors(&req)
 
 			if tt.err != nil {
-				if res.Error2 == nil {
+				if res.Error == nil {
 					t.Errorf("Expected error %v, got nil", tt.err)
 				}
 				// return as we don't need to check the rest of the fields.

--- a/checks/evaluation/binary_artifacts_test.go
+++ b/checks/evaluation/binary_artifacts_test.go
@@ -277,8 +277,8 @@ func TestBinaryArtifacts(t *testing.T) {
 			t.Parallel()
 			got := BinaryArtifacts(tt.args.name, tt.args.dl, tt.args.r)
 			if tt.wantErr {
-				if got.Error2 == nil {
-					t.Errorf("BinaryArtifacts() error = %v, wantErr %v", got.Error2, tt.wantErr)
+				if got.Error == nil {
+					t.Errorf("BinaryArtifacts() error = %v, wantErr %v", got.Error, tt.wantErr)
 				}
 			} else {
 				if got.Score != tt.want.Score {

--- a/checks/evaluation/dependency_update_tool_test.go
+++ b/checks/evaluation/dependency_update_tool_test.go
@@ -70,8 +70,8 @@ func TestDependencyUpdateTool(t *testing.T) {
 				},
 			},
 			want: checker.CheckResult{
-				Score:  0,
-				Error2: nil,
+				Score: 0,
+				Error: nil,
 			},
 			err: false,
 			expected: scut.TestReturn{
@@ -104,8 +104,8 @@ func TestDependencyUpdateTool(t *testing.T) {
 				},
 			},
 			want: checker.CheckResult{
-				Score:  10,
-				Error2: nil,
+				Score: 10,
+				Error: nil,
 			},
 			expected: scut.TestReturn{
 				Error:        nil,
@@ -131,8 +131,8 @@ func TestDependencyUpdateTool(t *testing.T) {
 				},
 			},
 			want: checker.CheckResult{
-				Score:  -1,
-				Error2: nil,
+				Score: -1,
+				Error: nil,
 			},
 			expected: scut.TestReturn{
 				Error: sce.ErrScorecardInternal,
@@ -147,8 +147,8 @@ func TestDependencyUpdateTool(t *testing.T) {
 				dl:   &scut.TestDetailLogger{},
 			},
 			want: checker.CheckResult{
-				Score:  -1,
-				Error2: nil,
+				Score: -1,
+				Error: nil,
 			},
 			expected: scut.TestReturn{
 				Error: sce.ErrScorecardInternal,
@@ -167,8 +167,8 @@ func TestDependencyUpdateTool(t *testing.T) {
 			if tt.want.Score != got.Score {
 				t.Errorf("DependencyUpdateTool() got Score = %v, want %v for %v", got.Score, tt.want.Score, tt.name)
 			}
-			if tt.err && got.Error2 == nil {
-				t.Errorf("DependencyUpdateTool() error = %v, want %v for %v", got.Error2, tt.want.Error2, tt.name)
+			if tt.err && got.Error == nil {
+				t.Errorf("DependencyUpdateTool() error = %v, want %v for %v", got.Error, tt.want.Error, tt.name)
 				return
 			}
 

--- a/checks/evaluation/webhooks_test.go
+++ b/checks/evaluation/webhooks_test.go
@@ -139,8 +139,8 @@ func TestWebhooks(t *testing.T) {
 			t.Parallel()
 			got := Webhooks(tt.args.name, tt.args.dl, tt.args.r)
 			if tt.wantErr {
-				if got.Error2 == nil {
-					t.Errorf("Webhooks() error = %v, wantErr %v", got.Error2, tt.wantErr)
+				if got.Error == nil {
+					t.Errorf("Webhooks() error = %v, wantErr %v", got.Error, tt.wantErr)
 				}
 			} else {
 				if got.Score != tt.want.Score {

--- a/checks/fuzzing_test.go
+++ b/checks/fuzzing_test.go
@@ -295,8 +295,8 @@ func TestFuzzing(t *testing.T) {
 			}
 
 			result := Fuzzing(&req)
-			if (result.Error2 != nil) != tt.wantErr {
-				t.Errorf("Fuzzing() error = %v, wantErr %v", result.Error2, tt.wantErr)
+			if (result.Error != nil) != tt.wantErr {
+				t.Errorf("Fuzzing() error = %v, wantErr %v", result.Error, tt.wantErr)
 				return
 			}
 

--- a/checks/maintained_test.go
+++ b/checks/maintained_test.go
@@ -345,7 +345,7 @@ func Test_Maintained(t *testing.T) {
 			res := Maintained(&req)
 
 			if tt.err != nil {
-				if res.Error2 == nil {
+				if res.Error == nil {
 					t.Errorf("Expected error %v, got nil", tt.err)
 				}
 				// return as we don't need to check the rest of the fields.

--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -128,8 +128,8 @@ func TestGithubWorkflowPinning(t *testing.T) {
 
 			s, e := testIsGitHubActionsWorkflowPinned(p, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -221,8 +221,8 @@ func TestNonGithubWorkflowPinning(t *testing.T) {
 
 			s, e := testIsGitHubActionsWorkflowPinned(p, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -268,8 +268,8 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 
 			s, e := testValidateGitHubWorkflowScriptFreeOfInsecureDownloads(p, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
@@ -392,8 +392,8 @@ func TestDockerfilePinning(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			s, e := testValidateDockerfileIsPinned(tt.filename, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -781,8 +781,8 @@ func TestDockerfilePinningWihoutHash(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			s, e := testValidateDockerfileIsPinned(tt.filename, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -970,8 +970,8 @@ func TestDockerfileScriptDownload(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			s, e := testValidateDockerfileIsFreeOfInsecureDownloads(tt.filename, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -1013,8 +1013,8 @@ func TestDockerfileScriptDownloadInfo(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			s, e := testValidateDockerfileIsFreeOfInsecureDownloads(tt.filename, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -1123,8 +1123,8 @@ func TestShellScriptDownload(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			s, e := testValidateShellScriptIsFreeOfInsecureDownloads(tt.filename, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -1178,8 +1178,8 @@ func TestShellScriptDownloadPinned(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			s, e := testValidateShellScriptIsFreeOfInsecureDownloads(tt.filename, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()
@@ -1257,8 +1257,8 @@ func TestGitHubWorflowRunDownload(t *testing.T) {
 
 			s, e := testValidateGitHubWorkflowScriptFreeOfInsecureDownloads(p, content, &dl)
 			actual := checker.CheckResult{
-				Score:  s,
-				Error2: e,
+				Score: s,
+				Error: e,
 			}
 			if !scut.ValidateTestReturn(t, tt.name, &tt.expected, &actual, &dl) {
 				t.Fail()

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -359,9 +359,9 @@ func TestSignedRelease(t *testing.T) {
 			name: "Error getting releases",
 			err:  errors.New("Error getting releases"),
 			expected: checker.CheckResult{
-				Pass:   false,
-				Score:  -1,
-				Error2: errors.New("Error getting releases"),
+				Pass:  false,
+				Score: -1,
+				Error: errors.New("Error getting releases"),
 			},
 		},
 	}
@@ -390,7 +390,7 @@ func TestSignedRelease(t *testing.T) {
 			res := SignedReleases(&req)
 
 			if tt.err != nil {
-				if res.Error2 == nil {
+				if res.Error == nil {
 					t.Errorf("Expected error %v, got nil", tt.err)
 				}
 				// return as we don't need to check the rest of the fields.

--- a/checks/webhook_test.go
+++ b/checks/webhook_test.go
@@ -123,7 +123,7 @@ func TestWebhooks(t *testing.T) {
 			}
 			res := WebHooks(&req)
 			if tt.err != nil {
-				if res.Error2 == nil {
+				if res.Error == nil {
 					t.Errorf("Expected error %v, got nil", tt.err)
 				}
 				// return as we don't need to check the rest of the fields.

--- a/cron/worker/main.go
+++ b/cron/worker/main.go
@@ -118,10 +118,10 @@ func processRequest(ctx context.Context,
 		}
 		for checkIndex := range result.Checks {
 			check := &result.Checks[checkIndex]
-			if !errors.Is(check.Error2, sce.ErrScorecardInternal) {
+			if !errors.Is(check.Error, sce.ErrScorecardInternal) {
 				continue
 			}
-			errorMsg := fmt.Sprintf("check %s has a runtime error: %v", check.Name, check.Error2)
+			errorMsg := fmt.Sprintf("check %s has a runtime error: %v", check.Name, check.Error)
 			if !(*ignoreRuntimeErrors) {
 				// nolint: goerr113
 				return errors.New(errorMsg)

--- a/e2e/binary_artifacts_test.go
+++ b/e2e/binary_artifacts_test.go
@@ -86,7 +86,6 @@ var _ = Describe("E2E TEST:"+checks.CheckBinaryArtifacts, func() {
 			result := checks.BinaryArtifacts(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "binary artifacts", &expected, &result, &dl)).Should(BeTrue())
@@ -117,7 +116,6 @@ var _ = Describe("E2E TEST:"+checks.CheckBinaryArtifacts, func() {
 			result := checks.BinaryArtifacts(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "binary artifacts", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -54,7 +54,6 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 			result := checks.BranchProtection(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 
 			// New version.
@@ -86,7 +85,6 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 			result := checks.BranchProtection(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 
 			// New version.
@@ -118,7 +116,6 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 			result := checks.BranchProtection(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 
 			// New version.
@@ -146,9 +143,9 @@ var _ = Describe("E2E TEST GITHUB_TOKEN:"+checks.CheckBranchProtection, func() {
 			}
 
 			result := checks.BranchProtection(&req)
+			Expect(result.Error).ShouldNot(BeNil())
 			// There should be an error with the GITHUB_TOKEN, until it's supported
 			// byt GitHub.
-			Expect(result.Error).ShouldNot(BeNil())
 			Expect(repoClient.Close()).Should(BeNil())
 		})
 	})

--- a/e2e/cii_best_practices_test.go
+++ b/e2e/cii_best_practices_test.go
@@ -52,7 +52,6 @@ var _ = Describe("E2E TEST:"+checks.CheckCIIBestPractices, func() {
 			result := checks.CIIBestPractices(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "passing badge", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/contributors_test.go
+++ b/e2e/contributors_test.go
@@ -52,7 +52,6 @@ var _ = Describe("E2E TEST:"+checks.CheckContributors, func() {
 			result := checks.Contributors(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "several contributors", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/dangerous_workflow_test.go
+++ b/e2e/dangerous_workflow_test.go
@@ -56,7 +56,6 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			// UPGRADEv2: to remove.
 			// Old version.
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "dangerous workflow", &expected, &result, &dl)).Should(BeTrue())
@@ -85,7 +84,6 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			// UPGRADEv2: to remove.
 			// Old version.
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "dangerous workflow", &expected, &result, &dl)).Should(BeTrue())
@@ -126,7 +124,6 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			// UPGRADEv2: to remove.
 			// Old version.
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "dangerous workflow", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/dependency_update_tool_test.go
+++ b/e2e/dependency_update_tool_test.go
@@ -56,7 +56,6 @@ var _ = Describe("E2E TEST:"+checks.CheckDependencyUpdateTool, func() {
 			result := checks.DependencyUpdateTool(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "dependabot", &expected, &result, &dl)).Should(BeTrue())
@@ -86,7 +85,6 @@ var _ = Describe("E2E TEST:"+checks.CheckDependencyUpdateTool, func() {
 			result := checks.DependencyUpdateTool(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "renovabot", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/license_test.go
+++ b/e2e/license_test.go
@@ -54,7 +54,6 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			}
 			result := checks.License(&req)
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 
 			Expect(scut.ValidateTestReturn(nil, "license found", &expected, &result,
@@ -82,7 +81,6 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			}
 			result := checks.License(&req)
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 
 			Expect(scut.ValidateTestReturn(nil, "license found", &expected, &result,
@@ -122,7 +120,6 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			}
 			result := checks.License(&req)
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 
 			Expect(scut.ValidateTestReturn(nil, "license found", &expected, &result,

--- a/e2e/maintained_test.go
+++ b/e2e/maintained_test.go
@@ -52,7 +52,6 @@ var _ = Describe("E2E TEST:"+checks.CheckMaintained, func() {
 			result := checks.Maintained(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "active repo", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/permissions_test.go
+++ b/e2e/permissions_test.go
@@ -56,7 +56,6 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			// UPGRADEv2: to remove.
 			// Old version.
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "token permissions", &expected, &result, &dl)).Should(BeTrue())
@@ -86,7 +85,6 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			// UPGRADEv2: to remove.
 			// Old version.
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "token permissions", &expected, &result, &dl)).Should(BeTrue())
@@ -128,7 +126,6 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 			// UPGRADEv2: to remove.
 			// Old version.
 
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "token permissions", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/sast_test.go
+++ b/e2e/sast_test.go
@@ -52,7 +52,6 @@ var _ = Describe("E2E TEST:"+checks.CheckSAST, func() {
 			result := checks.SAST(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "sast used", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/security_policy_test.go
+++ b/e2e/security_policy_test.go
@@ -56,7 +56,6 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 			result := checks.SecurityPolicy(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "policy found", &expected, &result, &dl)).Should(BeTrue())
@@ -86,7 +85,6 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 			result := checks.SecurityPolicy(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "policy found", &expected, &result, &dl)).Should(BeTrue())
@@ -116,7 +114,6 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 			result := checks.SecurityPolicy(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "policy found", &expected, &result, &dl)).Should(BeTrue())
@@ -146,7 +143,6 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 			result := checks.SecurityPolicy(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "policy found", &expected, &result, &dl)).Should(BeTrue())
@@ -187,7 +183,6 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 			result := checks.SecurityPolicy(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "policy found", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/signedreleases_test.go
+++ b/e2e/signedreleases_test.go
@@ -52,7 +52,6 @@ var _ = Describe("E2E TEST:"+checks.CheckSignedReleases, func() {
 			result := checks.SignedReleases(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "verified release", &expected, &result, &dl)).Should(BeTrue())

--- a/e2e/vulnerabilities_test.go
+++ b/e2e/vulnerabilities_test.go
@@ -55,7 +55,6 @@ var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 			result := checks.Vulnerabilities(&req)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeTrue())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "no osv vulnerabilities", &expected, &result, &dl)).Should(BeTrue())
@@ -87,7 +86,6 @@ var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 			result := checks.Vulnerabilities(&checkRequest)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "osv vulnerabilities", &expected, &result, &dl)).Should(BeTrue())
@@ -118,7 +116,6 @@ var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 			result := checks.Vulnerabilities(&checkRequest)
 			// UPGRADEv2: to remove.
 			// Old version.
-			Expect(result.Error).Should(BeNil())
 			Expect(result.Pass).Should(BeFalse())
 			// New version.
 			Expect(scut.ValidateTestReturn(nil, "osv vulnerabilities", &expected, &result, &dl)).Should(BeTrue())


### PR DESCRIPTION
- Removing the error field from the `CheckResult`
- https://github.com/ossf/scorecard/issues/1393

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Removing the error field from CheckResult 
```
