### PR TITLE
🐛 Bug fixing: Using the wrong URI to initialize the repo in Dependencydiff

### DIFF
--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -122,38 +122,36 @@ func getScorecardCheckResults(dCtx *dependencydiffContext) error {
 		}
 		// For now we skip those without source repo urls.
 		// TODO (#2063): use the BigQuery dataset to supplement null source repo URLs to fetch the Scorecard results for them.
-		if d.SourceRepository != nil && *d.SourceRepository != "" {
-			if d.ChangeType != nil {
-				if dCtx.changeTypesToCheck[*d.ChangeType] || dCtx.changeTypesToCheck == nil || len(dCtx.changeTypesToCheck) == 0 {
-					// Initialize the repo and client(s) corresponding to the checks to run.
-					// If no types have been specified, run checks on all types.
-					err = initRepoAndClientByChecks(dCtx, *d.SourceRepository)
-					if err != nil {
-						return fmt.Errorf("error initializing repo and clients: %w", err)
-					}
-					// Run scorecard on those types of dependencies that the caller would like to check.
-					// If the input map changeTypesToCheck is empty, by default, we run the checks for all valid types.
-					// TODO (#2064): use the Scorecare REST API to retrieve the Scorecard result statelessly.
-					scorecardResult, err := pkg.RunScorecards(
-						dCtx.ctx,
-						dCtx.ghRepo,
-						// TODO (#2065): In future versions, ideally, this should be
-						// the commitSHA corresponding to d.Version instead of HEAD.
-						clients.HeadSHA,
-						checksToRun,
-						dCtx.ghRepoClient,
-						dCtx.ossFuzzClient,
-						dCtx.ciiClient,
-						dCtx.vulnsClient,
-					)
-					// If the run fails, we leave the current dependency scorecard result empty and record the error
-					// rather than letting the entire API return nil since we still expect results for other dependencies.
-					if err != nil {
-						depCheckResult.ScorecardResultsWithError.Error = sce.WithMessage(sce.ErrScorecardInternal,
-							fmt.Sprintf("error running the scorecard checks: %v", err))
-					} else { // Otherwise, we record the scorecard check results for this dependency.
-						depCheckResult.ScorecardResultsWithError.ScorecardResults = &scorecardResult
-					}
+		if d.SourceRepository != nil && d.ChangeType != nil {
+			// Run the checks on all types if (1) the type is found in changeTypesToCheck or (2) no types are specified.
+			if dCtx.changeTypesToCheck[*d.ChangeType] || (dCtx.changeTypesToCheck == nil || len(dCtx.changeTypesToCheck) == 0) {
+				// Initialize the repo and client(s) corresponding to the checks to run.
+				err = initRepoAndClientByChecks(dCtx, *d.SourceRepository)
+				if err != nil {
+					return fmt.Errorf("error initializing repo and clients: %w", err)
+				}
+				// Run scorecard on those types of dependencies that the caller would like to check.
+				// If the input map changeTypesToCheck is empty, by default, we run the checks for all valid types.
+				// TODO (#2064): use the Scorecare REST API to retrieve the Scorecard result statelessly.
+				scorecardResult, err := pkg.RunScorecards(
+					dCtx.ctx,
+					dCtx.ghRepo,
+					// TODO (#2065): In future versions, ideally, this should be
+					// the commitSHA corresponding to d.Version instead of HEAD.
+					clients.HeadSHA,
+					checksToRun,
+					dCtx.ghRepoClient,
+					dCtx.ossFuzzClient,
+					dCtx.ciiClient,
+					dCtx.vulnsClient,
+				)
+				// If the run fails, we leave the current dependency scorecard result empty and record the error
+				// rather than letting the entire API return nil since we still expect results for other dependencies.
+				if err != nil {
+					depCheckResult.ScorecardResultsWithError.Error = sce.WithMessage(sce.ErrScorecardInternal,
+						fmt.Sprintf("error running the scorecard checks: %v", err))
+				} else { // Otherwise, we record the scorecard check results for this dependency.
+					depCheckResult.ScorecardResultsWithError.ScorecardResults = &scorecardResult
 				}
 			}
 		}

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -17,12 +17,10 @@ package dependencydiff
 import (
 	"context"
 	"fmt"
-	"path"
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/checks"
 	"github.com/ossf/scorecard/v4/clients"
-	"github.com/ossf/scorecard/v4/clients/githubrepo"
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/log"
 	"github.com/ossf/scorecard/v4/pkg"
@@ -69,10 +67,8 @@ func GetDependencyDiffResults(
 		return nil, fmt.Errorf("error in fetchRawDependencyDiffData: %w", err)
 	}
 
-	// Initialize the repo and client(s) corresponding to the checks to run.
-	err = initRepoAndClientByChecks(&dCtx)
 	if err != nil {
-		return nil, fmt.Errorf("error in initRepoAndClientByChecks: %w", err)
+		return nil, fmt.Errorf("error in initClientByChecks: %w", err)
 	}
 	err = getScorecardCheckResults(&dCtx)
 	if err != nil {
@@ -81,21 +77,20 @@ func GetDependencyDiffResults(
 	return dCtx.results, nil
 }
 
-func initRepoAndClientByChecks(dCtx *dependencydiffContext) error {
+func initRepoAndClientByChecks(dCtx *dependencydiffContext, dSrcRepo string) error {
 	repo, repoClient, ossFuzzClient, ciiClient, vulnsClient, err := checker.GetClients(
-		dCtx.ctx, path.Join(dCtx.ownerName, dCtx.repoName), "", dCtx.logger,
+		dCtx.ctx, dSrcRepo, "", dCtx.logger,
 	)
 	if err != nil {
-		return fmt.Errorf("error creating the github repo: %w", err)
-	}
-	// If the caller doesn't specify the checks to run, run all checks and return all the clients.
-	if dCtx.checkNamesToRun == nil || len(dCtx.checkNamesToRun) == 0 {
-		dCtx.ghRepo, dCtx.ghRepoClient, dCtx.ossFuzzClient, dCtx.ciiClient, dCtx.vulnsClient =
-			repo, repoClient, ossFuzzClient, ciiClient, vulnsClient
-		return nil
+		return fmt.Errorf("error getting the github repo and clients: %w", err)
 	}
 	dCtx.ghRepo = repo
-	dCtx.ghRepoClient = githubrepo.CreateGithubRepoClient(dCtx.ctx, dCtx.logger)
+	dCtx.ghRepoClient = repoClient
+	// If the caller doesn't specify the checks to run, run all the checks and return all the clients.
+	if dCtx.checkNamesToRun == nil || len(dCtx.checkNamesToRun) == 0 {
+		dCtx.ossFuzzClient, dCtx.ciiClient, dCtx.vulnsClient = ossFuzzClient, ciiClient, vulnsClient
+		return nil
+	}
 	for _, cn := range dCtx.checkNamesToRun {
 		switch cn {
 		case checks.CheckFuzzing:
@@ -128,29 +123,37 @@ func getScorecardCheckResults(dCtx *dependencydiffContext) error {
 		// For now we skip those without source repo urls.
 		// TODO (#2063): use the BigQuery dataset to supplement null source repo URLs to fetch the Scorecard results for them.
 		if d.SourceRepository != nil && *d.SourceRepository != "" {
-			if d.ChangeType != nil && (dCtx.changeTypesToCheck[*d.ChangeType] || dCtx.changeTypesToCheck == nil) {
-				// Run scorecard on those types of dependencies that the caller would like to check.
-				// If the input map changeTypesToCheck is empty, by default, we run checks for all valid types.
-				// TODO (#2064): use the Scorecare REST API to retrieve the Scorecard result statelessly.
-				scorecardResult, err := pkg.RunScorecards(
-					dCtx.ctx,
-					dCtx.ghRepo,
-					// TODO (#2065): In future versions, ideally, this should be
-					// the commitSHA corresponding to d.Version instead of HEAD.
-					clients.HeadSHA,
-					checksToRun,
-					dCtx.ghRepoClient,
-					dCtx.ossFuzzClient,
-					dCtx.ciiClient,
-					dCtx.vulnsClient,
-				)
-				// If the run fails, we leave the current dependency scorecard result empty and record the error
-				// rather than letting the entire API return nil since we still expect results for other dependencies.
-				if err != nil {
-					depCheckResult.ScorecardResultsWithError.Error = sce.WithMessage(sce.ErrScorecardInternal,
-						fmt.Sprintf("error running the scorecard checks: %v", err))
-				} else { // Otherwise, we record the scorecard check results for this dependency.
-					depCheckResult.ScorecardResultsWithError.ScorecardResults = &scorecardResult
+			if d.ChangeType != nil {
+				if dCtx.changeTypesToCheck[*d.ChangeType] || dCtx.changeTypesToCheck == nil {
+					// Initialize the repo and client(s) corresponding to the checks to run.
+					// If no types have been specified, run checks on all types.
+					err = initRepoAndClientByChecks(dCtx, *d.SourceRepository)
+					if err != nil {
+						return fmt.Errorf("error initializing repo and clients: %w", err)
+					}
+					// Run scorecard on those types of dependencies that the caller would like to check.
+					// If the input map changeTypesToCheck is empty, by default, we run the checks for all valid types.
+					// TODO (#2064): use the Scorecare REST API to retrieve the Scorecard result statelessly.
+					scorecardResult, err := pkg.RunScorecards(
+						dCtx.ctx,
+						dCtx.ghRepo,
+						// TODO (#2065): In future versions, ideally, this should be
+						// the commitSHA corresponding to d.Version instead of HEAD.
+						clients.HeadSHA,
+						checksToRun,
+						dCtx.ghRepoClient,
+						dCtx.ossFuzzClient,
+						dCtx.ciiClient,
+						dCtx.vulnsClient,
+					)
+					// If the run fails, we leave the current dependency scorecard result empty and record the error
+					// rather than letting the entire API return nil since we still expect results for other dependencies.
+					if err != nil {
+						depCheckResult.ScorecardResultsWithError.Error = sce.WithMessage(sce.ErrScorecardInternal,
+							fmt.Sprintf("error running the scorecard checks: %v", err))
+					} else { // Otherwise, we record the scorecard check results for this dependency.
+						depCheckResult.ScorecardResultsWithError.ScorecardResults = &scorecardResult
+					}
 				}
 			}
 		}

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -124,7 +124,8 @@ func getScorecardCheckResults(dCtx *dependencydiffContext) error {
 		// TODO (#2063): use the BigQuery dataset to supplement null source repo URLs to fetch the Scorecard results for them.
 		if d.SourceRepository != nil && d.ChangeType != nil {
 			// Run the checks on all types if (1) the type is found in changeTypesToCheck or (2) no types are specified.
-			if dCtx.changeTypesToCheck[*d.ChangeType] || (dCtx.changeTypesToCheck == nil || len(dCtx.changeTypesToCheck) == 0) {
+			noTypesGiven := dCtx.changeTypesToCheck == nil || len(dCtx.changeTypesToCheck) == 0
+			if dCtx.changeTypesToCheck[*d.ChangeType] || noTypesGiven {
 				// Initialize the repo and client(s) corresponding to the checks to run.
 				err = initRepoAndClientByChecks(dCtx, *d.SourceRepository)
 				if err != nil {

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -68,7 +68,7 @@ func GetDependencyDiffResults(
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("error in initClientByChecks: %w", err)
+		return nil, fmt.Errorf("error in initRepoAndClientByChecks: %w", err)
 	}
 	err = getScorecardCheckResults(&dCtx)
 	if err != nil {

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -124,7 +124,7 @@ func getScorecardCheckResults(dCtx *dependencydiffContext) error {
 		// TODO (#2063): use the BigQuery dataset to supplement null source repo URLs to fetch the Scorecard results for them.
 		if d.SourceRepository != nil && *d.SourceRepository != "" {
 			if d.ChangeType != nil {
-				if dCtx.changeTypesToCheck[*d.ChangeType] || dCtx.changeTypesToCheck == nil {
+				if dCtx.changeTypesToCheck[*d.ChangeType] || dCtx.changeTypesToCheck == nil || len(dCtx.changeTypesToCheck) == 0 {
 					// Initialize the repo and client(s) corresponding to the checks to run.
 					// If no types have been specified, run checks on all types.
 					err = initRepoAndClientByChecks(dCtx, *d.SourceRepository)

--- a/dependencydiff/dependencydiff_test.go
+++ b/dependencydiff/dependencydiff_test.go
@@ -71,22 +71,25 @@ func Test_initRepoAndClientByChecks(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
-		name                                       string
-		dCtx                                       dependencydiffContext
-		wantGhRepo, wantRepoClient, wantFuzzClient bool
-		wantVulnClient, wantCIIClient              bool
-		wantErr                                    bool
+		name                           string
+		dCtx                           dependencydiffContext
+		srcRepo                        string
+		wantRepoClient, wantFuzzClient bool
+		wantVulnClient, wantCIIClient  bool
+		wantErr                        bool
 	}{
 		{
 			name: "error creating repo",
 			dCtx: dependencydiffContext{
 				logger:          log.NewLogger(log.InfoLevel),
 				ctx:             context.Background(),
-				ownerName:       path.Join("host_not_exist.com", "owner_not_exist"),
-				repoName:        "repo_not_exist",
 				checkNamesToRun: []string{},
 			},
-			wantGhRepo:     false,
+			srcRepo: path.Join(
+				"host_not_exist.com",
+				"owner_not_exist",
+				"repo_not_exist",
+			),
 			wantRepoClient: false,
 			wantFuzzClient: false,
 			wantVulnClient: false,
@@ -99,13 +102,9 @@ func Test_initRepoAndClientByChecks(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := initRepoAndClientByChecks(&tt.dCtx)
+			err := initRepoAndClientByChecks(&tt.dCtx, tt.srcRepo)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("initRepoAndClientByChecks() error = {%v}, want error: %v", err, tt.wantErr)
-				return
-			}
-			if (tt.dCtx.ghRepo != nil) != tt.wantGhRepo {
-				t.Errorf("init repo error, wantGhRepo: %v, got %v", tt.wantGhRepo, tt.dCtx.ghRepo)
+				t.Errorf("initClientByChecks() error = {%v}, want error: %v", err, tt.wantErr)
 				return
 			}
 			if (tt.dCtx.ghRepoClient != nil) != tt.wantRepoClient {
@@ -151,12 +150,7 @@ func Test_getScorecardCheckResults(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			err := initRepoAndClientByChecks(&tt.dCtx)
-			if err != nil {
-				t.Errorf("init repo and client error")
-				return
-			}
-			err = getScorecardCheckResults(&tt.dCtx)
+			err := getScorecardCheckResults(&tt.dCtx)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getScorecardCheckResults() error = {%v}, want error: %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Fixing a bug introduced in PR #2046 where the `ghRepo` type of (clients.Repo) was created wrongly by the input `repoURI` rather than the dependency repoURI to be checked by scorecard.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The Dependencydiff module uses the input repo to initialize the `ghRepo` to run the scorecard check, resulting in all of the dependencies having the same check results and scores (of the input repo).

#### What is the new behavior (if this is a feature change)?**
The module will correctly initialize `ghRepo` using the dependency's srcRepo URI.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2046 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
No.

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
