### PR TITLE
🌱 Disable dependabot auto rebasing when any PR is merged

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
   directory: "/"
   schedule:
     interval: daily
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
   open-pull-requests-limit: 3
@@ -11,6 +12,7 @@ updates:
   directory: "/tools"
   schedule:
     interval: daily
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
   open-pull-requests-limit: 3
@@ -18,37 +20,57 @@ updates:
   directory: "/"
   schedule:
       interval: "daily"
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
 - package-ecosystem: docker
   directory: "/"
   schedule:
     interval: daily
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
   open-pull-requests-limit: 3
 - package-ecosystem: docker
-  directory: "/cron/bq"
+  directory: "/cron/internal/bq"
   schedule:
     interval: daily
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
   open-pull-requests-limit: 3
 - package-ecosystem: docker
-  directory: "/cron/worker"
+  directory: "/cron/internal/worker"
   schedule:
     interval: daily
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
 - package-ecosystem: docker
-  directory: "/cron/webhook"
+  directory: "/cron/internal/webhook"
   schedule:
     interval: daily
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
 - package-ecosystem: docker
-  directory: "/cron/controller"
+  directory: "/cron/internal/controller"
   schedule:
     interval: daily
+  rebase-strategy: disabled
+  commit-message:
+      prefix: ":seedling:"
+- package-ecosystem: docker
+  directory: "/cron/internal/cii"
+  schedule:
+    interval: daily
+  rebase-strategy: disabled
+  commit-message:
+      prefix: ":seedling:"
+- package-ecosystem: docker
+  directory: "/clients/githubrepo/roundtripper/tokens/server"
+  schedule:
+    interval: daily
+  rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?
Dependabot config update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Dependabot auto rebases every one of its open PR when any PR gets merged into main. 
This leads to a lot of unneeded CI runs.

#### What is the new behavior (if this is a feature change)?**
* disables automatic rebasing, so we can rebase 1 by 1 as needed when we approve PRs
* includes some missed Dockerfiles. Some of the distroless base images are 1 year out of date.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Docs for this flag are [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#rebase-strategy)

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
