### PR TITLE
🌱 Limit access to registered checks

### DIFF
--- a/checks/all_checks.go
+++ b/checks/all_checks.go
@@ -35,23 +35,22 @@ func getAll(overrideExperimental bool) checker.CheckNameToFnMap {
 		return possibleChecks
 	}
 
-	// TODO: remove this check when v6 is released
-	if _, v6 := os.LookupEnv("SCORECARD_V6"); !v6 {
+	if _, experimental := os.LookupEnv("SCORECARD_EXPERIMENTAL"); !experimental {
+		// TODO: remove this check when v6 is released
 		delete(possibleChecks, CheckWebHooks)
 	}
 
 	return possibleChecks
 }
 
-// GetAllForEnvironment returns the full list of checks, given any environment variable
-// constraints.
-func GetAllForEnvironment() checker.CheckNameToFnMap {
+// GetAll returns the full list of default checks, excluding any experimental checks
+// unless environment variable constraints are satisfied.
+func GetAll() checker.CheckNameToFnMap {
 	return getAll(false /*overrideExperimental*/)
 }
 
-// GetAll returns the full list of checks, regardless of
-// environment variable constraints.
-func GetAll() checker.CheckNameToFnMap {
+// GetAllWithExperimental returns the full list of checks, including experimental checks.
+func GetAllWithExperimental() checker.CheckNameToFnMap {
 	return getAll(true /*overrideExperimental*/)
 }
 

--- a/checks/webhook.go
+++ b/checks/webhook.go
@@ -39,13 +39,13 @@ func init() {
 // WebHooks run Webhooks check.
 func WebHooks(c *checker.CheckRequest) checker.CheckResult {
 	// TODO: remove this check when v6 is released
-	_, enabled := os.LookupEnv("SCORECARD_V6")
+	_, enabled := os.LookupEnv("SCORECARD_EXPERIMENTAL")
 	if !enabled {
 		c.Dlogger.Warn(&checker.LogMessage{
-			Text: "SCORECARD_V6 is not set, not running the Webhook check",
+			Text: "SCORECARD_EXPERIMENTAL is not set, not running the Webhook check",
 		})
 
-		e := sce.WithMessage(sce.ErrorUnsupportedCheck, "SCORECARD_V6 is not set, not running the Webhook check")
+		e := sce.WithMessage(sce.ErrorUnsupportedCheck, "SCORECARD_EXPERIMENTAL is not set, not running the Webhook check")
 		return checker.CreateRuntimeErrorResult(CheckWebHooks, e)
 	}
 

--- a/checks/webhook_test.go
+++ b/checks/webhook_test.go
@@ -98,7 +98,7 @@ func TestWebhooks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			os.Setenv("SCORECARD_V6", "true")
+			os.Setenv("SCORECARD_EXPERIMENTAL", "true")
 			ctrl := gomock.NewController(t)
 			mockRepo := mockrepo.NewMockRepoClient(ctrl)
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -68,7 +68,7 @@ func serveCmd(o *options.Options) *cobra.Command {
 				}
 				defer ossFuzzRepoClient.Close()
 				ciiClient := clients.DefaultCIIBestPracticesClient()
-				checksToRun := checks.GetAllForEnvironment()
+				checksToRun := checks.GetAll()
 				repoResult, err := pkg.RunScorecards(
 					ctx, repo, clients.HeadSHA /*commitSHA*/, checksToRun, repoClient,
 					ossFuzzRepoClient, ciiClient, vulnsClient)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -68,8 +68,9 @@ func serveCmd(o *options.Options) *cobra.Command {
 				}
 				defer ossFuzzRepoClient.Close()
 				ciiClient := clients.DefaultCIIBestPracticesClient()
+				checksToRun := checks.GetAllForEnvironment()
 				repoResult, err := pkg.RunScorecards(
-					ctx, repo, clients.HeadSHA /*commitSHA*/, checks.AllChecks, repoClient,
+					ctx, repo, clients.HeadSHA /*commitSHA*/, checksToRun, repoClient,
 					ossFuzzRepoClient, ciiClient, vulnsClient)
 				if err != nil {
 					logger.Error(err, "running enabled scorecard checks on repo")

--- a/docs/checks/internal/validate/main.go
+++ b/docs/checks/internal/validate/main.go
@@ -29,7 +29,7 @@ func main() {
 		panic(fmt.Sprintf("docs.Read: %v", err))
 	}
 
-	allChecks := checks.GetAll()
+	allChecks := checks.GetAllWithExperimental()
 	for check := range allChecks {
 		c, e := m.GetCheck(check)
 		if e != nil {

--- a/docs/checks/internal/validate/main.go
+++ b/docs/checks/internal/validate/main.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//      http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -29,7 +29,7 @@ func main() {
 		panic(fmt.Sprintf("docs.Read: %v", err))
 	}
 
-	allChecks := checks.AllChecks
+	allChecks := checks.GetAll()
 	for check := range allChecks {
 		c, e := m.GetCheck(check)
 		if e != nil {
@@ -58,7 +58,7 @@ func main() {
 	}
 	for _, check := range m.GetChecks() {
 		if _, exists := allChecks[check.GetName()]; !exists {
-			panic(fmt.Sprintf("check present in checks.yaml is not part of `checks.AllChecks`: %s", check.GetName()))
+			panic(fmt.Sprintf("check present in checks.yaml is not part of `checks.GetAll()`: %s", check.GetName()))
 		}
 	}
 }

--- a/options/flags.go
+++ b/options/flags.go
@@ -134,7 +134,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	)
 
 	checkNames := []string{}
-	for checkName := range checks.GetAll() {
+	for checkName := range checks.GetAllForEnvironment() {
 		checkNames = append(checkNames, checkName)
 	}
 	cmd.Flags().StringSliceVar(

--- a/options/flags.go
+++ b/options/flags.go
@@ -134,7 +134,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	)
 
 	checkNames := []string{}
-	for checkName := range checks.GetAllForEnvironment() {
+	for checkName := range checks.GetAll() {
 		checkNames = append(checkNames, checkName)
 	}
 	cmd.Flags().StringSliceVar(

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -107,7 +107,7 @@ func parseFromYAML(b []byte) (*ScorecardPolicy, error) {
 	retPolicy.Version = int32(sp.Version)
 
 	checksFound := make(map[string]bool)
-	allChecks := checks.GetAll()
+	allChecks := checks.GetAllWithExperimental()
 	for n, p := range sp.Policies {
 		if _, exists := allChecks[n]; !exists {
 			return &retPolicy, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("%v: %v", errInvalidCheck.Error(), n))
@@ -178,7 +178,7 @@ func GetEnabled(
 		}
 	default:
 		// Enable all checks that are supported.
-		for checkName := range checks.GetAllForEnvironment() {
+		for checkName := range checks.GetAll() {
 			if !isSupportedCheck(checkName, requiredRequestTypes) {
 				continue
 			}
@@ -212,14 +212,14 @@ func checksHavePolicies(sp *ScorecardPolicy, enabledChecks checker.CheckNameToFn
 func isSupportedCheck(checkName string, requiredRequestTypes []checker.RequestType) bool {
 	unsupported := checker.ListUnsupported(
 		requiredRequestTypes,
-		checks.GetAll()[checkName].SupportedRequestTypes)
+		checks.GetAllWithExperimental()[checkName].SupportedRequestTypes)
 	return len(unsupported) == 0
 }
 
 // Enables checks by name.
 func enableCheck(checkName string, enabledChecks *checker.CheckNameToFnMap) bool {
 	if enabledChecks != nil {
-		for key, checkFn := range checks.GetAll() {
+		for key, checkFn := range checks.GetAllWithExperimental() {
 			if strings.EqualFold(key, checkName) {
 				(*enabledChecks)[key] = checkFn
 				return true

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -107,8 +107,9 @@ func parseFromYAML(b []byte) (*ScorecardPolicy, error) {
 	retPolicy.Version = int32(sp.Version)
 
 	checksFound := make(map[string]bool)
+	allChecks := checks.GetAll()
 	for n, p := range sp.Policies {
-		if _, exists := checks.AllChecks[n]; !exists {
+		if _, exists := allChecks[n]; !exists {
 			return &retPolicy, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("%v: %v", errInvalidCheck.Error(), n))
 		}
 
@@ -177,7 +178,7 @@ func GetEnabled(
 		}
 	default:
 		// Enable all checks that are supported.
-		for checkName := range checks.GetAll() {
+		for checkName := range checks.GetAllForEnvironment() {
 			if !isSupportedCheck(checkName, requiredRequestTypes) {
 				continue
 			}
@@ -211,7 +212,7 @@ func checksHavePolicies(sp *ScorecardPolicy, enabledChecks checker.CheckNameToFn
 func isSupportedCheck(checkName string, requiredRequestTypes []checker.RequestType) bool {
 	unsupported := checker.ListUnsupported(
 		requiredRequestTypes,
-		checks.AllChecks[checkName].SupportedRequestTypes)
+		checks.GetAll()[checkName].SupportedRequestTypes)
 	return len(unsupported) == 0
 }
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Limit access to registered checks except through `checks.GetAll()` and `checks.GetAllForEnvironment()`. 
The intention is to provide two versions, one which returns everything, and one which excludes experimental features (unless enabled via environment flags). This was causing problems in #2133, as WebHooks was being run by default.

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
`checks.AllChecks` and `checks.GetAll()` were both public and being used.
`checks.GetAll()` did not filter on environment variable constraints, despite its comment saying it did

#### What is the new behavior (if this is a feature change)?**
`checks.allChecks` made private
`checks.GetAll()` had its comment updated to reflect the behavior
`checks.GetAllForEnvironment()` introduced to filter the checks to those supported by the environment variables.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
