### PR TITLE
🌱 Manual bump every docker distroless:base to `99133cb`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,7 +26,7 @@ updates:
 - package-ecosystem: docker
   directory: "/"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
@@ -34,7 +34,7 @@ updates:
 - package-ecosystem: docker
   directory: "/cron/internal/bq"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
@@ -42,35 +42,35 @@ updates:
 - package-ecosystem: docker
   directory: "/cron/internal/worker"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
 - package-ecosystem: docker
   directory: "/cron/internal/webhook"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
 - package-ecosystem: docker
   directory: "/cron/internal/controller"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
 - package-ecosystem: docker
   directory: "/cron/internal/cii"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
 - package-ecosystem: docker
   directory: "/clients/githubrepo/roundtripper/tokens/server"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build-scorecard
 
-FROM gcr.io/distroless/base:nonroot@sha256:533c15ef2acb1d3b1cd4e58d8aa2740900cae8f579243a53c53a6e28bcac0684
+FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
 COPY --from=build /src/scorecard /
 ENTRYPOINT [ "/scorecard" ]

--- a/cron/internal/bq/Dockerfile
+++ b/cron/internal/bq/Dockerfile
@@ -25,6 +25,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build-bq-transfer
 
-FROM gcr.io/distroless/base:nonroot@sha256:19d927c16ddb5415d5f6f529dbbeb13c460b84b304b97af886998d3fcf18ac81
+FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
 COPY --from=transfer /src/cron/internal/bq/data-transfer cron/internal/bq/data-transfer
 ENTRYPOINT ["cron/internal/bq/data-transfer"]

--- a/cron/internal/cii/Dockerfile
+++ b/cron/internal/cii/Dockerfile
@@ -25,6 +25,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build-cii-worker
 
-FROM gcr.io/distroless/base:nonroot@sha256:46d4514c17aca7a68559ee03975983339fc548e6d1014e2d7633f9123f2d3c59
+FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
 COPY --from=cii /src/cron/internal/cii/cii-worker cron/internal/cii/cii-worker
 ENTRYPOINT ["cron/internal/cii/cii-worker"]

--- a/cron/internal/controller/Dockerfile
+++ b/cron/internal/controller/Dockerfile
@@ -31,7 +31,7 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build-controller
 
-FROM gcr.io/distroless/base:nonroot@sha256:d65ac1a65a4d82a48ebd0a22aea2acdd95d7abeeda245dfee932ec0018c781f4
+FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
 COPY ./cron/internal/data/projects*csv cron/internal/data/
 COPY --from=shuffle /src/cron/internal/data/projects.release.csv cron/internal/data/projects.release.csv
 COPY --from=controller /src/cron/internal/controller/controller cron/internal/controller/controller

--- a/cron/internal/webhook/Dockerfile
+++ b/cron/internal/webhook/Dockerfile
@@ -25,6 +25,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build-webhook
 
-FROM gcr.io/distroless/base:nonroot@sha256:d65ac1a65a4d82a48ebd0a22aea2acdd95d7abeeda245dfee932ec0018c781f4
+FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
 COPY --from=webhook /src/cron/internal/webhook/webhook cron/internal/webhook/webhook
 ENTRYPOINT ["cron/internal/webhook/webhook"]

--- a/cron/internal/worker/Dockerfile
+++ b/cron/internal/worker/Dockerfile
@@ -25,6 +25,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build-worker
 
-FROM gcr.io/distroless/base:nonroot@sha256:d65ac1a65a4d82a48ebd0a22aea2acdd95d7abeeda245dfee932ec0018c781f4
+FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
 COPY --from=worker /src/cron/internal/worker/worker cron/internal/worker/worker
 ENTRYPOINT ["cron/internal/worker/worker"]


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Manual group of dependabot PRs, to handle the updates in 1 PR instead of 5.
Also cuts the docker updates to weekly as discussed [here](https://github.com/ossf/scorecard/pull/2378#pullrequestreview-1151317755)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2379
Fixes #2380
Fixes #2381 
Fixes #2382  
Fixes #2383
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
