### PR TITLE
🐛 Ignore Bot commits when checking for Code Review

### DIFF
--- a/checks/evaluation/code_review_test.go
+++ b/checks/evaluation/code_review_test.go
@@ -55,10 +55,10 @@ func TestCodeReview(t *testing.T) {
 			rawData: &checker.CodeReviewData{
 				DefaultBranchChangesets: []checker.Changeset{
 					{
-						Commits: []clients.Commit{{SHA: "1"}},
+						Commits: []clients.Commit{{SHA: "a"}},
 					},
 					{
-						Commits: []clients.Commit{{SHA: "1"}},
+						Commits: []clients.Commit{{SHA: "a"}},
 					},
 				},
 			},
@@ -75,7 +75,7 @@ func TestCodeReview(t *testing.T) {
 						RevisionID:     "1",
 						Commits: []clients.Commit{
 							{
-								SHA: "1",
+								SHA: "a",
 								AssociatedMergeRequest: clients.PullRequest{
 									Reviews: []clients.Review{
 										{
@@ -83,6 +83,15 @@ func TestCodeReview(t *testing.T) {
 										},
 									},
 								},
+							},
+						},
+					},
+					{
+						RevisionID: "b",
+						Commits: []clients.Commit{
+							{
+								Committer: clients.User{Login: "alice[bot]", IsBot: true},
+								SHA:       "b",
 							},
 						},
 					},
@@ -99,7 +108,7 @@ func TestCodeReview(t *testing.T) {
 					{
 						ReviewPlatform: checker.ReviewPlatformGerrit,
 						RevisionID:     "1",
-						Commits:        []clients.Commit{{SHA: "1"}},
+						Commits:        []clients.Commit{{SHA: "a"}},
 					},
 				},
 			},

--- a/checks/raw/code_review.go
+++ b/checks/raw/code_review.go
@@ -143,6 +143,9 @@ func getChangesets(commits []clients.Commit) []checker.Changeset {
 
 	for i := range commits {
 		rev := detectCommitRevisionInfo(&commits[i])
+		if rev.ID == "" {
+			rev.ID = commits[i].SHA
+		}
 
 		if changeset, ok := changesetsByRevInfo[rev]; !ok {
 			newChangeset := checker.Changeset{

--- a/clients/gitlabrepo/contributors.go
+++ b/clients/gitlabrepo/contributors.go
@@ -77,6 +77,7 @@ func (handler *contributorsHandler) setup() error {
 				Companies:        []string{users[0].Organization},
 				NumContributions: contrib.Commits,
 				ID:               int64(users[0].ID),
+				IsBot:            users[0].Bot,
 			}
 			handler.contributors = append(handler.contributors, contributor)
 		}

--- a/clients/user.go
+++ b/clients/user.go
@@ -21,6 +21,7 @@ type User struct {
 	Organizations    []User
 	NumContributions int
 	ID               int64
+	IsBot            bool
 }
 
 // RepoAssociation is how a user is associated with a repository.


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Ignore bot commits when checking for code review. This is an update to the evaluation logic as well as clients. It checks for Bots without relying solely on committer names.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Today, bot commits that are pushed directly to the default branch are considered unreviewed.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2302

#### Special notes for your reviewer
Raw result format is also updated.