### PR TITLE
🌱 Adjust 'exhaustive' linter to consider 'default' as exhaustive

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -81,6 +81,8 @@ linters-settings:
   errcheck:
     check-type-assertions: true
     check-blank: true
+  exhaustive:
+    default-signifies-exhaustive: true
   govet:
     enable:
       - fieldalignment

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -82,6 +82,7 @@ linters-settings:
     check-type-assertions: true
     check-blank: true
   exhaustive:
+    # https://golangci-lint.run/usage/linters/#exhaustive
     default-signifies-exhaustive: true
   govet:
     enable:


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Configuration change for `golangci-lint`. With the current linter settings, `default` is useless and satisfying the linter involves adding empty cases that clutter the code more than `default`. I realize this is subjective, but the current setting is overly cautious.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Switch statements on enums currently require cases for all enum members.

#### What is the new behavior (if this is a feature change)?**

`default` will satisfy the linter now. 

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
