### PR TITLE
🐛 Fix --local functionality

### DIFF
--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -66,8 +66,11 @@ func runEnabledChecks(ctx context.Context,
 
 func getRepoCommitHash(r clients.RepoClient) (string, error) {
 	commits, err := r.ListCommits()
-
-	if err != nil && !errors.Is(err, clients.ErrUnsupportedFeature) {
+	if err != nil {
+		// allow --local repos to still process
+		if errors.Is(err, clients.ErrUnsupportedFeature) {
+			return "unknown", nil
+		}
 		return "", sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("ListCommits:%v", err.Error()))
 	}
 


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?

Bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
A bug prevents running on local repos

#### What is the new behavior (if this is a feature change)?**

Running scorecard locally reports a commit of "unknown" since the local directory client doesn't support `ListCommits`. "unknown" is what was being returned before by `sigs.k8s.io/release-utils/version.GetVersionInfo()`
```
  "scorecard": {
    "version": "",
    "commit": "unknown"
  },
  ```
- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2334 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
