### PR TITLE
🐛 Propagate error in log

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -158,6 +158,6 @@ func rootCmd(o *options.Options) {
 		pol,
 	)
 	if resultsErr != nil {
-		log.Panicf("Failed to output results: %v", err)
+		log.Panicf("Failed to format results: %v", resultsErr)
 	}
 }


### PR DESCRIPTION
Propagate error in log
```release-notes
Propagate error in log
```