### PR TITLE
:sparkles: Support OneFuzz in fuzzing checks

### DIFF
--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -29,6 +29,7 @@ import (
 const (
 	fuzzerOSSFuzz         = "OSSFuzz"
 	fuzzerClusterFuzzLite = "ClusterFuzzLite"
+	oneFuzz               = "OneFuzz"
 	fuzzerBuiltInGo       = "GoBuiltInFuzzer"
 	// TODO: add more fuzzing check supports.
 )
@@ -73,6 +74,21 @@ func Fuzzing(c *checker.CheckRequest) (checker.FuzzingData, error) {
 				Name: fuzzerClusterFuzzLite,
 				URL:  asPointer("https://github.com/google/clusterfuzzlite"),
 				Desc: asPointer("continuous fuzzing solution that runs as part of Continuous Integration (CI) workflows"),
+				// TODO: File.
+			},
+		)
+	}
+
+	usingOneFuzz, e := checkOneFuzz(c)
+	if e != nil {
+		return checker.FuzzingData{}, fmt.Errorf("%w", e)
+	}
+	if usingOneFuzz {
+		fuzzers = append(fuzzers,
+			checker.Tool{
+				Name: oneFuzz,
+				URL:  asPointer("https://github.com/microsoft/onefuzz"),
+				Desc: asPointer("Enables continuous developer-driven fuzzing to proactively harden software prior to release."),
 				// TODO: File.
 			},
 		)
@@ -124,6 +140,22 @@ func checkCFLite(c *checker.CheckRequest) (bool, error) {
 		CaseSensitive: true,
 	}, func(path string, content []byte, args ...interface{}) (bool, error) {
 		result = fileparser.CheckFileContainsCommands(content, "#")
+		return false, nil
+	}, nil)
+	if e != nil {
+		return result, fmt.Errorf("%w", e)
+	}
+
+	return result, nil
+}
+
+func checkOneFuzz(c *checker.CheckRequest) (bool, error) {
+	result := false
+	e := fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
+		Pattern:       "^\\.onefuzz$",
+		CaseSensitive: true,
+	}, func(path string, content []byte, args ...interface{}) (bool, error) {
+		result = true
 		return false, nil
 	}, nil)
 	if e != nil {

--- a/checks/raw/fuzzing_test.go
+++ b/checks/raw/fuzzing_test.go
@@ -103,6 +103,65 @@ func Test_checkOSSFuzz(t *testing.T) {
 	}
 }
 
+// Test_checkOneFuzz is a test function for checkOneFuzz.
+func Test_checkOneFuzz(t *testing.T) {
+	t.Parallel()
+	//nolint
+	tests := []struct {
+		name     string
+		want     bool
+		wantErr  bool
+		fileName []string
+	}{
+		{
+			name:     "Test_checkOneFuzz success",
+			want:     true,
+			wantErr:  false,
+			fileName: []string{".onefuzz"},
+		},
+		{
+			name:     "Test_checkOneFuzz not found",
+			want:     false,
+			wantErr:  false,
+			fileName: []string{},
+		},
+		{
+			name:     "Test_checkOneFuzz failure",
+			want:     false,
+			wantErr:  true,
+			fileName: []string{".onefuzz"},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			defer ctrl.Finish()
+			mockFuzz := mockrepo.NewMockRepoClient(ctrl)
+			mockFuzz.EXPECT().ListFiles(gomock.Any()).Return(tt.fileName, nil).AnyTimes()
+			mockFuzz.EXPECT().GetFileContent(gomock.Any()).DoAndReturn(func(f string) (string, error) {
+				if tt.wantErr {
+					//nolint
+					return "", errors.New("error")
+				}
+				return "", nil
+			}).AnyTimes()
+			req := checker.CheckRequest{
+				RepoClient: mockFuzz,
+			}
+			got, err := checkOneFuzz(&req)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("checkOneFuzz() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("checkOneFuzz() = %v, want %v for test %v", got, tt.want, tt.name)
+			}
+		})
+	}
+}
+
 // Test_checkCFLite is a test function for checkCFLite.
 func Test_checkCFLite(t *testing.T) {
 	t.Parallel()

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -321,7 +321,7 @@ This check tries to determine if the project uses
 1. if the repository name is included in the [OSS-Fuzz](https://github.com/google/oss-fuzz) project list;
 2. if [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) is deployed in the repository;
 3. if there are user-defined language-specified fuzzing functions (currently only supports [Go fuzzing](https://go.dev/doc/fuzz/)) in the repository.
-4. if it contains a [OneFuzz](https://github.com/microsoft/onefuzz) integration [detection file](TODO:);
+4. if it contains a [OneFuzz](https://github.com/microsoft/onefuzz) integration [detection file](https://github.com/microsoft/onefuzz/blob/main/docs/getting-started.md#detecting-the-use-of-onefuzz);
 
 Fuzzing, or fuzz testing, is the practice of feeding unexpected or random data
 into a program to expose bugs. Regular fuzzing is important to detect

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -321,6 +321,7 @@ This check tries to determine if the project uses
 1. if the repository name is included in the [OSS-Fuzz](https://github.com/google/oss-fuzz) project list;
 2. if [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) is deployed in the repository;
 3. if there are user-defined language-specified fuzzing functions (currently only supports [Go fuzzing](https://go.dev/doc/fuzz/)) in the repository.
+4. if it contains a [OneFuzz](https://github.com/microsoft/onefuzz) integration [detection file](TODO:);
 
 Fuzzing, or fuzz testing, is the practice of feeding unexpected or random data
 into a program to expose bugs. Regular fuzzing is important to detect

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -378,6 +378,7 @@ checks:
       1. if the repository name is included in the [OSS-Fuzz](https://github.com/google/oss-fuzz) project list;
       2. if [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) is deployed in the repository;
       3. if there are user-defined language-specified fuzzing functions (currently only supports [Go fuzzing](https://go.dev/doc/fuzz/)) in the repository.
+      4. if it contains a [OneFuzz](https://github.com/microsoft/onefuzz) integration [detection file](https://github.com/microsoft/onefuzz/blob/main/docs/getting-started.md#detecting-the-use-of-onefuzz);
 
       Fuzzing, or fuzz testing, is the practice of feeding unexpected or random data
       into a program to expose bugs. Regular fuzzing is important to detect


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Add support for detecting [OneFuzz](https://github.com/microsoft/onefuzz) in fuzzing checks.

- [v] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The fuzzing check of scorecard checks for [OSS-Fuzz](https://github.com/google/oss-fuzz), [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/) and in a repo user-defined [golang fuzz functions](https://go.dev/doc/fuzz/) in the repo.

#### What is the new behavior (if this is a feature change)?**

Check for the existence of a [OneFuzz detection file](https://github.com/microsoft/onefuzz/blob/main/docs/getting-started.md#detecting-the-use-of-onefuzz) in the repo and give the check a full score (10/10) if such file is found.

- [v] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
Mentioned, but does not fix issue: https://github.com/ossf/scorecard/issues/897
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Yes

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Users now can check for OneFuzz integration in repo as a part of the fuzzing check.
```
