### PR TITLE
:bug: Fix bug 2051 

### DIFF
--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -444,7 +444,7 @@ func TestGithubTokenPermissionsLineNumber(t *testing.T) {
 
 			main := "main"
 			mockRepo.EXPECT().URI().Return("github.com/ossf/scorecard").AnyTimes()
-			mockRepo.EXPECT().GetDefaultBranch().Return(&clients.BranchRef{Name: &main}, nil).AnyTimes()
+			mockRepo.EXPECT().GetDefaultBranchName().Return(main, nil).AnyTimes()
 			mockRepo.EXPECT().ListFiles(gomock.Any()).DoAndReturn(func(predicate func(string) (bool, error)) ([]string, error) {
 				return []string{p}, nil
 			}).AnyTimes()

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -159,6 +159,15 @@ func (client *Client) GetDefaultBranch() (*clients.BranchRef, error) {
 	return client.branches.getDefaultBranch()
 }
 
+// GetDefaultBranchName implements RepoClient.GetDefaultBranchName.
+func (client *Client) GetDefaultBranchName() (string, error) {
+	if len(client.repourl.defaultBranch) > 0 {
+		return client.repourl.defaultBranch, nil
+	}
+
+	return "", fmt.Errorf("default branch name is empty")
+}
+
 // GetBranch implements RepoClient.GetBranch.
 func (client *Client) GetBranch(branch string) (*clients.BranchRef, error) {
 	return client.branches.getBranch(branch)

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -31,8 +31,9 @@ import (
 )
 
 var (
-	_                clients.RepoClient = &Client{}
-	errInputRepoType                    = errors.New("input repo should be of type repoURL")
+	_                     clients.RepoClient = &Client{}
+	errInputRepoType                         = errors.New("input repo should be of type repoURL")
+	errDefaultBranchEmpty                    = errors.New("default branch name is empty")
 )
 
 // Client is GitHub-specific implementation of RepoClient.
@@ -165,7 +166,7 @@ func (client *Client) GetDefaultBranchName() (string, error) {
 		return client.repourl.defaultBranch, nil
 	}
 
-	return "", fmt.Errorf("default branch name is empty")
+	return "", fmt.Errorf("%w", errDefaultBranchEmpty)
 }
 
 // GetBranch implements RepoClient.GetBranch.
@@ -203,7 +204,7 @@ func (client *Client) Search(request clients.SearchRequest) (clients.SearchRespo
 	return client.search.search(request)
 }
 
-// SearchCommits implements RepoClient.SearchCommits
+// SearchCommits implements RepoClient.SearchCommits.
 func (client *Client) SearchCommits(request clients.SearchCommitsOptions) ([]clients.Commit, error) {
 	return client.searchCommits.search(request)
 }

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -169,6 +169,11 @@ func (client *localDirClient) GetDefaultBranch() (*clients.BranchRef, error) {
 	return nil, fmt.Errorf("GetDefaultBranch: %w", clients.ErrUnsupportedFeature)
 }
 
+// GetDefaultBranchName implements RepoClient.GetDefaultBranchName.
+func (client *localDirClient) GetDefaultBranchName() (string, error) {
+	return "", fmt.Errorf("GetDefaultBranchName: %w", clients.ErrUnsupportedFeature)
+}
+
 // ListCommits implements RepoClient.ListCommits.
 func (client *localDirClient) ListCommits() ([]clients.Commit, error) {
 	return nil, fmt.Errorf("ListCommits: %w", clients.ErrUnsupportedFeature)

--- a/clients/mockclients/repo_client.go
+++ b/clients/mockclients/repo_client.go
@@ -93,6 +93,21 @@ func (mr *MockRepoClientMockRecorder) GetDefaultBranch() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultBranch", reflect.TypeOf((*MockRepoClient)(nil).GetDefaultBranch))
 }
 
+// GetDefaultBranchName mocks base method.
+func (m *MockRepoClient) GetDefaultBranchName() (string, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDefaultBranchName")
+	ret0, _ := ret[0].(string)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDefaultBranchName indicates an expected call of GetDefaultBranchName.
+func (mr *MockRepoClientMockRecorder) GetDefaultBranchName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDefaultBranchName", reflect.TypeOf((*MockRepoClient)(nil).GetDefaultBranchName))
+}
+
 // GetFileContent mocks base method.
 func (m *MockRepoClient) GetFileContent(filename string) ([]byte, error) {
 	m.ctrl.T.Helper()

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -33,6 +33,7 @@ type RepoClient interface {
 	ListFiles(predicate func(string) (bool, error)) ([]string, error)
 	GetFileContent(filename string) ([]byte, error)
 	GetBranch(branch string) (*BranchRef, error)
+	GetDefaultBranchName() (string, error)
 	GetDefaultBranch() (*BranchRef, error)
 	ListCommits() ([]Commit, error)
 	ListIssues() ([]Issue, error)

--- a/remediation/remediations.go
+++ b/remediation/remediations.go
@@ -51,7 +51,7 @@ func init() {
 func Setup(c *checker.CheckRequest) error {
 	once.Do(func() {
 		// Get the branch for remediation.
-		b, err := c.RepoClient.GetDefaultBranch()
+		b, err := c.RepoClient.GetDefaultBranchName()
 		if err != nil {
 			if !errors.Is(err, clients.ErrUnsupportedFeature) {
 				setupErr = err
@@ -59,16 +59,15 @@ func Setup(c *checker.CheckRequest) error {
 			return
 		}
 
-		if b != nil && b.Name != nil {
-			branch = *b.Name
-			uri := c.RepoClient.URI()
-			parts := strings.Split(uri, "/")
-			if len(parts) != 3 {
-				setupErr = fmt.Errorf("%w: enpty: %s", errInvalidArg, uri)
-				return
-			}
-			repo = fmt.Sprintf("%s/%s", parts[1], parts[2])
+		branch = b
+		uri := c.RepoClient.URI()
+		parts := strings.Split(uri, "/")
+		if len(parts) != 3 {
+			setupErr = fmt.Errorf("%w: empty: %s", errInvalidArg, uri)
+			return
 		}
+		repo = fmt.Sprintf("%s/%s", parts[1], parts[2])
+
 	})
 	return setupErr
 }

--- a/remediation/remediations.go
+++ b/remediation/remediations.go
@@ -67,7 +67,6 @@ func Setup(c *checker.CheckRequest) error {
 			return
 		}
 		repo = fmt.Sprintf("%s/%s", parts[1], parts[2])
-
 	})
 	return setupErr
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix - #2051

`remediations.go` uses `GetDefaultBranch` method. `GetDefaultBranch` queries branch protection status. Some of the branch protection attributes need `administration` access, which the `GITHUB_TOKEN` does not have. As a result, remediation code fails when run in scorecard-action, when the repo has branch protection enabled. 

https://github.com/ossf/scorecard/blob/0eb7cb2d748725b177d633bcd421a07fc0732721/clients/githubrepo/branches.go#L94-L106

This PR adds a new method called `GetDefaultBranchName`, which returns the default branch name using `client.repourl.defaultBranch`. This works regardless of branch protection status. 

Signed-off-by: Varun Sharma <varunsh@stepsecurity.io>


- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Pinned-Dependencies results do not show up in some scorecard-action runs

#### What is the new behavior (if this is a feature change)?**
Pinned-Dependencies results show up in scorecard-action runs

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2051
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Tested the change in a GitHub Actions workflow with scorecard-action and it worked fine. 
https://github.com/step-security/secure-workflows/runs/7802376762?check_suite_focus=true#step:4:867

#### Does this PR introduce a user-facing change?
No

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```

cc @laurentsimon 