### PR TITLE
✨ Use crane to add hash suggestion to unpinned Docker images

### DIFF
--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -136,10 +136,17 @@ func PinningDependencies(name string, dl checker.DetailLogger,
 }
 
 func generateRemediation(rr *checker.Dependency) *checker.Remediation {
-	if rr.Type == checker.DependencyUseTypeGHAction {
+	switch rr.Type {
+	case checker.DependencyUseTypeGHAction:
 		return remediation.CreateWorkflowPinningRemediation(rr.Location.Path)
+	case checker.DependencyUseTypeDockerfileContainerImage:
+		if rr.Name == nil {
+			return nil
+		}
+		return remediation.CreateDockerfilePinningRemediation(*rr.Name)
+	default:
+		return nil
 	}
-	return nil
 }
 
 func updatePinningResults(rr *checker.Dependency,

--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/google/go-containerregistry/pkg/crane"
+
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/checks/fileparser"
 	sce "github.com/ossf/scorecard/v4/errors"
@@ -172,6 +173,7 @@ func generateText(rr *checker.Dependency) string {
 		if hash, err := crane.Digest(*rr.Name); err == nil { // if NO error
 			return fmt.Sprintf("%s not pinned by hash. Fix by updating %[2]s to %[2]s@%s", rr.Type, *rr.Name, hash)
 		}
+	default:
 	}
 	return fmt.Sprintf("%s not pinned by hash", rr.Type)
 }

--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -159,18 +159,20 @@ func updatePinningResults(rr *checker.Dependency,
 }
 
 func generateText(rr *checker.Dependency) string {
-	if rr.Type == checker.DependencyUseTypeGHAction {
+	switch rr.Type {
+	case checker.DependencyUseTypeGHAction:
 		// Check if we are dealing with a GitHub action or a third-party one.
 		gitHubOwned := fileparser.IsGitHubOwnedAction(rr.Location.Snippet)
 		owner := generateOwnerToDisplay(gitHubOwned)
 		return fmt.Sprintf("%s %s not pinned by hash", owner, rr.Type)
-	} else if rr.Type == checker.DependencyUseTypeDockerfileContainerImage {
-		hash, err := crane.Digest(*rr.Name)
-		if err == nil {
+	case checker.DependencyUseTypeDockerfileContainerImage:
+		if rr.Name == nil {
+			break
+		}
+		if hash, err := crane.Digest(*rr.Name); err == nil { // if NO error
 			return fmt.Sprintf("%s not pinned by hash. Fix by updating %[2]s to %[2]s@%s", rr.Type, *rr.Name, hash)
 		}
 	}
-
 	return fmt.Sprintf("%s not pinned by hash", rr.Type)
 }
 

--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/google/go-containerregistry/pkg/crane"
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/checks/fileparser"
 	sce "github.com/ossf/scorecard/v4/errors"
@@ -163,6 +164,11 @@ func generateText(rr *checker.Dependency) string {
 		gitHubOwned := fileparser.IsGitHubOwnedAction(rr.Location.Snippet)
 		owner := generateOwnerToDisplay(gitHubOwned)
 		return fmt.Sprintf("%s %s not pinned by hash", owner, rr.Type)
+	} else if rr.Type == checker.DependencyUseTypeDockerfileContainerImage {
+		hash, err := crane.Digest(*rr.Name)
+		if err == nil {
+			return fmt.Sprintf("%s not pinned by hash. Fix by updating %[2]s to %[2]s@%s", rr.Type, *rr.Name, hash)
+		}
 	}
 
 	return fmt.Sprintf("%s not pinned by hash", rr.Type)

--- a/pkg/common.go
+++ b/pkg/common.go
@@ -32,16 +32,24 @@ func DetailToString(d *checker.CheckDetail, logLevel log.Level) string {
 		return ""
 	}
 
-	switch {
-	case d.Msg.Path != "" && d.Msg.Offset != 0 && d.Msg.EndOffset != 0 && d.Msg.Offset < d.Msg.EndOffset:
-		return fmt.Sprintf("%s: %s: %s:%d-%d", typeToString(d.Type), d.Msg.Text, d.Msg.Path, d.Msg.Offset, d.Msg.EndOffset)
-	case d.Msg.Path != "" && d.Msg.Offset != 0:
-		return fmt.Sprintf("%s: %s: %s:%d", typeToString(d.Type), d.Msg.Text, d.Msg.Path, d.Msg.Offset)
-	case d.Msg.Path != "" && d.Msg.Offset == 0:
-		return fmt.Sprintf("%s: %s: %s", typeToString(d.Type), d.Msg.Text, d.Msg.Path)
-	default:
-		return fmt.Sprintf("%s: %s", typeToString(d.Type), d.Msg.Text)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s: %s", typeToString(d.Type), d.Msg.Text))
+
+	if d.Msg.Path != "" {
+		sb.WriteString(fmt.Sprintf(": %s", d.Msg.Path))
+		if d.Msg.Offset != 0 {
+			sb.WriteString(fmt.Sprintf(":%d", d.Msg.Offset))
+		}
+		if d.Msg.EndOffset != 0 && d.Msg.Offset < d.Msg.EndOffset {
+			sb.WriteString(fmt.Sprintf("-%d", d.Msg.EndOffset))
+		}
 	}
+
+	if d.Msg.Remediation != nil {
+		sb.WriteString(fmt.Sprintf(": %s", d.Msg.Remediation.HelpText))
+	}
+
+	return sb.String()
 }
 
 func detailsToString(details []checker.CheckDetail, logLevel log.Level) (string, bool) {

--- a/pkg/common_test.go
+++ b/pkg/common_test.go
@@ -1,0 +1,144 @@
+// Copyright 2022 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkg
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/log"
+)
+
+func TestDetailString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		detail checker.CheckDetail
+		log    log.Level
+		want   string
+	}{
+		{
+			name: "ignoreDebug",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text: "should not appear",
+				},
+				Type: checker.DetailDebug,
+			},
+			log:  log.DefaultLevel,
+			want: "",
+		},
+		{
+			name: "includeDebug",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text: "should appear",
+				},
+				Type: checker.DetailDebug,
+			},
+			log:  log.DebugLevel,
+			want: "Debug: should appear",
+		},
+		{
+			name: "onlyType",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text: "some meaningful text",
+				},
+				Type: checker.DetailWarn,
+			},
+			log:  log.DefaultLevel,
+			want: "Warn: some meaningful text",
+		},
+		{
+			name: "displayPath",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text: "some meaningful text",
+					Path: "Dockerfile",
+				},
+				Type: checker.DetailWarn,
+			},
+			log:  log.DefaultLevel,
+			want: "Warn: some meaningful text: Dockerfile",
+		},
+		{
+			name: "displayStartOffset",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text:   "some meaningful text",
+					Path:   "Dockerfile",
+					Offset: 1,
+				},
+				Type: checker.DetailWarn,
+			},
+			log:  log.DefaultLevel,
+			want: "Warn: some meaningful text: Dockerfile:1",
+		},
+		{
+			name: "displayEndOffset",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text:      "some meaningful text",
+					Path:      "Dockerfile",
+					Offset:    1,
+					EndOffset: 7,
+				},
+				Type: checker.DetailWarn,
+			},
+			log:  log.DefaultLevel,
+			want: "Warn: some meaningful text: Dockerfile:1-7",
+		},
+		{
+			name: "ignoreInvalidEndOffset",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text:      "some meaningful text",
+					Path:      "Dockerfile",
+					Offset:    3,
+					EndOffset: 2,
+				},
+				Type: checker.DetailWarn,
+			},
+			log:  log.DefaultLevel,
+			want: "Warn: some meaningful text: Dockerfile:3",
+		},
+		{
+			name: "includeRemediation",
+			detail: checker.CheckDetail{
+				Msg: checker.LogMessage{
+					Text: "some meaningful text",
+					Path: "Dockerfile",
+					Remediation: &checker.Remediation{
+						HelpText: "fix x by doing y",
+					},
+				},
+				Type: checker.DetailWarn,
+			},
+			log:  log.DefaultLevel,
+			want: "Warn: some meaningful text: Dockerfile: fix x by doing y",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := DetailToString(&tt.detail, tt.log)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/remediation/remediations.go
+++ b/remediation/remediations.go
@@ -38,8 +38,8 @@ var errInvalidArg = errors.New("invalid argument")
 var (
 	workflowText = "update your workflow using https://app.stepsecurity.io/secureworkflow/%s/%s/%s?enable=%s"
 	//nolint
-	workflowMarkdown = "update your workflow using [https://app.stepsecurity.io](https://app.stepsecurity.io/secureworkflow/%s/%s/%s?enable=%s)"
-	dockerfileText   = "pin your Docker image (%[1]s). For linux/amd64 update to %[1]s@%s"
+	workflowMarkdown  = "update your workflow using [https://app.stepsecurity.io](https://app.stepsecurity.io/secureworkflow/%s/%s/%s?enable=%s)"
+	dockerfilePinText = "pin your Docker image by updating %[1]s to %[1]s@%s"
 )
 
 //nolint:gochecknoinits
@@ -108,7 +108,7 @@ func CreateDockerfilePinningRemediation(name *string) *checker.Remediation {
 		return nil
 	}
 
-	text := fmt.Sprintf(dockerfileText, *name, hash)
+	text := fmt.Sprintf(dockerfilePinText, *name, hash)
 	markdown := text
 
 	return &checker.Remediation{

--- a/remediation/remediations.go
+++ b/remediation/remediations.go
@@ -99,13 +99,16 @@ func createWorkflowRemediation(path, t string) *checker.Remediation {
 }
 
 // CreateDockerfilePinningRemediation create remediaiton for pinning Dockerfile images.
-func CreateDockerfilePinningRemediation(image string) *checker.Remediation {
-	hash, err := crane.Digest(image)
+func CreateDockerfilePinningRemediation(name *string) *checker.Remediation {
+	if name == nil {
+		return nil
+	}
+	hash, err := crane.Digest(*name)
 	if err != nil {
 		return nil
 	}
 
-	text := fmt.Sprintf(dockerfileText, image, hash)
+	text := fmt.Sprintf(dockerfileText, *name, hash)
 	markdown := text
 
 	return &checker.Remediation{

--- a/remediation/remediations.go
+++ b/remediation/remediations.go
@@ -20,6 +20,8 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/google/go-containerregistry/pkg/crane"
+
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/clients"
 )
@@ -37,6 +39,7 @@ var (
 	workflowText = "update your workflow using https://app.stepsecurity.io/secureworkflow/%s/%s/%s?enable=%s"
 	//nolint
 	workflowMarkdown = "update your workflow using [https://app.stepsecurity.io](https://app.stepsecurity.io/secureworkflow/%s/%s/%s?enable=%s)"
+	dockerfileText   = "pin your Docker image (%[1]s). For linux/amd64 update to %[1]s@%s"
 )
 
 //nolint:gochecknoinits
@@ -88,6 +91,22 @@ func createWorkflowRemediation(path, t string) *checker.Remediation {
 
 	text := fmt.Sprintf(workflowText, repo, p, branch, t)
 	markdown := fmt.Sprintf(workflowMarkdown, repo, p, branch, t)
+
+	return &checker.Remediation{
+		HelpText:     text,
+		HelpMarkdown: markdown,
+	}
+}
+
+// CreateDockerfilePinningRemediation create remediaiton for pinning Dockerfile images.
+func CreateDockerfilePinningRemediation(image string) *checker.Remediation {
+	hash, err := crane.Digest(image)
+	if err != nil {
+		return nil
+	}
+
+	text := fmt.Sprintf(dockerfileText, image, hash)
+	markdown := text
 
 	return &checker.Remediation{
 		HelpText:     text,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR attempts to address an enhancement in #967 

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

A warning is generated when a Docker dependency is not pinned.

> Warn: containerImage not pinned by hash: Dockerfile:1

#### What is the new behavior (if this is a feature change)?**

A hash is now provided, as determined by `crane`

> Warn: containerImage not pinned by hash. Fix by updating golang:1.17 to golang:1.17@sha256:e4d220556e80a686fad8874b40ccfa2f3172dfe5c6ca7f36f8ee79d594a9c959: Dockerfile:1

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #967 

#### Special notes for your reviewer

NONE

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

```release-note
Hash suggestions are now made for unpinned images in Dockerfiles
```
