### PR TITLE
🐛 Wrap check errors with distinct error for scorecard-action to ignore.

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/clients"
 	docs "github.com/ossf/scorecard/v4/docs/checks"
+	sce "github.com/ossf/scorecard/v4/errors"
 	sclog "github.com/ossf/scorecard/v4/log"
 	"github.com/ossf/scorecard/v4/options"
 	"github.com/ossf/scorecard/v4/pkg"
@@ -162,7 +163,7 @@ func rootCmd(o *options.Options) error {
 	// intentionally placed at end to preserve outputting results, even if a check has a runtime error
 	for _, result := range repoResult.Checks {
 		if result.Error != nil {
-			return fmt.Errorf("one or more checks had a runtime error: %w", result.Error)
+			return sce.WithMessage(sce.ErrorCheckRuntime, fmt.Sprintf("%s: %v", result.Name, result.Error))
 		}
 	}
 	return nil

--- a/errors/public.go
+++ b/errors/public.go
@@ -30,8 +30,10 @@ var (
 	ErrorInvalidURL = errors.New("invalid repo flag")
 	// ErrorShellParsing indicates there was an error when parsing shell code.
 	ErrorShellParsing = errors.New("error parsing shell code")
-	// ErrorUnsupportedCheck indicates check caanot be run for given request.
+	// ErrorUnsupportedCheck indicates check cannot be run for given request.
 	ErrorUnsupportedCheck = errors.New("check is not supported for this request")
+	// ErrorCheckRuntime indicates an individual check had a runtime error.
+	ErrorCheckRuntime = errors.New("check runtime error")
 )
 
 // WithMessage wraps any of the errors listed above.


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?
bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Runtime errors in individual checks bubble up to any cobra command created via `cmd.New()` after #2133
This unintentionally broke scorecard-action https://github.com/ossf/scorecard-action/issues/856

#### What is the new behavior (if this is a feature change)?**
Runtime errors are wrapped in a new error, `ErrorCheckRuntime` so that `scorecard-action` can ignore them. Which will be implemented in a separate PR after the next scorecard release.

- [ ] Tests for the changes have been added (for bug fixes/features)

This is a pretty difficult thing to test, forcing runtime errors to occur in a check.

#### Which issue(s) this PR fixes
Partially fixes https://github.com/ossf/scorecard-action/issues/856
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
