### PR TITLE
🌱 Add soft mem limit to controller k8s spec

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang@sha256:ea3d912d500b1ae0a691b2e53eb8a6345b579d42d7e6a64acca83d274b949740 AS base
+# golang:1.19
+FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/bq/Dockerfile
+++ b/cron/internal/bq/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang@sha256:ea3d912d500b1ae0a691b2e53eb8a6345b579d42d7e6a64acca83d274b949740 AS base
+# golang:1.19
+FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/cii/Dockerfile
+++ b/cron/internal/cii/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang@sha256:ea3d912d500b1ae0a691b2e53eb8a6345b579d42d7e6a64acca83d274b949740 AS base
+# golang:1.19
+FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/controller/Dockerfile
+++ b/cron/internal/controller/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang@sha256:ea3d912d500b1ae0a691b2e53eb8a6345b579d42d7e6a64acca83d274b949740 AS base
+# golang:1.19
+FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/webhook/Dockerfile
+++ b/cron/internal/webhook/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang@sha256:ea3d912d500b1ae0a691b2e53eb8a6345b579d42d7e6a64acca83d274b949740 AS base
+# golang:1.19
+FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/worker/Dockerfile
+++ b/cron/internal/worker/Dockerfile
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang@sha256:ea3d912d500b1ae0a691b2e53eb8a6345b579d42d7e6a64acca83d274b949740 AS base
+# golang:1.19
+FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/k8s/controller.release.yaml
+++ b/cron/k8s/controller.release.yaml
@@ -55,6 +55,8 @@ spec:
               args: ["--config=/etc/scorecard/config.yaml", "cron/internal/data/projects.release.csv"]
               imagePullPolicy: Always
               env:
+                - name: GOMEMLIMIT
+                  value: "950MiB"
                 - name: SCORECARD_REQUEST_TOPIC_URL
                   value: "gcppubsub://projects/openssf/topics/scorecard-batch-requests-releasetest"
                 - name: SCORECARD_DATA_BUCKET_URL

--- a/cron/k8s/controller.yaml
+++ b/cron/k8s/controller.yaml
@@ -54,6 +54,9 @@ spec:
               image: gcr.io/openssf/scorecard-batch-controller:stable
               args: ["--config=/etc/scorecard/config.yaml", "cron/internal/data/projects.csv"]
               imagePullPolicy: Always
+              env:
+                - name: GOMEMLIMIT
+                  value: "950MiB"
               resources:
                 limits:
                   memory: 1Gi


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

* Docker images now use go1.19 like the rest of scorecard. (which was also needed for `GOMEMLIMIT`)
* The controller now has a soft memory limit (with a 5-10% overhead as suggested by the [GC guide](https://tip.golang.org/doc/gc-guide)). The controller failed in a recent run due to `OOMKilled`

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Will apply the config change to the release test first, and then the production controller after a few days

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
