### PR TITLE
🐛 Remove Options that belong to the Action

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -28,22 +28,20 @@ import (
 
 // Options define common options for configuring scorecard.
 type Options struct {
-	Repo       string `env:"GITHUB_REPOSITORY"`
+	Repo       string
 	Local      string
-	Commit     string `env:"GITHUB_REF"`
+	Commit     string
 	LogLevel   string
-	Format     string `env:"SCORECARD_RESULTS_FORMAT"`
+	Format     string
 	NPM        string
 	PyPI       string
 	RubyGems   string
-	PolicyFile string `env:"SCORECARD_POLICY_FILE"`
+	PolicyFile string
 	// TODO(action): Add logic for writing results to file
-	ResultsFile string   `env:"SCORECARD_RESULTS_FILE"`
-	ChecksToRun []string `env:"SCORECARD_ENABLED_CHECKS"`
+	ResultsFile string
+	ChecksToRun []string
 	Metadata    []string
 	ShowDetails bool
-	// TODO(action): Add logic for determining if results should be published.
-	PublishResults bool `env:"SCORECARD_PUBLISH_RESULTS"`
 
 	// Feature flags.
 	EnableSarif       bool `env:"ENABLE_SARIF"`

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -37,7 +37,6 @@ func TestOptions_Validate(t *testing.T) {
 		ChecksToRun       []string
 		Metadata          []string
 		ShowDetails       bool
-		PublishResults    bool
 		EnableSarif       bool
 		EnableScorecardV5 bool
 		EnableScorecardV6 bool
@@ -106,7 +105,6 @@ func TestOptions_Validate(t *testing.T) {
 				ChecksToRun:       tt.fields.ChecksToRun,
 				Metadata:          tt.fields.Metadata,
 				ShowDetails:       tt.fields.ShowDetails,
-				PublishResults:    tt.fields.PublishResults,
 				EnableSarif:       tt.fields.EnableSarif,
 				EnableScorecardV5: tt.fields.EnableScorecardV5,
 				EnableScorecardV6: tt.fields.EnableScorecardV6,


### PR DESCRIPTION
See https://github.com/ossf/scorecard-action/issues/261
Remove Options that belong to the Action

```release-notes
Remove Options that belong to the Action
```