### PR TITLE
🐛 Prevent partial cron transfers caused by controller failures

### DIFF
--- a/cron/internal/bq/main.go
+++ b/cron/internal/bq/main.go
@@ -90,9 +90,12 @@ func getBucketSummary(ctx context.Context, bucketURL string) (*bucketSummary, er
 	return &summary, nil
 }
 
+// isCompleted checks if the percentage of completed shards is over the desired completion threshold.
+// It also returns false to prevent transfers in cases where the expected number of shards is 0,
+// as either the .shard_metadata file is missing, or there is nothing to transfer anyway.
 func isCompleted(expected, created int, completionThreshold float64) bool {
 	completedPercentage := float64(created) / float64(expected)
-	return completedPercentage >= completionThreshold
+	return expected > 0 && completedPercentage >= completionThreshold
 }
 
 func transferDataToBq(ctx context.Context,

--- a/cron/internal/bq/main_test.go
+++ b/cron/internal/bq/main_test.go
@@ -1,0 +1,62 @@
+// Copyright 2022 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"testing"
+)
+
+func TestIsCompleted(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name               string
+		inputExpected      int
+		inputCreated       int
+		completedThreshold float64
+		expectedCompleted  bool
+	}{
+		{
+			name:               "All shards completed",
+			inputExpected:      2,
+			inputCreated:       2,
+			completedThreshold: 0.5,
+			expectedCompleted:  true,
+		},
+		{
+			name:               "No expected shards",
+			inputExpected:      0,
+			inputCreated:       0,
+			completedThreshold: 0.9,
+			expectedCompleted:  false,
+		},
+		{
+			name:               "Completed shards same as threshold",
+			inputExpected:      10,
+			inputCreated:       1,
+			completedThreshold: 0.1,
+			expectedCompleted:  true,
+		},
+	}
+	for _, testcase := range testcases {
+		testcase := testcase
+		t.Run(testcase.name, func(t *testing.T) {
+			t.Parallel()
+			completed := isCompleted(testcase.inputExpected, testcase.inputCreated, testcase.completedThreshold)
+			if completed != testcase.expectedCompleted {
+				t.Errorf("test failed - expected: %t, got: %t", testcase.expectedCompleted, completed)
+			}
+		})
+	}
+}

--- a/cron/internal/worker/main.go
+++ b/cron/internal/worker/main.go
@@ -204,6 +204,15 @@ func startMetricsExporter() (monitoring.Exporter, error) {
 	return exporter, nil
 }
 
+func hasMetadataFile(ctx context.Context, req *data.ScorecardBatchRequest, bucketURL string) (bool, error) {
+	filename := data.GetBlobFilename(config.ShardMetadataFilename, req.GetJobTime().AsTime())
+	exists, err := data.BlobExists(ctx, bucketURL, filename)
+	if err != nil {
+		return false, fmt.Errorf("data.BlobExists: %w", err)
+	}
+	return exists, nil
+}
+
 func main() {
 	ctx := context.Background()
 
@@ -286,6 +295,15 @@ func main() {
 			logger.Info("subscription returned nil message during Receive, exiting")
 			break
 		}
+
+		// don't process requests from jobs without metadata files, as the results will never be transferred.
+		// https://github.com/ossf/scorecard/issues/2307
+		if hasMd, err := hasMetadataFile(ctx, req, bucketURL); !hasMd || err != nil {
+			// nack the message so it can be tried later, as the metadata file may not have been created yet.
+			subscriber.Nack()
+			continue
+		}
+
 		if err := processRequest(ctx, req, blacklistedChecks,
 			bucketURL, rawBucketURL, apiBucketURL, checkDocs,
 			repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, logger); err != nil {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
See #2307 for details.

#### What is the new behavior (if this is a feature change)?**
1. the BQ transfer tool will not transfer results for jobs without a `.shard_metadata` file.
2. cron workers won't process requests for jobs without a `.shard_metadata` file.

Note: This makes assumptions about how the pubsub subscription is configured, namely that messages redeliveries are limited. The default value (5 re-tries) works, and is currently being used by scorecardcron.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
#2307 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
