### PR TITLE
:bug: Signed-Releases - Check releases for signatures even if they only have source code

### DIFF
--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -30,8 +30,8 @@ var (
 
 const releaseLookBack = 5
 
-//SignedReleases applies the score policy for the Signed-Releases check.
-//nolint
+// SignedReleases applies the score policy for the Signed-Releases check.
+// nolint
 func SignedReleases(name string, dl checker.DetailLogger, r *checker.SignedReleasesData) checker.CheckResult {
 	if r == nil {
 		e := sce.WithMessage(sce.ErrScorecardInternal, "empty raw data")
@@ -42,7 +42,7 @@ func SignedReleases(name string, dl checker.DetailLogger, r *checker.SignedRelea
 	total := 0
 	score := 0
 	for _, release := range r.Releases {
-		if release.TagName == "" {
+		if release.ZipballURL == "" && release.TarballURL == "" && len(release.Assets) == 0 {
 			continue
 		}
 

--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -42,7 +42,7 @@ func SignedReleases(name string, dl checker.DetailLogger, r *checker.SignedRelea
 	total := 0
 	score := 0
 	for _, release := range r.Releases {
-		if len(release.Assets) == 0 {
+		if release.TagName == "" {
 			continue
 		}
 
@@ -127,6 +127,6 @@ func SignedReleases(name string, dl checker.DetailLogger, r *checker.SignedRelea
 	}
 
 	score = int(math.Floor(float64(score) / float64(totalReleases)))
-	reason := fmt.Sprintf("%d out of %d artifacts are signed or have provenance", total, totalReleases)
+	reason := fmt.Sprintf("%d out of %d most recent artifacts are signed or have provenance", total, totalReleases)
 	return checker.CreateResultWithScore(name, reason, score)
 }

--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -43,6 +43,9 @@ func SignedReleases(name string, dl checker.DetailLogger, r *checker.SignedRelea
 	score := 0
 	for _, release := range r.Releases {
 		if release.ZipballURL == "" && release.TarballURL == "" && len(release.Assets) == 0 {
+			dl.Warn(&checker.LogMessage{
+				Text: fmt.Sprintf("Couldn't find assets for release %s at url %s", release.TagName, release.URL),
+			})
 			continue
 		}
 

--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -31,7 +31,7 @@ var (
 const releaseLookBack = 5
 
 // SignedReleases applies the score policy for the Signed-Releases check.
-// nolint
+//nolint
 func SignedReleases(name string, dl checker.DetailLogger, r *checker.SignedReleasesData) checker.CheckResult {
 	if r == nil {
 		e := sce.WithMessage(sce.ErrScorecardInternal, "empty raw data")

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -371,6 +371,55 @@ func TestSignedRelease(t *testing.T) {
 				Error: errors.New("Error getting releases"),
 			},
 		},
+		{
+			name: "Releases with no assets",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					Assets:          []clients.ReleaseAsset{},
+					TarballURL:      "http://foo.com/asset.tar.gz",
+					ZipballURL:      "http://foo.com/asset.zip",
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 0,
+			},
+		},
+		{
+			name: "Some releases with no assets",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					Assets:          []clients.ReleaseAsset{},
+					TarballURL:      "http://foo.com/asset.tar.gz",
+					ZipballURL:      "http://foo.com/asset.zip",
+				},
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.sig",
+							URL:  "http://foo.com/v2.0.0/foo.sig",
+						},
+						{
+							Name: "foo.txt",
+							URL:  "http://foo.com/v1.0.0/foo.txt",
+						},
+					},
+					TarballURL: "http://foo.com",
+					ZipballURL: "http://foo.com/asset.zip",
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 4,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/clients/githubrepo/releases.go
+++ b/clients/githubrepo/releases.go
@@ -72,6 +72,8 @@ func releasesFrom(data []*github.RepositoryRelease) []clients.Release {
 			TagName:         r.GetTagName(),
 			URL:             r.GetURL(),
 			TargetCommitish: r.GetTargetCommitish(),
+			ZipballURL:      r.GetZipballURL(),
+			TarballURL:      r.GetTarballURL(),
 		}
 		for _, a := range r.Assets {
 			release.Assets = append(release.Assets, clients.ReleaseAsset{

--- a/clients/release.go
+++ b/clients/release.go
@@ -20,6 +20,8 @@ type Release struct {
 	URL             string
 	TargetCommitish string
 	Assets          []ReleaseAsset
+	ZipballURL      string
+	TarballURL      string
 }
 
 // ReleaseAsset is part of the Release bundle.

--- a/clients/release.go
+++ b/clients/release.go
@@ -19,9 +19,9 @@ type Release struct {
 	TagName         string
 	URL             string
 	TargetCommitish string
-	Assets          []ReleaseAsset
 	ZipballURL      string
 	TarballURL      string
+	Assets          []ReleaseAsset
 }
 
 // ReleaseAsset is part of the Release bundle.


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Fix issue where we skipped recent releases when looking for signature/provenance.

#### What is the current behavior?
Previously we checked for the presence of any assets. However, source code zips/tarballs aren't considered assets; they are created by default at the GitHub tag.

#### What is the new behavior (if this is a feature change)?**
Source code zips/tarballs 

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #2169.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```