### PR TITLE
✨ Detect PyUp as an automated dependency update tool

### DIFF
--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -99,6 +99,19 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 				},
 			},
 		})
+	case ".pyup.yml":
+		*ptools = append(*ptools, checker.Tool{
+			Name: "PyUp",
+			URL:  asPointer("https://pyup.io/"),
+			Desc: asPointer("Automated dependency updates for Python."),
+			Files: []checker.File{
+				{
+					Path:   name,
+					Type:   checker.FileTypeSource,
+					Offset: checker.OffsetDefault,
+				},
+			},
+		})
 	default:
 		// Continue iterating.
 		return true, nil

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -110,6 +110,15 @@ func Test_checkDependencyFileExists(t *testing.T) {
 			want:    false,
 			wantErr: false,
 		},
+		{
+			name: ".pyup.yml",
+			args: args{
+				name: ".pyup.yml",
+				data: &[]checker.Tool{},
+			},
+			want:    false,
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This adds PyUp as a detected automated dependency update tool

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

New behavior is that having a .pyup.yml is detected as having an automated dependency tool setup similar to dependabot or renovate.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Projects using PyUp with a .pyup.yml in their repository will now pass the Dependency-Update-Tool check
```
