### PR TITLE
✨ Enhancement: Dependency-diff API optimization - changing the input param changeType from a map to an array

### DIFF
--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -93,11 +93,14 @@ func GetDependencyDiffResults(
 
 func mapDependencyEcosystemNaming(deps []dependency) error {
 	for i := range deps {
+		// Since we allow a dependency's ecosystem to be nil, so skip those nil ones and only map
+		// those valid ones.
 		if deps[i].Ecosystem == nil {
 			continue
 		}
 		mappedEcosys, err := toEcosystem(*deps[i].Ecosystem)
 		if err != nil {
+			//// Iff. the ecosystem is not empty and the mapping entry is not found, we will return an error.
 			wrappedErr := fmt.Errorf("error mapping dependency ecosystem: %w", err)
 			return wrappedErr
 		}

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -185,10 +185,6 @@ func getScorecardCheckResults(dCtx *dependencydiffContext) error {
 	return nil
 }
 
-func asPointer(s string) *string {
-	return &s
-}
-
 func isSpecifiedByUser(ct pkg.ChangeType, changeTypes []string) bool {
 	if len(changeTypes) == 0 {
 		return false

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -93,14 +93,11 @@ func GetDependencyDiffResults(
 
 func mapDependencyEcosystemNaming(deps []dependency) error {
 	for i := range deps {
-		// Since we allow a dependency's ecosystem to be nil, so skip those nil ones and only map
-		// those valid ones.
 		if deps[i].Ecosystem == nil {
 			continue
 		}
 		mappedEcosys, err := toEcosystem(*deps[i].Ecosystem)
 		if err != nil {
-			//// Iff. the ecosystem is not empty and the mapping entry is not found, we will return an error.
 			wrappedErr := fmt.Errorf("error mapping dependency ecosystem: %w", err)
 			return wrappedErr
 		}

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -55,7 +55,7 @@ func GetDependencyDiffResults(
 	repoURI string, /* Use the format "ownerName/repoName" as the repo URI, such as "ossf/scorecard". */
 	base, head string, /* Two code commits base and head, can use either SHAs or branch names. */
 	checksToRun []string, /* A list of enabled check names to run. */
-	changeTypesToCheck []string, /* A list of change types for which to surface scorecard results. */
+	changeTypes []string, /* A list of dependency change types for which we surface scorecard results. */
 ) ([]pkg.DependencyCheckResult, error) {
 
 	logger := sclog.NewLogger(sclog.DefaultLevel)
@@ -71,7 +71,7 @@ func GetDependencyDiffResults(
 		base:               base,
 		head:               head,
 		ctx:                ctx,
-		changeTypesToCheck: changeTypesToCheck,
+		changeTypesToCheck: changeTypes,
 		checkNamesToRun:    checksToRun,
 	}
 	// Fetch the raw dependency diffs. This API will also handle error cases such as invalid base or head.

--- a/dependencydiff/dependencydiff.go
+++ b/dependencydiff/dependencydiff.go
@@ -159,7 +159,7 @@ func getScorecardCheckResults(dCtx *dependencydiffContext) error {
 		}
 		// (1) If no change types are specified, run the checks on all types of dependencies.
 		// (2) If there are change types specified by the user, run the checks on the specified types.
-		noneGivenOrIsSpecified := (dCtx.changeTypesToCheck == nil || len(dCtx.changeTypesToCheck) == 0) || /* None specified.*/
+		noneGivenOrIsSpecified := len(dCtx.changeTypesToCheck) == 0 || /* None specified.*/
 			isSpecifiedByUser(*d.ChangeType, dCtx.changeTypesToCheck) /* Specified by the user.*/
 		// For now we skip those without source repo urls.
 		// TODO (#2063): use the BigQuery dataset to supplement null source repo URLs to fetch the Scorecard results for them.
@@ -206,7 +206,7 @@ func asPointer(s string) *string {
 }
 
 func isSpecifiedByUser(ct pkg.ChangeType, changeTypes []string) bool {
-	if changeTypes == nil || len(changeTypes) == 0 {
+	if len(changeTypes) == 0 {
 		return false
 	}
 	for _, ctByUser := range changeTypes {

--- a/dependencydiff/dependencydiff_test.go
+++ b/dependencydiff/dependencydiff_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/ossf/scorecard/v4/clients"
-	"github.com/ossf/scorecard/v4/log"
+	sclog "github.com/ossf/scorecard/v4/log"
 	"github.com/ossf/scorecard/v4/pkg"
 )
 

--- a/dependencydiff/dependencydiff_test.go
+++ b/dependencydiff/dependencydiff_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/clients"
 	"github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/pkg"
 )
 
 // Test_fetchRawDependencyDiffData is a test function for fetchRawDependencyDiffData.
@@ -217,6 +218,56 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 			err := mapDependencyEcosystemNaming(tt.deps)
 			if tt.errWanted != nil && errors.Is(tt.errWanted, err) {
 				t.Errorf("not a wanted error, want:%v, got:%v", tt.errWanted, err)
+				return
+			}
+		})
+	}
+}
+
+func Test_isSpecifiedByUser(t *testing.T) {
+	t.Parallel()
+	//nolint
+	tests := []struct {
+		name               string
+		ct                 pkg.ChangeType
+		changeTypesToCheck []string
+		resultWanted       bool
+	}{
+		{
+			name: "error invalid github ecosystem",
+		},
+		{
+			name:               "added",
+			ct:                 pkg.ChangeType("added"),
+			changeTypesToCheck: nil,
+			resultWanted:       false,
+		},
+		{
+			name:               "ct is added but not specified",
+			ct:                 pkg.ChangeType("added"),
+			changeTypesToCheck: []string{"removed"},
+			resultWanted:       false,
+		},
+		{
+			name:               "removed",
+			ct:                 pkg.ChangeType("added"),
+			changeTypesToCheck: []string{"added", "removed"},
+			resultWanted:       true,
+		},
+		{
+			name:               "not_supported",
+			ct:                 pkg.ChangeType("not_supported"),
+			changeTypesToCheck: []string{"added", "removed"},
+			resultWanted:       false,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := isSpecifiedByUser(tt.ct, tt.changeTypesToCheck)
+			if result != tt.resultWanted {
+				t.Errorf("result (%v) != result wanted (%v)", result, tt.resultWanted)
 				return
 			}
 		})

--- a/e2e/dependencydiff_test.go
+++ b/e2e/dependencydiff_test.go
@@ -22,7 +22,6 @@ import (
 
 	"github.com/ossf/scorecard/v4/checks"
 	"github.com/ossf/scorecard/v4/dependencydiff"
-	"github.com/ossf/scorecard/v4/pkg"
 )
 
 const (
@@ -38,8 +37,8 @@ var _ = Describe("E2E TEST:"+dependencydiff.Depdiff, func() {
 			checksToRun := []string{
 				checks.CheckBranchProtection,
 			}
-			changeTypesToCheck := map[pkg.ChangeType]bool{
-				pkg.Removed: true, // Only checking those removed ones will make this test faster.
+			changeTypesToCheck := []string{
+				"removed", // Only checking those removed ones will make this test faster.
 			}
 			results, err := dependencydiff.GetDependencyDiffResults(
 				ctx,
@@ -56,8 +55,8 @@ var _ = Describe("E2E TEST:"+dependencydiff.Depdiff, func() {
 			checksToRun := []string{
 				checks.CheckBranchProtection,
 			}
-			changeTypesToCheck := map[pkg.ChangeType]bool{
-				pkg.Removed: true,
+			changeTypesToCheck := []string{
+				"removed",
 			}
 			results, err := dependencydiff.GetDependencyDiffResults(
 				ctx,
@@ -74,8 +73,8 @@ var _ = Describe("E2E TEST:"+dependencydiff.Depdiff, func() {
 			checksToRun := []string{
 				checks.CheckFuzzing,
 			}
-			changeTypesToCheck := map[pkg.ChangeType]bool{
-				pkg.Removed: true,
+			changeTypesToCheck := []string{
+				"removed",
 			}
 			_, err := dependencydiff.GetDependencyDiffResults(
 				ctx,


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Changing the type of the input parameter of the Dependency-diff API from `map` to `[]string` to make it more intuitive for users to use.

This API hasn't been used by other apps or services (the CLI / the Action visualization haven't arrived in the rpeo yet), so this change should be safe.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The `GetDependencyDiffResults` API takes  `changeTypesToCheck map[pkg.ChangeType]bool` as one of its inputs to specify those change types for which we'll surface scorecard results. However, this is not that intuitive since users have to construct a hashmap to use this API. A better way is to simply take an array of strings, and create the hashmap in the function when it's needed.

#### What is the new behavior (if this is a feature change)?**
`changeTypesToCheck` will be a type of `[]string`.

- [x] Tests for the changes have been added (for bug fixes/features)
Additional unit tests added.
The original e2e tests can cover this minor change.

#### Special notes
This needs to be merged before the CLI PR #2077 if LGTM


#### Does this PR introduce a user-facing change?
No.

```release-note
NONE
```
