### PR TITLE
🐛 Fix bug in `docker run scorecard version`

### DIFF
--- a/cloudbuild/scorecard-tag.yaml
+++ b/cloudbuild/scorecard-tag.yaml
@@ -15,26 +15,13 @@
 steps:
   - id: Get Git history
     name: gcr.io/cloud-builders/git
-    args:
-      - fetch
-      - '--unshallow'
-      - '--tags'
-      - origin
-      - $COMMIT_SHA
+    args: ['fetch', '--unshallow', '--tags', 'origin', '$COMMIT_SHA']
   - id: Get tag commit
     name: gcr.io/cloud-builders/git
-    entrypoint: bash
-    args:
-      - '-c'
-      - >-
-        git rev-list -n 1 tags/$TAG_NAME > /workspace/commit-sha.txt
-  - id: Push docker tag
-    name: gcr.io/cloud-builders/docker
-    entrypoint: bash
-    args:
-      - '-c'
-      - >-
-        docker pull gcr.io/openssf/scorecard:$(cat /workspace/commit-sha.txt) &&
-        docker tag gcr.io/openssf/scorecard:$(cat /workspace/commit-sha.txt) gcr.io/openssf/scorecard:$TAG_NAME &&
-        docker push gcr.io/openssf/scorecard:$TAG_NAME
+    args: ['checkout', '$TAG_NAME']
+  - name: gcr.io/cloud-builders/docker
+    args: [ 'build', '.',
+      '-t', 'gcr.io/openssf/scorecard:$COMMIT_SHA',
+      '-t', 'gcr.io/openssf/scorecard:$TAG_NAME',
+      '-f', 'Dockerfile']
 images: ['gcr.io/openssf/scorecard']


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Currently CloudBuild simply tags the Docker image with the version (e.g v4.3.1). But we also need to re-build this Docker image before tagging it so that `scorecard version` command returns the right value.

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Fix bug in docker run scorecard version
```
