### PR TITLE
🐛 Update env variables in cron

### DIFF
--- a/cron/k8s/transfer-raw.yaml
+++ b/cron/k8s/transfer-raw.yaml
@@ -34,8 +34,8 @@ spec:
               requests:
                 memory: 1Gi
             env:
-              - name: RAW_SCORECARD_BIGQUERY_TABLE
+              - name: SCORECARD_BIGQUERY_TABLE
                 value: "scorecard-rawdata"
-              - name: RAW_SCORECARD_DATA_BUCKET_URL
+              - name: SCORECARD_DATA_BUCKET_URL
                 value: "gs://ossf-scorecard-rawdata"
           restartPolicy: OnFailure

--- a/cron/k8s/transfer.release-raw.yaml
+++ b/cron/k8s/transfer.release-raw.yaml
@@ -30,9 +30,9 @@ spec:
             image: gcr.io/openssf/scorecard-bq-transfer:latest
             imagePullPolicy: Always
             env:
-            - name: RAW_SCORECARD_DATA_BUCKET_URL
+            - name: SCORECARD_DATA_BUCKET_URL
               value: "gs://ossf-scorecard-rawdata-releasetest"
-            - name: RAW_SCORECARD_BIGQUERY_TABLE
+            - name: SCORECARD_BIGQUERY_TABLE
               value: "scorecard-rawdata-releasetest"
             - name: SCORECARD_COMPLETION_THRESHOLD
               value: "0.9"


### PR DESCRIPTION
Env variables used in k8 configs use the wrong name. This PR fixes it.
No braking changes
```release-notes
Fix Env variables used in k8 configs
```

closes https://github.com/ossf/scorecard/issues/1857