### PR TITLE
🌱 Fail unit-test job if codecov upload fails

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -90,13 +90,8 @@ jobs:
       - name: codecov
         uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 2.1.0
         with:
-         files: ./e2e-coverage.out
-         verbose: true
-
-      - name: codecov attestor
-        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 2.1.0
-        with:
-         files: ./attestor/e2e/e2e-coverage.out
+         fail_ci_if_error: true
+         files: ./e2e-coverage.out,./attestor/e2e/e2e-coverage.out
          verbose: true
 
       - name: find comment

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,12 +68,8 @@ jobs:
      - name: Upload codecoverage
        uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 2.1.0
        with:
-         files: ./unit-coverage.out
-         verbose: true
-     - name: Upload codecoverage attestor
-       uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 2.1.0
-       with:
-         files: ./attestor/unit-coverage.out
+         fail_ci_if_error: true
+         files: ./unit-coverage.out,./attestor/unit-coverage.out
          verbose: true
   generate-mocks:
     name: generate-mocks


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?
GitHub action change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
codecov fails silently. And the PR waits forever for results to be posted.

#### What is the new behavior (if this is a feature change)?**
the `unit-test` job will fail and can be re-run. 
Typos which affect the codecov upload can be spotted easier

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2411 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
