### PR TITLE
🐛 Skip in-progress gradle/wrapper-validation-action runs

### DIFF
--- a/checks/raw/packaging.go
+++ b/checks/raw/packaging.go
@@ -64,7 +64,7 @@ func Packaging(c *checker.CheckRequest) (checker.PackagingData, error) {
 			continue
 		}
 
-		runs, err := c.RepoClient.ListSuccessfulWorkflowRuns(filepath.Base(fp))
+		runs, err := c.RepoClient.ListWorkflowRuns(filepath.Base(fp), true)
 		if err != nil {
 			return data, fmt.Errorf("Client.Actions.ListWorkflowRunsByFileName: %w", err)
 		}

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -186,8 +186,8 @@ func (client *Client) ListWebhooks() ([]clients.Webhook, error) {
 }
 
 // ListSuccessfulWorkflowRuns implements RepoClient.WorkflowRunsByFilename.
-func (client *Client) ListSuccessfulWorkflowRuns(filename string) ([]clients.WorkflowRun, error) {
-	return client.workflows.listSuccessfulWorkflowRuns(filename)
+func (client *Client) ListWorkflowRuns(filename string, successfulOnly bool) ([]clients.WorkflowRun, error) {
+	return client.workflows.listWorkflowRuns(filename, successfulOnly)
 }
 
 // ListCheckRunsForRef implements RepoClient.ListCheckRunsForRef.

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -195,8 +195,8 @@ func (client *localDirClient) ListContributors() ([]clients.User, error) {
 	return nil, fmt.Errorf("ListContributors: %w", clients.ErrUnsupportedFeature)
 }
 
-// ListSuccessfulWorkflowRuns implements RepoClient.WorkflowRunsByFilename.
-func (client *localDirClient) ListSuccessfulWorkflowRuns(filename string) ([]clients.WorkflowRun, error) {
+// ListWorkflowRuns implements RepoClient.WorkflowRunsByFilename.
+func (client *localDirClient) ListWorkflowRuns(filename string, successfulOnly bool) ([]clients.WorkflowRun, error) {
 	return nil, fmt.Errorf("ListSuccessfulWorkflowRuns: %w", clients.ErrUnsupportedFeature)
 }
 

--- a/clients/mockclients/repo_client.go
+++ b/clients/mockclients/repo_client.go
@@ -288,21 +288,6 @@ func (mr *MockRepoClientMockRecorder) ListStatuses(ref interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListStatuses", reflect.TypeOf((*MockRepoClient)(nil).ListStatuses), ref)
 }
 
-// ListSuccessfulWorkflowRuns mocks base method.
-func (m *MockRepoClient) ListSuccessfulWorkflowRuns(filename string) ([]clients.WorkflowRun, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListSuccessfulWorkflowRuns", filename)
-	ret0, _ := ret[0].([]clients.WorkflowRun)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListSuccessfulWorkflowRuns indicates an expected call of ListSuccessfulWorkflowRuns.
-func (mr *MockRepoClientMockRecorder) ListSuccessfulWorkflowRuns(filename interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSuccessfulWorkflowRuns", reflect.TypeOf((*MockRepoClient)(nil).ListSuccessfulWorkflowRuns), filename)
-}
-
 // ListWebhooks mocks base method.
 func (m *MockRepoClient) ListWebhooks() ([]clients.Webhook, error) {
 	m.ctrl.T.Helper()
@@ -316,6 +301,21 @@ func (m *MockRepoClient) ListWebhooks() ([]clients.Webhook, error) {
 func (mr *MockRepoClientMockRecorder) ListWebhooks() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWebhooks", reflect.TypeOf((*MockRepoClient)(nil).ListWebhooks))
+}
+
+// ListWorkflowRuns mocks base method.
+func (m *MockRepoClient) ListWorkflowRuns(filename string, successfulOnly bool) ([]clients.WorkflowRun, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListWorkflowRuns", filename, successfulOnly)
+	ret0, _ := ret[0].([]clients.WorkflowRun)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListWorkflowRuns indicates an expected call of ListWorkflowRuns.
+func (mr *MockRepoClientMockRecorder) ListWorkflowRuns(filename, successfulOnly interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListWorkflowRuns", reflect.TypeOf((*MockRepoClient)(nil).ListWorkflowRuns), filename, successfulOnly)
 }
 
 // Search mocks base method.

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -41,7 +41,7 @@ type RepoClient interface {
 	ListIssues() ([]Issue, error)
 	ListReleases() ([]Release, error)
 	ListContributors() ([]User, error)
-	ListSuccessfulWorkflowRuns(filename string) ([]WorkflowRun, error)
+	ListWorkflowRuns(filename string, successfulOnly bool) ([]WorkflowRun, error)
 	ListCheckRunsForRef(ref string) ([]CheckRun, error)
 	ListStatuses(ref string) ([]Status, error)
 	ListWebhooks() ([]Webhook, error)

--- a/clients/workflows.go
+++ b/clients/workflows.go
@@ -16,6 +16,8 @@ package clients
 
 // WorkflowRun represents VCS WorkflowRun.
 type WorkflowRun struct {
-	HeadSHA *string `json:"head_sha"`
-	URL     string
+	HeadSHA    *string `json:"head_sha"`
+	URL        string
+	Complete   bool
+	Successful bool
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

In-progress runs of the Action are considered failing, leading to inconsistent results (if run on a repo that would normally be OK while the Action is still running.)

#### What is the new behavior (if this is a feature change)?**

In-progress runs of the Action are ignored, latest complete run is used.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Does this PR introduce a user-facing change?

```release-note
Binary-Artifacts no longer considers in-progress workflow runs for gradle/wrapper-validation-action to be failing
```
