### PR TITLE
:bug: Replace deprecated set-output with GITHUB_OUTPUT

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -46,7 +46,7 @@ jobs:
           check-latest: true
       - name: Configure ldflags
         id: ldflags
-        run: echo "::set-output name=version_flags::$(./scripts/version-ldflags)"
+        run: echo "version_flags=$(./scripts/version-ldflags)" >> "$GITHUB_OUTPUT"
       - name: Import GPG key
         id: import_gpg
         uses: crazy-max/ghaction-import-gpg@c8bb57c57e8df1be8c73ff3d59deab1dbc00e0d1 # v3.1.0
@@ -71,7 +71,7 @@ jobs:
           set -euo pipefail
 
           checksum_file=$(echo "$ARTIFACTS" | jq -r '.[] | select (.type=="Checksum") | .path')
-          echo "::set-output name=hashes::$(cat $checksum_file | base64 -w0)"
+          echo "hashes=$(cat $checksum_file | base64 -w0)" >> "$GITHUB_OUTPUT"
 
   provenance:
     needs: [goreleaser]

--- a/.github/workflows/slsa-goreleaser.yml
+++ b/.github/workflows/slsa-goreleaser.yml
@@ -20,7 +20,7 @@ jobs:
           fetch-depth: 0
       - id: ldflags
         run: |
-          echo "::set-output name=value::$(./scripts/version-ldflags)"
+          echo "value=$(./scripts/version-ldflags)" >> "$GITHUB_OUTPUT"
 
   # Trusted builder.
   build:


### PR DESCRIPTION
#### What kind of change does this PR introduce?

 Replace deprecated set-output with GITHUB_OUTPUT on workflows.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Use set-output to set outputs in workflows.

#### What is the new behavior (if this is a feature change)?**

Use GITHUB_OUTPUT to set outputs in workflows.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes https://github.com/ossf/scorecard/issues/2376

#### Special notes for your reviewer

I was not able to run E2E tests with make e2e-pat.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

NONE