### PR TITLE
🐛 Deduplicate projects in cron job by excluding URL queries and fragments

### DIFF
--- a/cron/internal/data/add/main.go
+++ b/cron/internal/data/add/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net/url"
 	"os"
 	"strings"
 
@@ -73,7 +74,11 @@ func getRepoURLs(iter data.Iterator) ([]data.RepoFormat, error) {
 		if err != nil {
 			return nil, fmt.Errorf("iter.Next: %w", err)
 		}
-		mapURL := strings.ToLower(repo.Repo)
+		parsedURL, err := url.Parse(strings.ToLower(repo.Repo))
+		if err != nil {
+			panic(err)
+		}
+		mapURL := fmt.Sprintf("%s/%s", parsedURL.Host, parsedURL.Path)
 		if _, ok := repoMap[mapURL]; !ok {
 			repoURLs[mapURL] = new(data.RepoFormat)
 			*repoURLs[mapURL] = repo

--- a/cron/internal/data/add/main_test.go
+++ b/cron/internal/data/add/main_test.go
@@ -103,6 +103,20 @@ func TestGetRepoURLs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "SkipDuplicates",
+			filename: "testdata/skip_duplicates.csv",
+			outcome: []data.RepoFormat{
+				{
+					Repo:     "github.com/owner1/repo1",
+					Metadata: []string{"meta1", "meta2"},
+				},
+				{
+					Repo:     "github.com/owner2/repo2",
+					Metadata: []string{"meta3", "meta4"},
+				},
+			},
+		},
 	}
 	for _, testcase := range testcases {
 		testcase := testcase

--- a/cron/internal/data/add/testdata/skip_duplicates.csv
+++ b/cron/internal/data/add/testdata/skip_duplicates.csv
@@ -1,0 +1,5 @@
+repo,metadata
+github.com/owner1/repo1,"meta1,meta2"
+github.com/owner1/repo1,
+github.com/owner2/repo2,"meta3,meta4"
+github.com/owner2/repo2#foo,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
`cron/internal/data/projects.csv` has duplicate entries, which leads to duplicates in the public BigQuery data
e.g.:
```
github.com/adobe-fonts/source-code-pro,criticality_score:0.386850
github.com/adobe-fonts/source-code-pro#release,
```

In the latest BigQuery data, there are two repos with the name `github.com/adobe-fonts/source-code-pro`. One received a score of 4.8 and the other 4.4. The difference is only due to a rate limit error that occurred during one run. They return identical results for me locally.

#### What is the new behavior (if this is a feature change)?**

Uses https://pkg.go.dev/net/url#URL to pull out `host` and `path` when deduplicating `cron/internal/data/projects.csv` entries. Ignoring queries, fragments, etc.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Changes to `cron/internal/data/projects.csv` were generated by running `make add-projects`

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
