### PR TITLE
🐛 Ignore line continuations when matching run steps.

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -426,8 +426,9 @@ func stepsMatch(stepToMatch *JobMatcherStep, step *actionlint.Step) bool {
 		if run == nil {
 			return false
 		}
+		withoutLineContinuations := regexp.MustCompile("\\\\(\n|\r|\r\n)").ReplaceAllString(run.Value, "")
 		r := regexp.MustCompile(stepToMatch.Run)
-		if !r.MatchString(run.Value) {
+		if !r.MatchString(withoutLineContinuations) {
 			return false
 		}
 	}

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -939,6 +939,11 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "maven publish multi-line",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-maven-multi-line.yaml",
+			expected: true,
+		},
+		{
 			name:     "gradle publish",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-gradle.yaml",
 			expected: true,
@@ -1004,7 +1009,7 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			}
 			workflow, errs := actionlint.Parse(content)
 			if len(errs) > 0 && workflow == nil {
-				t.Errorf("cannot parse file: %v", err)
+				t.Errorf("cannot parse file: %v", errs)
 			}
 			p := strings.Replace(tt.filename, "../testdata/", "", 1)
 

--- a/checks/testdata/.github/workflows/github-workflow-packaging-maven-multi-line.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-maven-multi-line.yaml
@@ -1,0 +1,23 @@
+# Copyright 2022 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+      - run: |
+          mvn \
+            clean deploy


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?

Bug fix for #2321 

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Line continuations in `run` steps prevented our regex from desired patterns.

#### What is the new behavior (if this is a feature change)?**
Line continuations are removed before matching any `run` steps. This applies to all instances which attempt match run steps, not just maven or packaging usages.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2321 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
