### PR TITLE
:warning: Remove the pass from the `CheckResult`

### DIFF
--- a/checker/check_result.go
+++ b/checker/check_result.go
@@ -28,18 +28,6 @@ type (
 )
 
 const (
-	// MaxResultConfidence implies full certainty about a check result.
-	// TODO(#1393): remove after deprecation.
-	MaxResultConfidence = 10
-	// HalfResultConfidence signifies uncertainty about a check's score.
-	// TODO(#1393): remove after deprecation.
-	HalfResultConfidence = 5
-	// MinResultConfidence signifies no confidence in the check result.
-	// TODO(#1393): remove after deprecation.
-	MinResultConfidence = 0
-	// TODO(#1393): remove after deprecation.
-	migrationThresholdPassValue = 8
-
 	// MaxResultScore is the best score that can be given by a check.
 	MaxResultScore = 10
 	// MinResultScore is the worst score that can be given by a check.
@@ -81,7 +69,6 @@ type CheckResult struct {
 	// TODO(#1393): Remove old structure after deprecation.
 	Name    string
 	Details []string
-	Pass    bool
 
 	// UPGRADEv2: New structure. Omitting unchanged Name field
 	// for simplicity.
@@ -165,14 +152,9 @@ func NormalizeReason(reason string, score int) string {
 // the check runs without runtime errors and we want to assign a
 // specific score.
 func CreateResultWithScore(name, reason string, score int) CheckResult {
-	pass := true
-	if score < migrationThresholdPassValue {
-		pass = false
-	}
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Pass: pass,
 		// New structure.
 		Version: 2,
 		Error:   nil,
@@ -187,15 +169,10 @@ func CreateResultWithScore(name, reason string, score int) CheckResult {
 // multiple tests and we want to assign a score proportional
 // the the number of tests that succeeded.
 func CreateProportionalScoreResult(name, reason string, b, t int) CheckResult {
-	pass := true
 	score := CreateProportionalScore(b, t)
-	if score < migrationThresholdPassValue {
-		pass = false
-	}
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Pass: pass,
 		// New structure.
 		Version: 2,
 		Error:   nil,
@@ -225,7 +202,6 @@ func CreateInconclusiveResult(name, reason string) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Pass: false,
 		// New structure.
 		Version: 2,
 		Score:   InconclusiveResultScore,
@@ -238,7 +214,6 @@ func CreateRuntimeErrorResult(name string, e error) CheckResult {
 	return CheckResult{
 		Name: name,
 		// Old structure.
-		Pass: false,
 		// New structure.
 		Version: 2,
 		Error:   e,


### PR DESCRIPTION
- Remove Pass field from CheckResult

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Removing the pass from CheckResult.

```
