### PR TITLE
✨  Allow contents: write for Token-Permissions when doing mvn release 

### DIFF
--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -269,6 +269,17 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
+			name:      "release workflow contents write",
+			filenames: []string{"./testdata/.github/workflows/github-workflow-permissions-contents-writes-release-mvn-release.yaml"},
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  1,
+				NumberOfDebug: 4,
+			},
+		},
+		{
 			name:      "package workflow write",
 			filenames: []string{"./testdata/.github/workflows/github-workflow-permissions-packages-writes.yaml"},
 			expected: scut.TestReturn{

--- a/checks/raw/permissions.go
+++ b/checks/raw/permissions.go
@@ -491,6 +491,16 @@ func isReleasingWorkflow(workflow *actionlint.Workflow, fp string, pdata *permis
 			},
 			LogText: "candidate SLSA publishing workflow using slsa-github-generator",
 		},
+		{
+			// Running mvn release:prepare requires committing changes.
+			// https://maven.apache.org/maven-release/maven-release-plugin/examples/prepare-release.html
+			Steps: []*fileparser.JobMatcherStep{
+				{
+					Run: ".*mvn.*release:prepare.*",
+				},
+			},
+			LogText: "candidate mvn release workflow",
+		},
 	}
 
 	return isWorkflowOf(workflow, fp, jobMatchers, "not a releasing workflow", pdata)

--- a/checks/testdata/.github/workflows/github-workflow-permissions-contents-writes-release-mvn-release.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-permissions-contents-writes-release-mvn-release.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: mvn release workflow
+on: [push]
+permissions: 
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && startsWith(github.event.head_commit.message, '[release]')
+    permissions: 
+      contents: write
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+      - uses: actions/setup-java@2c7a4878f5d120bd643426d54ae1209b29cc01a3 # v3.4.1
+      - name: release
+        run: |
+          git config user.name "${{ github.event.head_commit.committer.name }}"
+          git config user.email "${{ github.event.head_commit.committer.email }}"
+          ./mvnw -B -s .mvn/release.settings.xml release:prepare release:perform -Drepository.url=https://${{ github.actor }}:${{ secrets.github_token }}@github.com/${{ github.repository }}.git -Dcentral.username=raphw -Dcentral.password=${{ secrets.central_password }} -Dgpg.passphrase=${{ secrets.gpg_passphrase }} -Dgpg.keyname=ABCDEF0123456789 -Dgradle.key=${{ secrets.gradle_key }} -Dgradle.secret=${{ secrets.gradle_secret }} -Pchecksum-enforce


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This allows workflow steps that call 'mvn release:prepare' to use `contents: write` permissions as they are needed for doing the maven release process.

(Is it a bug fix, feature, docs update, something else?)

Somewhere between a bug and a feature

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Current behavior is that a workflow that is doing mvn release will get dinged on the Token-Permissions check due to `contents: write` permission for that workflow

#### What is the new behavior (if this is a feature change)?**

A workflow using `mvn release:prepare` will be allowed the `contents: write` permission without lowering the score

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
The Token-Permissions check no longer penalizes workflows with the `contents: write` permission if they are using it to run `mvn release:prepare`.
```
