### PR TITLE
🐛 Fix remediation text when Scorecard is run multiple times within a program

### DIFF
--- a/checks/evaluation/permissions.go
+++ b/checks/evaluation/permissions.go
@@ -56,7 +56,7 @@ func applyScorePolicy(results *checker.TokenPermissionsData, c *checker.CheckReq
 	hm := make(map[string]permissions)
 	dl := c.Dlogger
 	//nolint:errcheck
-	remediaitonMetadata, _ := remediation.Setup(c)
+	remediaitonMetadata, _ := remediation.New(c)
 
 	for _, r := range results.TokenPermissions {
 		var msg checker.LogMessage

--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -54,7 +54,7 @@ func PinningDependencies(name string, c *checker.CheckRequest,
 	pr := make(map[checker.DependencyUseType]pinnedResult)
 	dl := c.Dlogger
 	//nolint:errcheck
-	remediaitonMetadata, _ := remediation.Setup(c)
+	remediaitonMetadata, _ := remediation.New(c)
 
 	for i := range r.Dependencies {
 		rr := r.Dependencies[i]

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -170,7 +170,8 @@ func Test_PinningDependencies(t *testing.T) {
 			t.Parallel()
 
 			dl := scut.TestDetailLogger{}
-			actual := PinningDependencies("checkname", &dl,
+			c := checker.CheckRequest{Dlogger: &dl}
+			actual := PinningDependencies("checkname", &c,
 				&checker.PinningDependenciesData{
 					Dependencies: tt.dependencies,
 				})

--- a/checks/permissions.go
+++ b/checks/permissions.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ossf/scorecard/v4/checks/evaluation"
 	"github.com/ossf/scorecard/v4/checks/raw"
 	sce "github.com/ossf/scorecard/v4/errors"
-	"github.com/ossf/scorecard/v4/remediation"
 )
 
 // CheckTokenPermissions is the exported name for Token-Permissions check.
@@ -39,11 +38,6 @@ func init() {
 
 // TokenPermissions will run the Token-Permissions check.
 func TokenPermissions(c *checker.CheckRequest) checker.CheckResult {
-	if err := remediation.Setup(c); err != nil {
-		e := sce.WithMessage(sce.ErrScorecardInternal, err.Error())
-		return checker.CreateRuntimeErrorResult(CheckTokenPermissions, e)
-	}
-
 	rawData, err := raw.TokenPermissions(c)
 	if err != nil {
 		e := sce.WithMessage(sce.ErrScorecardInternal, err.Error())
@@ -56,5 +50,5 @@ func TokenPermissions(c *checker.CheckRequest) checker.CheckResult {
 	}
 
 	// Return the score evaluation.
-	return evaluation.TokenPermissions(CheckTokenPermissions, c.Dlogger, &rawData)
+	return evaluation.TokenPermissions(CheckTokenPermissions, c, &rawData)
 }

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -364,6 +364,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 
 			ctrl := gomock.NewController(t)
 			mockRepo := mockrepo.NewMockRepoClient(ctrl)
+			mockRepo.EXPECT().GetDefaultBranchName().Return("main", nil)
 
 			main := "main"
 			mockRepo.EXPECT().URI().Return("github.com/ossf/scorecard").AnyTimes()

--- a/checks/pinned_dependencies.go
+++ b/checks/pinned_dependencies.go
@@ -19,7 +19,6 @@ import (
 	"github.com/ossf/scorecard/v4/checks/evaluation"
 	"github.com/ossf/scorecard/v4/checks/raw"
 	sce "github.com/ossf/scorecard/v4/errors"
-	"github.com/ossf/scorecard/v4/remediation"
 )
 
 // CheckPinnedDependencies is the registered name for FrozenDeps.
@@ -39,11 +38,6 @@ func init() {
 
 // PinningDependencies will check the repository for its use of dependencies.
 func PinningDependencies(c *checker.CheckRequest) checker.CheckResult {
-	if err := remediation.Setup(c); err != nil {
-		e := sce.WithMessage(sce.ErrScorecardInternal, err.Error())
-		return checker.CreateRuntimeErrorResult(CheckPinnedDependencies, e)
-	}
-
 	rawData, err := raw.PinningDependencies(c)
 	if err != nil {
 		e := sce.WithMessage(sce.ErrScorecardInternal, err.Error())
@@ -55,5 +49,5 @@ func PinningDependencies(c *checker.CheckRequest) checker.CheckResult {
 		c.RawResults.PinningDependenciesResults = rawData
 	}
 
-	return evaluation.PinningDependencies(CheckPinnedDependencies, c.Dlogger, &rawData)
+	return evaluation.PinningDependencies(CheckPinnedDependencies, c, &rawData)
 }

--- a/remediation/remediations.go
+++ b/remediation/remediations.go
@@ -39,8 +39,8 @@ type RemediationMetadata struct {
 	repo   string
 }
 
-// Setup sets up remediation code.
-func Setup(c *checker.CheckRequest) (RemediationMetadata, error) {
+// New returns remediation relevant metadata from a CheckRequest.
+func New(c *checker.CheckRequest) (RemediationMetadata, error) {
 	if c == nil || c.RepoClient == nil {
 		return RemediationMetadata{}, nil
 	}

--- a/remediation/remediations_test.go
+++ b/remediation/remediations_test.go
@@ -38,7 +38,7 @@ func TestRepeatedSetup(t *testing.T) {
 		c := checker.CheckRequest{
 			RepoClient: mockRepo,
 		}
-		rmd, err := Setup(&c)
+		rmd, err := New(&c)
 		if err != nil {
 			t.Error(err)
 		}

--- a/remediation/remediations_test.go
+++ b/remediation/remediations_test.go
@@ -1,0 +1,51 @@
+// Copyright 2022 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package remediation
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/ossf/scorecard/v4/checker"
+	mockrepo "github.com/ossf/scorecard/v4/clients/mockclients"
+)
+
+func TestRepeatedSetup(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+
+	for i := 0; i < 2; i++ {
+		mockRepo := mockrepo.NewMockRepoClient(ctrl)
+		mockRepo.EXPECT().GetDefaultBranchName().Return("main", nil).AnyTimes()
+		uri := fmt.Sprintf("github.com/ossf/scorecard%d", i)
+		mockRepo.EXPECT().URI().Return(uri).AnyTimes()
+
+		c := checker.CheckRequest{
+			RepoClient: mockRepo,
+		}
+		rmd, err := Setup(&c)
+		if err != nil {
+			t.Error(err)
+		}
+
+		want := fmt.Sprintf("ossf/scorecard%d", i)
+		if rmd.repo != want {
+			t.Errorf("failed. expected: %v, got: %v", want, rmd.repo)
+		}
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?
bug fix for incorrect repo info in remediation text. the problem affected the weekly scorecard cron job

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The remediation text used to reflect the first repo / branch  processed by a scorecard cron worker.

#### What is the new behavior (if this is a feature change)?**
The remediation text will now match the repo/branch being analyzed. 

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
#2152 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
This is a temporary fix, and modifies the function signatures for `evaluation.PinningDependencies` and `evaluation.TokenPermissions`. I don't think anyone besides ourselves are using these exported functions.


#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
