### PR TITLE
🐛 Ignore shell parsing errors when reporting results

### DIFF
--- a/checks/cii_best_practices.go
+++ b/checks/cii_best_practices.go
@@ -24,7 +24,6 @@ import (
 // CheckCIIBestPractices is the registered name for CIIBestPractices.
 const CheckCIIBestPractices = "CII-Best-Practices"
 
-
 //nolint:gochecknoinits
 func init() {
 	if err := registerCheck(CheckCIIBestPractices, CIIBestPractices, nil); err != nil {

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -236,14 +236,6 @@ func createReturnForIsShellScriptFreeOfInsecureDownloads(r pinnedResult,
 		dl, err)
 }
 
-func testValidateShellScriptIsFreeOfInsecureDownloads(pathfn string,
-	content []byte, dl checker.DetailLogger,
-) (int, error) {
-	var r pinnedResult
-	_, err := validateShellScriptIsFreeOfInsecureDownloads(pathfn, content, dl, &r)
-	return createReturnForIsShellScriptFreeOfInsecureDownloads(r, dl, err)
-}
-
 var validateShellScriptIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFileContent = func(
 	pathfn string,
 	content []byte,
@@ -292,14 +284,6 @@ func createReturnForIsDockerfileFreeOfInsecureDownloads(r pinnedResult,
 	return createReturnValues(r,
 		"no insecure (not pinned by hash) dependency downloads found in Dockerfiles",
 		dl, err)
-}
-
-func testValidateDockerfileIsFreeOfInsecureDownloads(pathfn string,
-	content []byte, dl checker.DetailLogger,
-) (int, error) {
-	var r pinnedResult
-	_, err := validateDockerfileIsFreeOfInsecureDownloads(pathfn, content, dl, &r)
-	return createReturnForIsDockerfileFreeOfInsecureDownloads(r, dl, err)
 }
 
 func isDockerfile(pathfn string, content []byte) bool {
@@ -400,12 +384,6 @@ func createReturnForIsDockerfilePinned(r pinnedResult, dl checker.DetailLogger, 
 	return createReturnValues(r,
 		"Dockerfile dependencies are pinned",
 		dl, err)
-}
-
-func testValidateDockerfileIsPinned(pathfn string, content []byte, dl checker.DetailLogger) (int, error) {
-	var r pinnedResult
-	_, err := validateDockerfileIsPinned(pathfn, content, dl, &r)
-	return createReturnForIsDockerfilePinned(r, dl, err)
 }
 
 var validateDockerfileIsPinned fileparser.DoWhileTrueOnFileContent = func(
@@ -542,14 +520,6 @@ func createReturnForIsGitHubWorkflowScriptFreeOfInsecureDownloads(r pinnedResult
 		dl, err)
 }
 
-func testValidateGitHubWorkflowScriptFreeOfInsecureDownloads(pathfn string,
-	content []byte, dl checker.DetailLogger,
-) (int, error) {
-	var r pinnedResult
-	_, err := validateGitHubWorkflowIsFreeOfInsecureDownloads(pathfn, content, dl, &r)
-	return createReturnForIsGitHubWorkflowScriptFreeOfInsecureDownloads(r, dl, err)
-}
-
 // validateGitHubWorkflowIsFreeOfInsecureDownloads checks if the workflow file downloads dependencies that are unpinned.
 // Returns true if the check should continue executing after this file.
 var validateGitHubWorkflowIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFileContent = func(
@@ -652,12 +622,6 @@ func createReturnForIsGitHubActionsWorkflowPinned(r worklowPinningResult, dl che
 	return createReturnValuesForGitHubActionsWorkflowPinned(r,
 		"actions are pinned",
 		dl, err)
-}
-
-func testIsGitHubActionsWorkflowPinned(pathfn string, content []byte, dl checker.DetailLogger) (int, error) {
-	var r worklowPinningResult
-	_, err := validateGitHubActionWorkflow(pathfn, content, dl, &r)
-	return createReturnForIsGitHubActionsWorkflowPinned(r, dl, err)
 }
 
 func generateOwnerToDisplay(gitHubOwned bool) string {

--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -1115,6 +1115,17 @@ func TestShellScriptDownload(t *testing.T) {
 				NumberOfDebug: 0,
 			},
 		},
+		{
+			name:     "invalid shell script",
+			filename: "./testdata/script-invalid.sh",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  1,
+				NumberOfDebug: 1,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
@@ -1613,4 +1624,40 @@ func Test_maxScore(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testValidateShellScriptIsFreeOfInsecureDownloads(pathfn string,
+	content []byte, dl checker.DetailLogger,
+) (int, error) {
+	var r pinnedResult
+	_, err := validateShellScriptIsFreeOfInsecureDownloads(pathfn, content, dl, &r)
+	return createReturnForIsShellScriptFreeOfInsecureDownloads(r, dl, err)
+}
+
+func testValidateDockerfileIsFreeOfInsecureDownloads(pathfn string,
+	content []byte, dl checker.DetailLogger,
+) (int, error) {
+	var r pinnedResult
+	_, err := validateDockerfileIsFreeOfInsecureDownloads(pathfn, content, dl, &r)
+	return createReturnForIsDockerfileFreeOfInsecureDownloads(r, dl, err)
+}
+
+func testValidateDockerfileIsPinned(pathfn string, content []byte, dl checker.DetailLogger) (int, error) {
+	var r pinnedResult
+	_, err := validateDockerfileIsPinned(pathfn, content, dl, &r)
+	return createReturnForIsDockerfilePinned(r, dl, err)
+}
+
+func testValidateGitHubWorkflowScriptFreeOfInsecureDownloads(pathfn string,
+	content []byte, dl checker.DetailLogger,
+) (int, error) {
+	var r pinnedResult
+	_, err := validateGitHubWorkflowIsFreeOfInsecureDownloads(pathfn, content, dl, &r)
+	return createReturnForIsGitHubWorkflowScriptFreeOfInsecureDownloads(r, dl, err)
+}
+
+func testIsGitHubActionsWorkflowPinned(pathfn string, content []byte, dl checker.DetailLogger) (int, error) {
+	var r worklowPinningResult
+	_, err := validateGitHubActionWorkflow(pathfn, content, dl, &r)
+	return createReturnForIsGitHubActionsWorkflowPinned(r, dl, err)
 }

--- a/checks/shell_download_validate.go
+++ b/checks/shell_download_validate.go
@@ -17,7 +17,6 @@ package checks
 import (
 	"bufio"
 	"bytes"
-	"errors"
 	"fmt"
 	"net/url"
 	"path"
@@ -599,8 +598,8 @@ func isChocoUnpinnedDownload(cmd []string) bool {
 		str := parts[0]
 
 		if strings.EqualFold(str, "--requirechecksum") ||
-		  strings.EqualFold(str, "--requirechecksums") ||
-		  strings.EqualFold(str, "--require-checksums") {
+			strings.EqualFold(str, "--requirechecksums") ||
+			strings.EqualFold(str, "--require-checksums") {
 			return false
 		}
 	}
@@ -995,12 +994,11 @@ func validateShellFile(pathfn string, startLine, endLine uint,
 	content []byte, taintedFiles map[string]bool, dl checker.DetailLogger,
 ) (bool, error) {
 	r, err := validateShellFileAndRecord(pathfn, startLine, endLine, content, taintedFiles, dl)
-	if err != nil && errors.Is(err, sce.ErrorShellParsing) {
-		// Discard and print this particular error for now.
+	if err != nil {
+		// Print this particular error.
 		dl.Debug(&checker.LogMessage{
 			Text: err.Error(),
 		})
-		err = nil
 	}
 	return r, err
 }

--- a/checks/shell_download_validate_test.go
+++ b/checks/shell_download_validate_test.go
@@ -101,7 +101,7 @@ func TestValidateShellFile(t *testing.T) {
 	}
 	dl := scut.TestDetailLogger{}
 	_, err = validateShellFile(filename, 0, 0, content, map[string]bool{}, &dl)
-	if err != nil {
-		t.Errorf("failed to discard shell parsing error: %v", err)
+	if err == nil {
+		t.Errorf("failed to detect shell parsing error: %v", err)
 	}
 }


### PR DESCRIPTION
Ignore shell parsing errors when reporting results
no breaking changes
```release-notes
Ignore shell parsing errors when reporting results
```

closes https://github.com/ossf/scorecard/issues/1876