### PR TITLE
✨ Scorecard returns a non-zero exit code if any check has a runtime error

### DIFF
--- a/checks/sast.go
+++ b/checks/sast.go
@@ -72,7 +72,7 @@ func SAST(c *checker.CheckRequest) checker.CheckResult {
 		codeQlScore == checker.InconclusiveResultScore {
 		// That can never happen since sastToolInCheckRuns can never
 		// retun checker.InconclusiveResultScore.
-		return checker.CreateInconclusiveResult(CheckSAST, "internal error")
+		return checker.CreateRuntimeErrorResult(CheckSAST, sce.ErrScorecardInternal)
 	}
 
 	// Both scores are conclusive.

--- a/checks/webhook.go
+++ b/checks/webhook.go
@@ -46,7 +46,7 @@ func WebHooks(c *checker.CheckRequest) checker.CheckResult {
 		})
 
 		e := sce.WithMessage(sce.ErrorUnsupportedCheck, "SCORECARD_V6 is not set, not running the Webhook check")
-		return checker.CreateRuntimeErrorResult(CheckWebHooks, e)
+		return checker.CreateInconclusiveResult(CheckWebHooks, e.Error())
 	}
 
 	rawData, err := raw.WebHook(c)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -52,7 +52,8 @@ func New(o *options.Options) *cobra.Command {
 			if err != nil {
 				return fmt.Errorf("validating options: %w", err)
 			}
-
+			// options are good at this point. silence usage so it doesn't print for runtime errors
+			cmd.SilenceUsage = true
 			return nil
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -155,13 +156,13 @@ func rootCmd(o *options.Options) error {
 		pol,
 	)
 	if resultsErr != nil {
-		return fmt.Errorf("failed to format results: %w", err)
+		return fmt.Errorf("failed to format results: %w", resultsErr)
 	}
 
-	// intentionally placed at end of function to preserve behavior of outputting results, even if a check has a runtime error
+	// intentionally placed at end to preserve outputting results, even if a check has a runtime error
 	for _, result := range repoResult.Checks {
 		if result.Error != nil {
-			return fmt.Errorf("one or more checks had a runtime error: %w", err)
+			return fmt.Errorf("one or more checks had a runtime error: %w", result.Error)
 		}
 	}
 	return nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"log"
 	"os"
 	"sort"
 	"strings"
@@ -56,9 +55,8 @@ func New(o *options.Options) *cobra.Command {
 
 			return nil
 		},
-		// TODO(cmd): Consider using RunE here
-		Run: func(cmd *cobra.Command, args []string) {
-			rootCmd(o)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return rootCmd(o)
 		},
 	}
 
@@ -71,12 +69,12 @@ func New(o *options.Options) *cobra.Command {
 }
 
 // rootCmd runs scorecard checks given a set of arguments.
-func rootCmd(o *options.Options) {
+func rootCmd(o *options.Options) error {
 	p := &packageManager{}
 	// Set `repo` from package managers.
 	pkgResp, err := fetchGitRepositoryFromPackageManagers(o.NPM, o.PyPI, o.RubyGems, p)
 	if err != nil {
-		log.Panic(err)
+		return fmt.Errorf("fetchGitRepositoryFromPackageManagers: %w", err)
 	}
 	if pkgResp.exists {
 		o.Repo = pkgResp.associatedRepo
@@ -84,7 +82,7 @@ func rootCmd(o *options.Options) {
 
 	pol, err := policy.ParseFromFile(o.PolicyFile)
 	if err != nil {
-		log.Panicf("readPolicy: %v", err)
+		return fmt.Errorf("readPolicy: %w", err)
 	}
 
 	ctx := context.Background()
@@ -92,7 +90,7 @@ func rootCmd(o *options.Options) {
 	repoURI, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, err := checker.GetClients(
 		ctx, o.Repo, o.Local, logger)
 	if err != nil {
-		log.Panic(err)
+		return fmt.Errorf("GetClients: %w", err)
 	}
 	defer repoClient.Close()
 	if ossFuzzRepoClient != nil {
@@ -102,7 +100,7 @@ func rootCmd(o *options.Options) {
 	// Read docs.
 	checkDocs, err := docs.Read()
 	if err != nil {
-		log.Panicf("cannot read yaml file: %v", err)
+		return fmt.Errorf("cannot read yaml file: %w", err)
 	}
 
 	var requiredRequestTypes []checker.RequestType
@@ -114,7 +112,7 @@ func rootCmd(o *options.Options) {
 	}
 	enabledChecks, err := policy.GetEnabled(pol, o.ChecksToRun, requiredRequestTypes)
 	if err != nil {
-		log.Panic(err)
+		return fmt.Errorf("GetEnabled: %w", err)
 	}
 
 	if o.Format == options.FormatDefault {
@@ -134,7 +132,7 @@ func rootCmd(o *options.Options) {
 		vulnsClient,
 	)
 	if err != nil {
-		log.Panic(err)
+		return fmt.Errorf("RunScorecards: %w", err)
 	}
 	repoResult.Metadata = append(repoResult.Metadata, o.Metadata...)
 
@@ -157,6 +155,14 @@ func rootCmd(o *options.Options) {
 		pol,
 	)
 	if resultsErr != nil {
-		log.Panicf("Failed to format results: %v", resultsErr)
+		return fmt.Errorf("failed to format results: %w", err)
 	}
+
+	// intentionally placed at end of function to preserve behavior of outputting results, even if a check has a runtime error
+	for _, result := range repoResult.Checks {
+		if result.Error != nil {
+			return fmt.Errorf("one or more checks had a runtime error: %w", err)
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Scorecard now returns a non-zero exit code if any checks return a runtime error. 

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Scorecard returns an exit code of 0 if most checks have runtime errors

#### What is the new behavior (if this is a feature change)?**
Scorecard now returns an exit code of 1 in the same scenarios

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #2124
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Had to modify a few existing checks to conform to the new semantics.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Scorecard runs with runtime errors now return a non-zero exit code
```
