### PR TITLE
✨  support for SLSA provenance in Signed-Release

### DIFF
--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -22,7 +22,7 @@ import (
 	sce "github.com/ossf/scorecard/v4/errors"
 )
 
-var artifactExtensions = []string{".asc", ".minisig", ".sig", ".sign"}
+var artifactExtensions = []string{".asc", ".minisig", ".sig", ".sign", ".intoto.jsonl"}
 
 const releaseLookBack = 5
 

--- a/checks/raw/contributors.go
+++ b/checks/raw/contributors.go
@@ -38,7 +38,6 @@ func Contributors(c clients.RepoClient) (checker.ContributorsData, error) {
 		}
 
 		for _, org := range contrib.Organizations {
-			fmt.Println(user.Login, ":", user.Organizations)
 			if org.Login != "" && !orgContains(user.Organizations, org.Login) {
 				user.Organizations = append(user.Organizations, org)
 			}
@@ -54,7 +53,6 @@ func Contributors(c clients.RepoClient) (checker.ContributorsData, error) {
 			company = strings.ReplaceAll(company, ",", "")
 			company = strings.TrimLeft(company, "@")
 			company = strings.Trim(company, " ")
-			fmt.Println(user.Login, ":", user.Companies)
 			if company != "" && !companyContains(user.Companies, company) {
 				user.Companies = append(user.Companies, company)
 			}

--- a/checks/raw/contributors.go
+++ b/checks/raw/contributors.go
@@ -38,6 +38,7 @@ func Contributors(c clients.RepoClient) (checker.ContributorsData, error) {
 		}
 
 		for _, org := range contrib.Organizations {
+			fmt.Println(user.Login, ":", user.Organizations)
 			if org.Login != "" && !orgContains(user.Organizations, org.Login) {
 				user.Organizations = append(user.Organizations, org)
 			}
@@ -53,6 +54,7 @@ func Contributors(c clients.RepoClient) (checker.ContributorsData, error) {
 			company = strings.ReplaceAll(company, ",", "")
 			company = strings.TrimLeft(company, "@")
 			company = strings.Trim(company, " ")
+			fmt.Println(user.Login, ":", user.Companies)
 			if company != "" && !companyContains(user.Companies, company) {
 				user.Companies = append(user.Companies, company)
 			}

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -103,7 +103,7 @@ func TestSignedRelease(t *testing.T) {
 					TargetCommitish: "master",
 					Assets: []clients.ReleaseAsset{
 						{
-							Name: "foo.asc",
+							Name: "foo.intoto.jsonl",
 							URL:  "http://foo.com/v1.0.0/foo.intoto.jsonl",
 						},
 					},

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -95,6 +95,25 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
+			name: "Releases with assests with intoto SLSA provenance",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.asc",
+							URL:  "http://foo.com/v1.0.0/foo.intoto.jsonl",
+						},
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 10,
+			},
+		},
+		{
 			name: "Releases with assests with signed artifacts-sig",
 			releases: []clients.Release{
 				{


### PR DESCRIPTION
Search for `.intoto.jsonl` in the release check.
```release-notes
Search for `.intoto.jsonl` in the release check.
```