### PR TITLE
🐛 Fix remediation code

### DIFF
--- a/checks/remediations.go
+++ b/checks/remediations.go
@@ -46,10 +46,13 @@ func remdiationSetup(c *checker.CheckRequest) error {
 	remediationOnce.Do(func() {
 		// Get the branch for remediation.
 		b, err := c.RepoClient.GetDefaultBranch()
-		if err != nil && !errors.Is(err, clients.ErrUnsupportedFeature) {
-			remediationSetupErr = err
+		if err != nil {
+			if !errors.Is(err, clients.ErrUnsupportedFeature) {
+				remediationSetupErr = err
+			}
 			return
 		}
+
 		if b.Name != nil {
 			remediationBranch = *b.Name
 			uri := c.Repo.URI()


### PR DESCRIPTION
Fix remediation code. The if statement was incorrect: we were not returning in case there was an error. `b` was nil in this case and caused a nil pointer.

```release-notes
Fix remediation code
```

closes https://github.com/ossf/scorecard/issues/1942