### PR TITLE
⚠️ Warn and not fail if job perms are content:write

### DIFF
--- a/checks/evaluation/permissions.go
+++ b/checks/evaluation/permissions.go
@@ -241,8 +241,9 @@ func calculateScore(result map[string]permissions) int {
 
 		// contents.
 		// Allows attacker to commit unreviewed code.
+		// Scoring does not apply to job-level permissions, as this is a common place to use third-party actions.
 		// High risk: -10
-		if permissionIsPresent(perms, "contents") {
+		if permissionIsPresentInTopLevel(perms, "contents") {
 			score -= checker.MaxResultScore
 		}
 

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -251,7 +251,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 			filenames: []string{"./testdata/.github/workflows/github-workflow-permissions-contents-writes-no-release.yaml"},
 			expected: scut.TestReturn{
 				Error:         nil,
-				Score:         checker.MinResultScore,
+				Score:         checker.MaxResultScore,
 				NumberOfWarn:  1,
 				NumberOfInfo:  1,
 				NumberOfDebug: 4,


### PR DESCRIPTION
Following discussion in #2338, it has been determined that the permissions check should no longer deduct when a job is set to write. This code is a minimalist change, and will require additional polish/cleanup of obsolete logic later.

Signed-off-by: Eddie Knight <iv.eddieknight@gmail.com>

#### What kind of change does this PR introduce?

Changes how scoring is done for token permissions

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The Token-Permissions check is opinionated regarding job-level permissions.

#### What is the new behavior (if this is a feature change)?**

The Token-Permissions check now will only issue a warning regarding job-level permissions.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
 
Fixes #2338

#### Special notes for your reviewer

I wasn't able to get the Token-Permissions check to report anything lower than 10/10 when running locally, even for repos that are less than 10 when checked via the API. As such, my validation checks were limited. I suggest a regular contributor or maintainer validates these changes before merging.

#### Does this PR introduce a user-facing change?

```release-note
Job Level Permissions will no longer be evaluated on the Scorecard, but warnings will still be issued.
```
