### PR TITLE
✨ Enable SAST check in cron by default

### DIFF
--- a/cron/internal/config/config.yaml
+++ b/cron/internal/config/config.yaml
@@ -23,7 +23,7 @@ webhook-url:
 cii-data-bucket-url: gs://ossf-scorecard-cii-data
 # TODO: Temporarily remove SAST and CI-Tests which require lot of GitHub API tokens.
 # TODO(#859): Re-add Contributors after fixing inconsistencies.
-blacklisted-checks: SAST,CI-Tests,Contributors
+blacklisted-checks: CI-Tests,Contributors
 metric-exporter: stackdriver
 result-data-bucket-url: gs://ossf-scorecard-data2
 # Raw results.

--- a/cron/internal/config/config_test.go
+++ b/cron/internal/config/config_test.go
@@ -33,7 +33,7 @@ const (
 	prodCompletionThreshold        = 0.99
 	prodWebhookURL                 = ""
 	prodCIIDataBucket              = "gs://ossf-scorecard-cii-data"
-	prodBlacklistedChecks          = "SAST,CI-Tests,Contributors"
+	prodBlacklistedChecks          = "CI-Tests,Contributors"
 	prodShardSize           int    = 10
 	prodMetricExporter      string = "stackdriver"
 	// Raw results.

--- a/cron/k8s/worker.release.yaml
+++ b/cron/k8s/worker.release.yaml
@@ -44,8 +44,6 @@ spec:
           value: "10.4.4.210:80"
         - name: "SCORECARD_API_RESULTS_BUCKET_URL"
           value: "gs://ossf-scorecard-cron-releasetest-results"
-        - name: "SCORECARD_BLACKLISTED_CHECKS"
-          value: "CI-Tests,Contributors"
         resources:
           requests:
             memory: 5Gi


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?

feature

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
SAST is not enabled in the weekly cron

#### What is the new behavior (if this is a feature change)?**
SAST will run in the weekly cron
graphQL API usage will increase from 1 to 2 API calls per repo

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
This is running in the daily release test cron job and is working as intended so far. There haven't been any graphQL failures which would require us to fall back to the REST API endpoint. I'll convert this from draft PR to PR when today's test ends.
 
We have enough graphQL API points available (separate from the REST API limits) to absorb the increase

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
SAST data will be available in the public BigQuery dataset
```
