### PR TITLE
🐛 Fix `scorecard version` not showing build info

### DIFF
--- a/scripts/version-ldflags
+++ b/scripts/version-ldflags
@@ -23,5 +23,5 @@ GIT_HASH=$(git rev-parse HEAD)
 # https://mirrors.edge.kernel.org/pub/software/scm/git/docs/git-log.html
 SOURCE_DATE_EPOCH=$(git log --date=iso8601-strict -1 --pretty=%ct)
 GIT_TREESTATE=$(if git diff --quiet; then echo "clean"; else echo "dirty"; fi)
-PKG=$(go list -m | head -n1)/pkg
+PKG=sigs.k8s.io/release-utils/version
 echo "-X $PKG.gitVersion=$GIT_VERSION -X $PKG.gitCommit=$GIT_HASH -X $PKG.gitTreeState=$GIT_TREESTATE -X $PKG.buildDate=$SOURCE_DATE_EPOCH -w -extldflags \"-static\""


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Bug fix the issue where `scorecard version` was not showing any build info. We were relying on `k8s/release-utils` for this but build info is only available through the binaries that invoke them.

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
NONE
For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
