### PR TITLE
🐛 Fix bug in Scorecard tag Docker image creation

### DIFF
--- a/cloudbuild/scorecard-tag.yaml
+++ b/cloudbuild/scorecard-tag.yaml
@@ -13,12 +13,28 @@
 # limitations under the License.
 
 steps:
-- id: 'Get Git history'
-  name: 'gcr.io/cloud-builders/git'
-  args: ['fetch', '--unshallow', '--tags', 'origin', '$COMMIT_SHA']
-- name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '.',
-    '-t', 'gcr.io/openssf/scorecard:stable',
-    '-t', 'gcr.io/openssf/scorecard:$TAG_NAME',
-    '-f', 'Dockerfile']
+  - id: Get Git history
+    name: gcr.io/cloud-builders/git
+    args:
+      - fetch
+      - '--unshallow'
+      - '--tags'
+      - origin
+      - $COMMIT_SHA
+  - id: Get tag commit
+    name: gcr.io/cloud-builders/git
+    entrypoint: bash
+    args:
+      - '-c'
+      - >-
+        git rev-list -n 1 tags/$TAG_NAME > /workspace/commit-sha.txt
+  - id: Push docker tag
+    name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - '-c'
+      - >-
+        docker pull gcr.io/openssf/scorecard:$(cat /workspace/commit-sha.txt) &&
+        docker tag gcr.io/openssf/scorecard:$(cat /workspace/commit-sha.txt) gcr.io/openssf/scorecard:$TAG_NAME &&
+        docker push gcr.io/openssf/scorecard:$TAG_NAME
 images: ['gcr.io/openssf/scorecard']


### PR DESCRIPTION
#### What kind of change does this PR introduce?

There is a bug in how we generate Docker images for new tags (like v4.2.0). Currently we tag HEAD as the latest tag irrespective of which commit the tag it applied to. This PR fixes that.

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Bug fix in Docker image creation
```
