### PR TITLE
🌱 cron: make CSV header optional (3/n)

### DIFF
--- a/cron/internal/data/iterator.go
+++ b/cron/internal/data/iterator.go
@@ -55,7 +55,7 @@ type csvIterator struct {
 	count   int
 }
 
-// check if the most recently decoded record is a header, and skip it if it is
+// check if the most recently decoded record is a header, and skip it if it is.
 func (reader *csvIterator) ignoreHeader() {
 	header, err := csvutil.Header(RepoFormat{}, "csv")
 	if err != nil {

--- a/cron/internal/data/iterator_test.go
+++ b/cron/internal/data/iterator_test.go
@@ -153,6 +153,37 @@ func TestCsvIterator(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Ignore First Header Row",
+			filename: "testdata/ignore_header.csv",
+			outcomes: []outcome{
+				{
+					hasError: false,
+					repo: RepoFormat{
+						Repo: "github.com/owner1/repo1",
+					},
+				},
+				{
+					// will error due to GitHub URL sanity check
+					hasError: true,
+					repo: RepoFormat{
+						Repo: "repo",
+					},
+				},
+			},
+		},
+		{
+			name:     "No Header Row",
+			filename: "testdata/no_header.csv",
+			outcomes: []outcome{
+				{
+					hasError: false,
+					repo: RepoFormat{
+						Repo: "github.com/owner1/repo1",
+					},
+				},
+			},
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/cron/internal/data/iterator_test.go
+++ b/cron/internal/data/iterator_test.go
@@ -184,6 +184,11 @@ func TestCsvIterator(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:     "Only Header Row",
+			filename: "testdata/only_header.csv",
+			outcomes: []outcome{},
+		},
 	}
 
 	for _, testcase := range testcases {

--- a/cron/internal/data/testdata/ignore_header.csv
+++ b/cron/internal/data/testdata/ignore_header.csv
@@ -1,0 +1,3 @@
+repo,metadata
+github.com/owner1/repo1,
+repo,metadata

--- a/cron/internal/data/testdata/no_header.csv
+++ b/cron/internal/data/testdata/no_header.csv
@@ -1,0 +1,1 @@
+github.com/owner1/repo1,

--- a/cron/internal/data/testdata/only_header.csv
+++ b/cron/internal/data/testdata/only_header.csv
@@ -1,0 +1,1 @@
+repo,metadata


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?

Part of a series of refactors to generalize the cron infrastructure to enable re-use by the [ossf criticality score project](https://github.com/ossf/criticality_score)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
CSV files read by the controller needed to have a header line:
```
repo,metadata
```

#### What is the new behavior (if this is a feature change)?**
The header line is now optional, and is skipped by the `data.csvIterator`.
- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Follow up PR for #2235 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
