### PR TITLE
:bug: Check for security polices in RST format at toplevel and .github as well

### DIFF
--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -107,6 +107,8 @@ func isSecurityPolicyFilename(name string) bool {
 		strings.EqualFold(name, "security.adoc") ||
 		strings.EqualFold(name, ".github/security.adoc") ||
 		strings.EqualFold(name, "docs/security.adoc") ||
+		strings.EqualFold(name, "security.rst") ||
+		strings.EqualFold(name, ".github/security.rst") ||
 		strings.EqualFold(name, "doc/security.rst") ||
 		strings.EqualFold(name, "docs/security.rst")
 }

--- a/checks/security_policy_test.go
+++ b/checks/security_policy_test.go
@@ -64,6 +64,26 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 		},
 		{
+			name: "security.rst",
+			files: []string{
+				"security.rst",
+			},
+			want: scut.TestReturn{
+				Score:        10,
+				NumberOfInfo: 1,
+			},
+		},
+		{
+			name: ".github/security.rst",
+			files: []string{
+				".github/security.rst",
+			},
+			want: scut.TestReturn{
+				Score:        10,
+				NumberOfInfo: 1,
+			},
+		},
+		{
 			name: "docs/security.rst",
 			files: []string{
 				"docs/security.rst",


### PR DESCRIPTION

#### What kind of change does this PR introduce?

This updates the security policy check to find RST files in more places.

Examples of repos this would now catch:
https://github.com/apache/airflow/blob/main/.github/SECURITY.rst
https://github.com/opencast/pyCA/blob/main/SECURITY.rst


- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

RST files are only looked for in doc/ or docs/

#### What is the new behavior (if this is a feature change)?**

RST files are looked for in all the places markdown and asciidoc files are.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

Not a go programmer by trade. Might have messed something up!

#### Does this PR introduce a user-facing change?

```release-note

The Security-Policy check now looks for ReStructuredText (.rst) files in the same place it looks for Markdown and AsciiDoc files.
```
