### PR TITLE
✨ Add support for Phabricator as a code review system

### DIFF
--- a/checks/code_review_test.go
+++ b/checks/code_review_test.go
@@ -187,6 +187,51 @@ func TestCodereview(t *testing.T) {
 				Score: 5,
 			},
 		},
+		{
+			name: "Valid Phabricator commit",
+			commits: []clients.Commit{
+				{
+					SHA: "sha",
+					Committer: clients.User{
+						Login: "bob",
+					},
+					Message: "Title\nReviewed By: alice\nDifferential Revision: PHAB234",
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 10,
+			},
+		},
+		{
+			name: "Phabricator like, missing differential",
+			commits: []clients.Commit{
+				{
+					SHA: "sha",
+					Committer: clients.User{
+						Login: "bob",
+					},
+					Message: "Title\nReviewed By: alice",
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 0,
+			},
+		},
+		{
+			name: "Phabricator like, missing reviewed by",
+			commits: []clients.Commit{
+				{
+					SHA: "sha",
+					Committer: clients.User{
+						Login: "bob",
+					},
+					Message: "Title\nDifferential Revision: PHAB234",
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 0,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/checks/evaluation/code_review.go
+++ b/checks/evaluation/code_review.go
@@ -203,7 +203,8 @@ func isReviewedOnPhabricator(c *checker.DefaultBranchCommit, dl checker.DetailLo
 	}
 
 	m := c.CommitMessage
-	if strings.Contains(m, "\nReviewed By: ") {
+	if strings.Contains(m, "\nDifferential Revision: ") &&
+		strings.Contains(m, "\nReviewed By: ") {
 		dl.Debug(&checker.LogMessage{
 			Text: fmt.Sprintf("commit %s was approved through %s", c.SHA, reviewPlatformPhabricator),
 		})

--- a/checks/evaluation/code_review.go
+++ b/checks/evaluation/code_review.go
@@ -23,9 +23,10 @@ import (
 )
 
 var (
-	reviewPlatformGitHub = "GitHub"
-	reviewPlatformProw   = "Prow"
-	reviewPlatformGerrit = "Gerrit"
+	reviewPlatformGitHub      = "GitHub"
+	reviewPlatformProw        = "Prow"
+	reviewPlatformGerrit      = "Gerrit"
+	reviewPlatformPhabricator = "Phabricator"
 )
 
 // CodeReview applies the score policy for the Code-Review check.
@@ -42,10 +43,11 @@ func CodeReview(name string, dl checker.DetailLogger,
 	}
 
 	totalReviewed := map[string]int{
-		// The 3 platforms we support.
-		reviewPlatformGitHub: 0,
-		reviewPlatformProw:   0,
-		reviewPlatformGerrit: 0,
+		// The 4 platforms we support.
+		reviewPlatformGitHub:      0,
+		reviewPlatformProw:        0,
+		reviewPlatformGerrit:      0,
+		reviewPlatformPhabricator: 0,
 	}
 
 	for i := range r.DefaultBranchCommits {
@@ -64,7 +66,8 @@ func CodeReview(name string, dl checker.DetailLogger,
 
 	if totalReviewed[reviewPlatformGitHub] == 0 &&
 		totalReviewed[reviewPlatformGerrit] == 0 &&
-		totalReviewed[reviewPlatformProw] == 0 {
+		totalReviewed[reviewPlatformProw] == 0 &&
+		totalReviewed[reviewPlatformPhabricator] == 0 {
 		return checker.CreateMinScoreResult(name, "no reviews found")
 	}
 
@@ -111,6 +114,9 @@ func getApprovedReviewSystem(c *checker.DefaultBranchCommit, dl checker.DetailLo
 
 	case isReviewedOnGerrit(c, dl):
 		return reviewPlatformGerrit
+
+	case isReviewedOnPhabricator(c, dl):
+		return reviewPlatformPhabricator
 	}
 
 	return ""
@@ -182,6 +188,24 @@ func isReviewedOnGerrit(c *checker.DefaultBranchCommit, dl checker.DetailLogger)
 		strings.Contains(m, "\nReviewed-by: ") {
 		dl.Debug(&checker.LogMessage{
 			Text: fmt.Sprintf("commit %s was approved through %s", c.SHA, reviewPlatformGerrit),
+		})
+		return true
+	}
+	return false
+}
+
+func isReviewedOnPhabricator(c *checker.DefaultBranchCommit, dl checker.DetailLogger) bool {
+	if isBot(c.Committer.Login) {
+		dl.Debug(&checker.LogMessage{
+			Text: fmt.Sprintf("skip commit %s from bot account: %s", c.SHA, c.Committer.Login),
+		})
+		return true
+	}
+
+	m := c.CommitMessage
+	if strings.Contains(m, "\nReviewed By: ") {
+		dl.Debug(&checker.LogMessage{
+			Text: fmt.Sprintf("commit %s was approved through %s", c.SHA, reviewPlatformPhabricator),
 		})
 		return true
 	}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Supports the "Reviewed By" field used by Phabricator to check if a repo uses Phabricator as their code review system.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Repos that use Phabricator are marked as not requiring code review.

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #1883

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Repositories using Phabricator will now pass the Code review check.
```
