### PR TITLE
✨ Use sha256 for release hashes

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -94,7 +94,6 @@ checksum:
   # Accepted options are sha256, sha512, sha1, crc32, md5, sha224 and sha384.
   # Default is sha256.
   name_template: "{{ .ProjectName }}_checksums.txt"
-  algorithm: sha512
 
 snapshot:
   name_template: SNAPSHOT-{{ .ShortCommit }}


### PR DESCRIPTION
This updates the hash from sha512 to sha256 for release hashes. That's what's expected by the SLSA generator.
sha256 is enough for security
```release-notes
Use sha256 for goreleaser config
```