### PR TITLE
🐛 Add scorecard-action to the security-events allowlist in Token Permissions check

### DIFF
--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -56,7 +56,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore - 1,
 				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -67,7 +67,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  3,
 				NumberOfInfo:  2,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -78,7 +78,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -89,7 +89,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -100,7 +100,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -111,7 +111,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  0,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -122,7 +122,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -133,7 +133,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  0,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -144,7 +144,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 7,
+				NumberOfDebug: 6,
 			},
 		},
 		{
@@ -155,7 +155,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  10,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -166,7 +166,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  10,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -177,7 +177,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -188,7 +188,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore - 1,
 				NumberOfWarn:  2,
 				NumberOfInfo:  2,
-				NumberOfDebug: 7,
+				NumberOfDebug: 6,
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore - 2,
 				NumberOfWarn:  2,
 				NumberOfInfo:  3,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -210,7 +210,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -221,7 +221,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -232,7 +232,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -254,7 +254,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -265,7 +265,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -276,7 +276,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 		{
@@ -287,7 +287,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         9,
 				NumberOfWarn:  1,
 				NumberOfInfo:  3,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -298,7 +298,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore - 1,
 				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 5,
+				NumberOfDebug: 4,
 			},
 		},
 		{
@@ -312,7 +312,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore - 1,
 				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 11,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -326,7 +326,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  2,
 				NumberOfInfo:  1,
-				NumberOfDebug: 11,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -340,7 +340,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  1,
-				NumberOfDebug: 12,
+				NumberOfDebug: 10,
 			},
 		},
 		{
@@ -353,7 +353,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
 				NumberOfInfo:  1,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			},
 		},
 	}

--- a/checks/raw/permissions.go
+++ b/checks/raw/permissions.go
@@ -390,9 +390,8 @@ func isAllowedWorkflow(workflow *actionlint.Workflow, fp string, pdata *permissi
 			if uses == nil {
 				continue
 			}
-			if before, _, found := strings.Cut(uses.Value, "@"); found {
-				uses.Value = before
-			}
+			// remove any version pinning for the comparison
+			uses.Value = strings.Split(uses.Value, "@")[0]
 			if allowlist[uses.Value] {
 				tokenPermissions.File.Offset = fileparser.GetLineNumber(uses.Pos)
 				tokenPermissions.Msg = stringPointer("allowed SARIF workflow detected")

--- a/e2e/permissions_test.go
+++ b/e2e/permissions_test.go
@@ -50,7 +50,7 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			}
 			result := checks.TokenPermissions(&req)
 			// New version.
@@ -75,7 +75,7 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			}
 			result := checks.TokenPermissions(&req)
 			// New version.
@@ -112,7 +112,7 @@ var _ = Describe("E2E TEST:"+checks.CheckTokenPermissions, func() {
 				Score:         checker.MinResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  2,
-				NumberOfDebug: 6,
+				NumberOfDebug: 5,
 			}
 			result := checks.TokenPermissions(&req)
 			// New version.


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Using `scorecard-action` no longer decreases a project's score. 

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Repositories that use `ossf/scorecard-action` lose 1 point due to the Token Permissions check, because `ossf/scorecard-action` requires `security-events: write`. 

#### What is the new behavior (if this is a feature change)?**
This PR adds `ossf/scorecard-action` to the  allowed list of actions that can use `security-events: write` without affecting scoring.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2152

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
