### PR TITLE
✨ Silence scorecard warning

### DIFF
--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -14,10 +14,7 @@
 
 name: publishimage
 
-permissions:
-  contents: read
-  id-token: write
-  packages: write
+permissions: read-all
 
 on:
   push:
@@ -30,6 +27,10 @@ jobs:
   unit-test:
     name: publishimage
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+      packages: write
     env:
       COSIGN_EXPERIMENTAL: "true"
     steps:


### PR DESCRIPTION
Scorecard complains because the top level permissions are not set to read.
Ill tackle this false positive as part of https://github.com/ossf/scorecard/issues/1874