### PR TITLE
✨ Add CODEOWNERS branch protection check

### DIFF
--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -134,7 +134,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  5,
+				NumberOfWarn:  6,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
@@ -172,8 +172,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  6,
-				NumberOfInfo:  8,
+				NumberOfWarn:  7,
+				NumberOfInfo:  9,
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
@@ -227,7 +227,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				Error:         nil,
 				Score:         8,
 				NumberOfWarn:  2,
-				NumberOfInfo:  12,
+				NumberOfInfo:  14,
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
@@ -280,7 +280,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  5,
+				NumberOfWarn:  6,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},

--- a/checks/evaluation/branch_protection.go
+++ b/checks/evaluation/branch_protection.go
@@ -435,7 +435,7 @@ func nonAdminThoroughReviewProtection(branch *clients.BranchRef, dl checker.Deta
 
 func codeownersBranchProtection(branch *clients.BranchRef, dl checker.DetailLogger) (int, int) {
 	score := 0
-	max := 0
+	max := 1
 
 	log := branch.Protected != nil && *branch.Protected
 

--- a/checks/evaluation/branch_protection.go
+++ b/checks/evaluation/branch_protection.go
@@ -108,7 +108,7 @@ func BranchProtection(name string, dl checker.DetailLogger,
 func computeNonAdminBasicScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.basic
 	}
 	return score
@@ -117,7 +117,7 @@ func computeNonAdminBasicScore(scores []levelScore) int {
 func computeAdminBasicScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.adminBasic
 	}
 	return score
@@ -126,7 +126,7 @@ func computeAdminBasicScore(scores []levelScore) int {
 func computeNonAdminReviewScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.review
 	}
 	return score
@@ -135,7 +135,7 @@ func computeNonAdminReviewScore(scores []levelScore) int {
 func computeAdminReviewScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.adminReview
 	}
 	return score
@@ -144,7 +144,7 @@ func computeAdminReviewScore(scores []levelScore) int {
 func computeNonAdminThoroughReviewScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.thoroughReview
 	}
 	return score
@@ -153,7 +153,7 @@ func computeNonAdminThoroughReviewScore(scores []levelScore) int {
 func computeAdminThoroughReviewScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.adminThoroughReview
 	}
 	return score
@@ -162,7 +162,7 @@ func computeAdminThoroughReviewScore(scores []levelScore) int {
 func computeNonAdminContextScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.context
 	}
 	return score
@@ -171,7 +171,7 @@ func computeNonAdminContextScore(scores []levelScore) int {
 func computeCodeownerThoroughReviewScore(scores []levelScore) int {
 	score := 0
 	for i := range scores {
-                s := scores[i]
+		s := scores[i]
 		score += s.scores.codeownerReview
 	}
 	return score
@@ -223,12 +223,13 @@ func computeScore(scores []levelScore) (int, error) {
 	}
 
 	// Fourth, check the thorough non-admin reviews.
-        // Also check whether this repo requires codeowner review
+	// Also check whether this repo requires codeowner review
 	maxThoroughReviewScore := maxScore.thoroughReview * len(scores)
 	maxCodeownerReviewScore := maxScore.codeownerReview * len(scores)
 	thoroughReviewScore := computeNonAdminThoroughReviewScore(scores)
 	codeownerReviewScore := computeCodeownerThoroughReviewScore(scores)
-	score += noarmalizeScore(thoroughReviewScore+codeownerReviewScore, maxThoroughReviewScore+maxCodeownerReviewScore, nonAdminThoroughReviewLevel)
+	score += noarmalizeScore(thoroughReviewScore+codeownerReviewScore, maxThoroughReviewScore+maxCodeownerReviewScore,
+		nonAdminThoroughReviewLevel)
 	if thoroughReviewScore != maxThoroughReviewScore {
 		return int(score), nil
 	}

--- a/checks/evaluation/branch_protection.go
+++ b/checks/evaluation/branch_protection.go
@@ -108,7 +108,8 @@ func BranchProtection(name string, dl checker.DetailLogger,
 
 func computeNonAdminBasicScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.basic
 	}
 	return score
@@ -116,7 +117,8 @@ func computeNonAdminBasicScore(scores []levelScore) int {
 
 func computeAdminBasicScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.adminBasic
 	}
 	return score
@@ -124,7 +126,8 @@ func computeAdminBasicScore(scores []levelScore) int {
 
 func computeNonAdminReviewScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.review
 	}
 	return score
@@ -132,7 +135,8 @@ func computeNonAdminReviewScore(scores []levelScore) int {
 
 func computeAdminReviewScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.adminReview
 	}
 	return score
@@ -140,7 +144,8 @@ func computeAdminReviewScore(scores []levelScore) int {
 
 func computeNonAdminThoroughReviewScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.thoroughReview
 	}
 	return score
@@ -148,7 +153,8 @@ func computeNonAdminThoroughReviewScore(scores []levelScore) int {
 
 func computeAdminThoroughReviewScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.adminThoroughReview
 	}
 	return score
@@ -156,7 +162,8 @@ func computeAdminThoroughReviewScore(scores []levelScore) int {
 
 func computeNonAdminContextScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.context
 	}
 	return score
@@ -164,7 +171,8 @@ func computeNonAdminContextScore(scores []levelScore) int {
 
 func computeCodeownerThoroughReviewScore(scores []levelScore) int {
 	score := 0
-	for _, s := range scores {
+	for i := range scores {
+                s := scores[i]
 		score += s.scores.codeownerReview
 	}
 	return score

--- a/checks/evaluation/branch_protection_test.go
+++ b/checks/evaluation/branch_protection_test.go
@@ -31,6 +31,7 @@ func testScore(branch *clients.BranchRef, dl checker.DetailLogger) (int, error) 
 	score.scores.context, score.maxes.context = nonAdminContextProtection(branch, dl)
 	score.scores.thoroughReview, score.maxes.thoroughReview = nonAdminThoroughReviewProtection(branch, dl)
 	score.scores.adminThoroughReview, score.maxes.adminThoroughReview = adminThoroughReviewProtection(branch, dl)
+	score.scores.codeownerReview, score.maxes.codeownerReview = codeownersBranchProtection(branch, dl)
 
 	return computeScore([]levelScore{score})
 }
@@ -52,7 +53,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  5,
+				NumberOfWarn:  6,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
@@ -96,7 +97,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  3,
+				NumberOfWarn:  4,
 				NumberOfInfo:  4,
 				NumberOfDebug: 0,
 			},
@@ -126,7 +127,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  4,
+				NumberOfWarn:  5,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
 			},
@@ -156,7 +157,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  4,
+				NumberOfWarn:  5,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
 			},
@@ -186,7 +187,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         3,
-				NumberOfWarn:  3,
+				NumberOfWarn:  4,
 				NumberOfInfo:  4,
 				NumberOfDebug: 0,
 			},
@@ -216,7 +217,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         2,
-				NumberOfWarn:  4,
+				NumberOfWarn:  5,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
 			},
@@ -246,7 +247,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         1,
-				NumberOfWarn:  5,
+				NumberOfWarn:  6,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
@@ -277,7 +278,7 @@ func TestIsBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         1,
-				NumberOfWarn:  5,
+				NumberOfWarn:  6,
 				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			},
