### PR TITLE
:warning: Removing the confidence field from `CheckResult` struct

### DIFF
--- a/checker/check_result.go
+++ b/checker/check_result.go
@@ -79,10 +79,9 @@ const (
 // nolint:govet
 type CheckResult struct {
 	// TODO(#1393): Remove old structure after deprecation.
-	Name       string
-	Details    []string
-	Confidence int
-	Pass       bool
+	Name    string
+	Details []string
+	Pass    bool
 
 	// UPGRADEv2: New structure. Omitting unchanged Name field
 	// for simplicity.
@@ -173,8 +172,7 @@ func CreateResultWithScore(name, reason string, score int) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Confidence: MaxResultScore,
-		Pass:       pass,
+		Pass: pass,
 		// New structure.
 		Version: 2,
 		Error:   nil,
@@ -197,8 +195,7 @@ func CreateProportionalScoreResult(name, reason string, b, t int) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Confidence: MaxResultConfidence,
-		Pass:       pass,
+		Pass: pass,
 		// New structure.
 		Version: 2,
 		Error:   nil,
@@ -228,8 +225,7 @@ func CreateInconclusiveResult(name, reason string) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Confidence: 0,
-		Pass:       false,
+		Pass: false,
 		// New structure.
 		Version: 2,
 		Score:   InconclusiveResultScore,
@@ -242,8 +238,7 @@ func CreateRuntimeErrorResult(name string, e error) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Confidence: 0,
-		Pass:       false,
+		Pass: false,
 		// New structure.
 		Version: 2,
 		Error:   e,

--- a/cron/format/json.go
+++ b/cron/format/json.go
@@ -96,8 +96,7 @@ func AsJSON(r *pkg.ScorecardResult, showDetails bool, logLevel log.Level, writer
 	//nolint
 	for _, checkResult := range r.Checks {
 		tmpResult := jsonCheckResult{
-			Name:       checkResult.Name,
-			Confidence: checkResult.Confidence,
+			Name: checkResult.Name,
 		}
 		if showDetails {
 			for i := range checkResult.Details2 {

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -95,8 +95,7 @@ func (r *ScorecardResult) AsJSON(showDetails bool, logLevel log.Level, writer io
 	//nolint
 	for _, checkResult := range r.Checks {
 		tmpResult := jsonCheckResult{
-			Name:       checkResult.Name,
-			Confidence: checkResult.Confidence,
+			Name: checkResult.Name,
 		}
 		if showDetails {
 			for i := range checkResult.Details2 {


### PR DESCRIPTION
- Removing the confidence field from `CheckResult` struct
- https://github.com/ossf/scorecard/issues/1393

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Removing confidence from the CheckResult result.

```
