### PR TITLE
✨ Enhancement: letting the ecosystem naming convention mapping log the missing entry info rather than returning an error, typo fixes

### DIFF
--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -79,32 +79,14 @@ func GetDependencyDiffResults(
 	if err != nil {
 		return nil, fmt.Errorf("error in fetchRawDependencyDiffData: %w", err)
 	}
-  // Map the ecosystem naming convention from GitHub to OSV.
-	err = mapDependencyEcosystemNaming(dCtx.dependencydiffs)
-	if err != nil {
-		return nil, fmt.Errorf("error in mapDependencyEcosystemNaming: %w", err)
-	}
+	// Map the ecosystem naming convention from GitHub to OSV.
+	mapDependencyEcosystemNaming(logger, dCtx.dependencydiffs)
+
 	err = getScorecardCheckResults(&dCtx)
 	if err != nil {
 		return nil, fmt.Errorf("error getting scorecard check results: %w", err)
 	}
 	return dCtx.results, nil
-}
-
-func mapDependencyEcosystemNaming(deps []dependency) error {
-	for i := range deps {
-		if deps[i].Ecosystem == nil {
-			continue
-		}
-		mappedEcosys, err := toEcosystem(*deps[i].Ecosystem)
-		if err != nil {
-			wrappedErr := fmt.Errorf("error mapping dependency ecosystem: %w", err)
-			return wrappedErr
-		}
-		deps[i].Ecosystem = asPointer(string(mappedEcosys))
-
-	}
-	return nil
 }
 
 func initRepoAndClientByChecks(dCtx *dependencydiffContext, dSrcRepo string) error {

--- a/dependencydiff/dependencydiff_test.go
+++ b/dependencydiff/dependencydiff_test.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/ossf/scorecard/v4/clients"
 	"github.com/ossf/scorecard/v4/log"
-	sclog "github.com/ossf/scorecard/v4/log"
 )
 
 // Test_fetchRawDependencyDiffData is a test function for fetchRawDependencyDiffData.
@@ -219,7 +218,7 @@ func Test_ecosystemMapping(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			mapDependencyEcosystemNaming(sclog.NewLogger(sclog.DefaultLevel), tt.deps)
+			mapDependencyEcosystemNaming(log.NewLogger(log.DefaultLevel), tt.deps)
 			for i, d := range tt.deps {
 				if d.Ecosystem != nil {
 					if *d.Ecosystem != tt.ecosystemWanted[i] {

--- a/dependencydiff/errors.go
+++ b/dependencydiff/errors.go
@@ -18,6 +18,7 @@ import "errors"
 
 // static Errors for mapping
 var (
-	errMappingNotFound = errors.New("ecosystem mapping not found")
-	errInvalid         = errors.New("invalid")
+	errMappingNotFound    = errors.New("ecosystem mapping not found")
+	errInvalid            = errors.New("invalid")
+	errMappingNotExpected = errors.New("mapping result not expected")
 )

--- a/dependencydiff/errors.go
+++ b/dependencydiff/errors.go
@@ -18,7 +18,6 @@ import "errors"
 
 // static Errors for mapping
 var (
-	errMappingNotFound    = errors.New("ecosystem mapping not found")
 	errInvalid            = errors.New("invalid")
 	errMappingNotExpected = errors.New("mapping result not expected")
 )


### PR DESCRIPTION
#### What kind of change does this PR introduce?
1. typo fixes
2. Letting the ecosystem naming convention mapping module no longer return an error. Instead, log the info when no mapping entries are found for an ecosystem name, so that missing one mapping won't cause the others to fail.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
If no mapping entries are found for an ecosystem name, it returns an error and terminates the subsequent mapping execution.

#### What is the new behavior (if this is a feature change)?**
The module logs the "mapping not found for dependency xxx" info instead of directly returning an error.

- [x] Tests for the changes have been added (for bug fixes/features)


#### Does this PR introduce a user-facing change?
No.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->
NONE
```release-note
NONE
```