@@ -308,7 +309,7 @@ func TestIsBranchProtected(t *testing.T) {
 				Error:         nil,
 				Score:         8,
 				NumberOfWarn:  1,
-				NumberOfInfo:  6,
+				NumberOfInfo:  7,
 				NumberOfDebug: 0,
 			},
 			branch: &clients.BranchRef{
@@ -327,6 +328,36 @@ func TestIsBranchProtected(t *testing.T) {
 					RequiredPullRequestReviews: clients.PullRequestReviewRule{
 						DismissStaleReviews:          &trueVal,
 						RequireCodeOwnerReviews:      &trueVal,
+						RequiredApprovingReviewCount: &oneVal,
+					},
+				},
+			},
+		},
+		{
+			name: "Branches are protected and require codeowner review",
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         8,
+				NumberOfWarn:  2,
+				NumberOfInfo:  6,
+				NumberOfDebug: 0,
+			},
+			branch: &clients.BranchRef{
+				Name:      &branchVal,
+				Protected: &trueVal,
+				BranchProtectionRule: clients.BranchProtectionRule{
+					EnforceAdmins:        &trueVal,
+					RequireLinearHistory: &trueVal,
+					AllowForcePushes:     &falseVal,
+					AllowDeletions:       &falseVal,
+					CheckRules: clients.StatusChecksRule{
+						RequiresStatusChecks: &falseVal,
+						UpToDateBeforeMerge:  &trueVal,
+						Contexts:             []string{"foo"},
+					},
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						DismissStaleReviews:          &trueVal,
+						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &oneVal,
 					},
 				},

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -65,7 +65,7 @@ certain workflows for branches, such as requiring review or passing certain
 status checks before acceptance into a main branch, or preventing rewriting of
 public history.
 
