### PR TITLE
✨ Update raw format for Dangerous workflows

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -296,14 +296,19 @@ const (
 // DangerousWorkflowData contains raw results
 // for dangerous workflow check.
 type DangerousWorkflowData struct {
-	Workflows []Workflow
+	Workflows []DangerousWorkflow
 }
 
-// Workflow represents a result for a workflow.
+// DangerousWorkflow represents a dangerous workflow.
+type DangerousWorkflow struct {
+	Workflow Workflow
+	Type     DangerousWorkflowType
+}
+
+// Workflow represents a workflow.
 type Workflow struct {
 	Job  *WorkflowJob
 	File File
-	Type DangerousWorkflowType
 }
 
 // WorkflowJob reprresents a workflow job.

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -283,24 +283,27 @@ type CIIBestPracticesData struct {
 	Badge CIIBadge
 }
 
+// DangerousWorkflowType represents a type of dangerous workflow.
+type DangerousWorkflowType int
+
+const (
+	// DangerousWorkflowScriptInjection represents a script injection.
+	DangerousWorkflowScriptInjection DangerousWorkflowType = iota
+	// DangerousWorkflowUntrustedCheckout represents an untrusted checkout.
+	DangerousWorkflowUntrustedCheckout
+)
+
 // DangerousWorkflowData contains raw results
 // for dangerous workflow check.
 type DangerousWorkflowData struct {
-	ScriptInjections   []ScriptInjection
-	UntrustedCheckouts []UntrustedCheckout
-	// TODO: other
+	Workflows []Workflow
 }
 
-// UntrustedCheckout represents an untrusted checkout.
-type UntrustedCheckout struct {
+// Workflow represents a result for a workflow.
+type Workflow struct {
 	Job  *WorkflowJob
 	File File
-}
-
-// ScriptInjection represents a script injection.
-type ScriptInjection struct {
-	Job  *WorkflowJob
-	File File
+	Type DangerousWorkflowType
 }
 
 // WorkflowJob reprresents a workflow job.

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -301,14 +301,9 @@ type DangerousWorkflowData struct {
 
 // DangerousWorkflow represents a dangerous workflow.
 type DangerousWorkflow struct {
-	Workflow Workflow
-	Type     DangerousWorkflowType
-}
-
-// Workflow represents a workflow.
-type Workflow struct {
 	Job  *WorkflowJob
 	File File
+	Type DangerousWorkflowType
 }
 
 // WorkflowJob reprresents a workflow job.

--- a/checks/evaluation/dangerous_workflow.go
+++ b/checks/evaluation/dangerous_workflow.go
@@ -34,20 +34,20 @@ func DangerousWorkflow(name string, dl checker.DetailLogger,
 		var text string
 		switch e.Type {
 		case checker.DangerousWorkflowUntrustedCheckout:
-			text = fmt.Sprintf("untrusted code checkout '%v'", e.File.Snippet)
+			text = fmt.Sprintf("untrusted code checkout '%v'", e.Workflow.File.Snippet)
 		case checker.DangerousWorkflowScriptInjection:
-			text = fmt.Sprintf("script injection with untrusted input '%v'", e.File.Snippet)
+			text = fmt.Sprintf("script injection with untrusted input '%v'", e.Workflow.File.Snippet)
 		default:
 			err := sce.WithMessage(sce.ErrScorecardInternal, "invalid type")
 			return checker.CreateRuntimeErrorResult(name, err)
 		}
 
 		dl.Warn(&checker.LogMessage{
-			Path:    e.File.Path,
-			Type:    e.File.Type,
-			Offset:  e.File.Offset,
+			Path:    e.Workflow.File.Path,
+			Type:    e.Workflow.File.Type,
+			Offset:  e.Workflow.File.Offset,
 			Text:    text,
-			Snippet: e.File.Snippet,
+			Snippet: e.Workflow.File.Snippet,
 		})
 	}
 

--- a/checks/evaluation/dangerous_workflow.go
+++ b/checks/evaluation/dangerous_workflow.go
@@ -34,20 +34,20 @@ func DangerousWorkflow(name string, dl checker.DetailLogger,
 		var text string
 		switch e.Type {
 		case checker.DangerousWorkflowUntrustedCheckout:
-			text = fmt.Sprintf("untrusted code checkout '%v'", e.Workflow.File.Snippet)
+			text = fmt.Sprintf("untrusted code checkout '%v'", e.File.Snippet)
 		case checker.DangerousWorkflowScriptInjection:
-			text = fmt.Sprintf("script injection with untrusted input '%v'", e.Workflow.File.Snippet)
+			text = fmt.Sprintf("script injection with untrusted input '%v'", e.File.Snippet)
 		default:
 			err := sce.WithMessage(sce.ErrScorecardInternal, "invalid type")
 			return checker.CreateRuntimeErrorResult(name, err)
 		}
 
 		dl.Warn(&checker.LogMessage{
-			Path:    e.Workflow.File.Path,
-			Type:    e.Workflow.File.Type,
-			Offset:  e.Workflow.File.Offset,
+			Path:    e.File.Path,
+			Type:    e.File.Type,
+			Offset:  e.File.Offset,
 			Text:    text,
-			Snippet: e.Workflow.File.Snippet,
+			Snippet: e.File.Snippet,
 		})
 	}
 

--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -192,15 +192,17 @@ func checkJobForUntrustedCodeCheckout(job *actionlint.Job, path string,
 			strings.Contains(ref.Value.Value, checkoutUntrustedWorkflowRunRef) {
 			line := fileparser.GetLineNumber(step.Pos)
 			pdata.Workflows = append(pdata.Workflows,
-				checker.Workflow{
-					File: checker.File{
-						Path:    path,
-						Type:    checker.FileTypeSource,
-						Offset:  line,
-						Snippet: ref.Value.Value,
-					},
-					Job:  createJob(job),
+				checker.DangerousWorkflow{
 					Type: checker.DangerousWorkflowUntrustedCheckout,
+					Workflow: checker.Workflow{
+						File: checker.File{
+							Path:    path,
+							Type:    checker.FileTypeSource,
+							Offset:  line,
+							Snippet: ref.Value.Value,
+						},
+						Job: createJob(job),
+					},
 				},
 			)
 		}
@@ -252,14 +254,16 @@ func checkVariablesInScript(script string, pos *actionlint.Pos,
 		if containsUntrustedContextPattern(variable) {
 			line := fileparser.GetLineNumber(pos)
 			pdata.Workflows = append(pdata.Workflows,
-				checker.Workflow{
-					File: checker.File{
-						Path:    path,
-						Type:    checker.FileTypeSource,
-						Offset:  line,
-						Snippet: variable,
+				checker.DangerousWorkflow{
+					Workflow: checker.Workflow{
+						File: checker.File{
+							Path:    path,
+							Type:    checker.FileTypeSource,
+							Offset:  line,
+							Snippet: variable,
+						},
+						Job: createJob(job),
 					},
-					Job:  createJob(job),
 					Type: checker.DangerousWorkflowScriptInjection,
 				},
 			)

--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -194,15 +194,13 @@ func checkJobForUntrustedCodeCheckout(job *actionlint.Job, path string,
 			pdata.Workflows = append(pdata.Workflows,
 				checker.DangerousWorkflow{
 					Type: checker.DangerousWorkflowUntrustedCheckout,
-					Workflow: checker.Workflow{
-						File: checker.File{
-							Path:    path,
-							Type:    checker.FileTypeSource,
-							Offset:  line,
-							Snippet: ref.Value.Value,
-						},
-						Job: createJob(job),
+					File: checker.File{
+						Path:    path,
+						Type:    checker.FileTypeSource,
+						Offset:  line,
+						Snippet: ref.Value.Value,
 					},
+					Job: createJob(job),
 				},
 			)
 		}
@@ -255,15 +253,13 @@ func checkVariablesInScript(script string, pos *actionlint.Pos,
 			line := fileparser.GetLineNumber(pos)
 			pdata.Workflows = append(pdata.Workflows,
 				checker.DangerousWorkflow{
-					Workflow: checker.Workflow{
-						File: checker.File{
-							Path:    path,
-							Type:    checker.FileTypeSource,
-							Offset:  line,
-							Snippet: variable,
-						},
-						Job: createJob(job),
+					File: checker.File{
+						Path:    path,
+						Type:    checker.FileTypeSource,
+						Offset:  line,
+						Snippet: variable,
 					},
+					Job:  createJob(job),
 					Type: checker.DangerousWorkflowScriptInjection,
 				},
 			)

--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -191,15 +191,16 @@ func checkJobForUntrustedCodeCheckout(job *actionlint.Job, path string,
 		if strings.Contains(ref.Value.Value, checkoutUntrustedPullRequestRef) ||
 			strings.Contains(ref.Value.Value, checkoutUntrustedWorkflowRunRef) {
 			line := fileparser.GetLineNumber(step.Pos)
-			pdata.UntrustedCheckouts = append(pdata.UntrustedCheckouts,
-				checker.UntrustedCheckout{
+			pdata.Workflows = append(pdata.Workflows,
+				checker.Workflow{
 					File: checker.File{
 						Path:    path,
 						Type:    checker.FileTypeSource,
 						Offset:  line,
 						Snippet: ref.Value.Value,
 					},
-					Job: createJob(job),
+					Job:  createJob(job),
+					Type: checker.DangerousWorkflowUntrustedCheckout,
 				},
 			)
 		}
@@ -250,15 +251,16 @@ func checkVariablesInScript(script string, pos *actionlint.Pos,
 		variable := script[s+3 : s+e]
 		if containsUntrustedContextPattern(variable) {
 			line := fileparser.GetLineNumber(pos)
-			pdata.ScriptInjections = append(pdata.ScriptInjections,
-				checker.ScriptInjection{
+			pdata.Workflows = append(pdata.Workflows,
+				checker.Workflow{
 					File: checker.File{
 						Path:    path,
 						Type:    checker.FileTypeSource,
 						Offset:  line,
 						Snippet: variable,
 					},
-					Job: createJob(job),
+					Job:  createJob(job),
+					Type: checker.DangerousWorkflowScriptInjection,
 				},
 			)
 		}

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -175,7 +175,7 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 				return
 			}
 
-			nb := len(dw.ScriptInjections) + len(dw.UntrustedCheckouts)
+			nb := len(dw.Workflows)
 			if nb != tt.expected.nb {
 				t.Errorf(cmp.Diff(nb, tt.expected.nb))
 			}

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -92,7 +92,6 @@ func (r *ScorecardResult) AsJSON(showDetails bool, logLevel log.Level, writer io
 		Metadata: r.Metadata,
 	}
 
-	//nolint
 	for _, checkResult := range r.Checks {
 		tmpResult := jsonCheckResult{
 			Name: checkResult.Name,
@@ -139,7 +138,6 @@ func (r *ScorecardResult) AsJSON2(showDetails bool,
 		AggregateScore: jsonFloatScore(score),
 	}
 
-	//nolint
 	for _, checkResult := range r.Checks {
 		doc, e := checkDocs.GetCheck(checkResult.Name)
 		if e != nil {

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -156,10 +156,10 @@ const (
 )
 
 type jsonWorkflow struct {
-	Job *jsonWorkflowJob `json:"job"`
+	Job  *jsonWorkflowJob `json:"job"`
+	File *jsonFile        `json:"file"`
 	// Type is a string to allow different types for permissions, unpinned dependencies, etc.
-	Type string   `json:"type"`
-	File jsonFile `json:"file"`
+	Type string `json:"type"`
 }
 
 type jsonWorkflowJob struct {
@@ -201,18 +201,18 @@ func (r *jsonScorecardRawResult) addDangerousWorkflowRawResults(df *checker.Dang
 	r.Results.Workflows = []jsonWorkflow{}
 	for _, e := range df.Workflows {
 		v := jsonWorkflow{
-			File: jsonFile{
-				Path:   e.Workflow.File.Path,
-				Offset: int(e.Workflow.File.Offset),
+			File: &jsonFile{
+				Path:   e.File.Path,
+				Offset: int(e.File.Offset),
 			},
 		}
-		if e.Workflow.File.Snippet != "" {
-			v.File.Snippet = &e.Workflow.File.Snippet
+		if e.File.Snippet != "" {
+			v.File.Snippet = &e.File.Snippet
 		}
-		if e.Workflow.Job != nil {
+		if e.Job != nil {
 			v.Job = &jsonWorkflowJob{
-				Name: e.Workflow.Job.Name,
-				ID:   e.Workflow.Job.ID,
+				Name: e.Job.Name,
+				ID:   e.Job.ID,
 			}
 		}
 

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -25,6 +25,9 @@ import (
 	sce "github.com/ossf/scorecard/v4/errors"
 )
 
+// TODO: add a "check" field to all results so that they can be linked to a check.
+// TODO(#1874): Add a severity field in all results.
+
 var errorInvalidType = errors.New("invalid type")
 
 // Flat JSON structure to hold raw results.

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -141,7 +141,7 @@ func (r *ScorecardResult) AsString(showDetails bool, logLevel log.Level,
 	checkDocs checks.Doc, writer io.Writer,
 ) error {
 	data := make([][]string, len(r.Checks))
-	//nolint
+
 	for i, row := range r.Checks {
 		const withdetails = 5
 		const withoutdetails = 4


### PR DESCRIPTION
Using a `type` for the dangerous workflow results. This will avoid updating the structure/BQ table every time we add a new type of check.

Note: need https://github.com/ossf/scorecard/pull/1864 to be merged

```release-notes
Update raw format for Dangerous workflows
```