-Note: The following settings queried by the Branch-Protection check require an admin token: `DismissStaleReviews`, `EnforceAdmin`, and `StrictStatusCheck`. If
+Note: The following settings queried by the Branch-Protection check require an admin token: `DismissStaleReviews`, `EnforceAdmin`, `StrictStatusCheck` and `RequireCodeownerReview`. If
 the provided token does not have admin access, the check will query the branch
 settings accessible to non-admins and provide results based only on these settings.
 Even so, we recommend using a non-admin token, which provides a thorough enough
@@ -116,6 +116,9 @@ Tier 4 Requirements (9/10 points):
 
 Tier 5 Requirements (10/10 points):
   - For administrators: Dismiss stale reviews
+
+Extra Credit:
+  - Require CODEOWNER review
  
 
 **Remediation steps**

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -116,7 +116,7 @@ Tier 4 Requirements (9/10 points):
 
 Tier 5 Requirements (10/10 points):
   - For administrators: Dismiss stale reviews
-  - Require CODEOWNER review
+  - For administrators: Require CODEOWNER review
  
 
 **Remediation steps**
@@ -386,7 +386,7 @@ This check will only succeed if a Github project is >90 days old. Projects
 that are younger than this are too new to assess whether they are maintained
 or not, and users should inspect the contents of those projects to ensure they
 are as expected.
-
+ 
 
 **Remediation steps**
 - There is no remediation work needed from projects with a low score; this check simply provides insight into the project activity and maintenance commitment. External users should determine whether the software is the type that would not normally need active maintenance.

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -116,8 +116,6 @@ Tier 4 Requirements (9/10 points):
 
 Tier 5 Requirements (10/10 points):
   - For administrators: Dismiss stale reviews
-
-Extra Credit:
   - Require CODEOWNER review
  
 

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -153,7 +153,7 @@ checks:
       status checks before acceptance into a main branch, or preventing rewriting of
       public history.
 
-      Note: The following settings queried by the Branch-Protection check require an admin token: `DismissStaleReviews`, `EnforceAdmin`, and `StrictStatusCheck`. If
+      Note: The following settings queried by the Branch-Protection check require an admin token: `DismissStaleReviews`, `EnforceAdmin`, `StrictStatusCheck` and `RequireCodeownerReview`. If
       the provided token does not have admin access, the check will query the branch
       settings accessible to non-admins and provide results based only on these settings.
       Even so, we recommend using a non-admin token, which provides a thorough enough
@@ -204,6 +204,9 @@ checks:
       
       Tier 5 Requirements (10/10 points):
         - For administrators: Dismiss stale reviews
+
+      Extra Credit:
+        - Require CODEOWNER review
 
     remediation:
       - >-

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -204,8 +204,6 @@ checks:
       
       Tier 5 Requirements (10/10 points):
         - For administrators: Dismiss stale reviews
-
-      Extra Credit:
         - Require CODEOWNER review
 
     remediation:

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -204,7 +204,7 @@ checks:
       
       Tier 5 Requirements (10/10 points):
         - For administrators: Dismiss stale reviews
-        - Require CODEOWNER review
+        - For administrators: Require CODEOWNER review
 
     remediation:
       - >-

--- a/e2e/branch_protection_test.go
+++ b/e2e/branch_protection_test.go
@@ -48,7 +48,7 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 				Error:         nil,
 				Score:         6,
 				NumberOfWarn:  1,
-				NumberOfInfo:  3,
+				NumberOfInfo:  4,
 				NumberOfDebug: 3,
 			}
 			result := checks.BranchProtection(&req)
@@ -105,7 +105,7 @@ var _ = Describe("E2E TEST PAT:"+checks.CheckBranchProtection, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         1,
-				NumberOfWarn:  2,
+				NumberOfWarn:  3,
 				NumberOfInfo:  3,
 				NumberOfDebug: 3,
 			}


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Enhance Branch-Protection check to require CODEOWNER review.

This adds 'bonus points' to the Branch-Protection check, but doesn't detract from the score if it's not enabled.

#### What is the current behavior?
Today, the Branch-Protection check requires that code review must be completed before merge. In GitHub, CODEOWNERS can be assigned to subpaths in a. Without CODEOWNER review, anyone with write access to the repo can approve any PR. In large repos with many modules and many maintainers, CODEOWNERS allows maintainers to delegate code reviews and limit the scope of approval. 

#### What is the new behavior (if this is a feature change)?**
Added a unit test; updated existing unit tests.

#### Does this PR introduce a user-facing change?

```release-note
Scorecard will evaluate whether CODEOWNER review is required for protected branches.
```
