### PR TITLE
🌱 enable more performant isText

### DIFF
--- a/cron/k8s/worker.release.yaml
+++ b/cron/k8s/worker.release.yaml
@@ -44,8 +44,6 @@ spec:
               value: "10.4.4.210:80"
             - name: "SCORECARD_API_RESULTS_BUCKET_URL"
               value: "gs://ossf-scorecard-cron-releasetest-results"
-            - name: SCORECARD_COMPARE_ISTEXT
-              value: "1"
           resources:
             requests:
               memory: 5Gi


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?
performance optimization

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Code relies on calling `unicode.IsPrint`
#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2412
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Over the last 3 days, there have been ~40k files in the cron worker release test where the two `isText` implementations have differed.
 
98% of these differences were the old `raw.isText` returning `false` and new implementation returning `true`. The difference is due to space characters that aren't the ASCII space character (which is the only space where `unicode.IsPrint()` returns true). The following spaces were prevalent in the test repos:
*  [Byte Order Mark](https://en.wikipedia.org/wiki/Byte_order_mark)
* [NBSP](https://en.wikipedia.org/wiki/Non-breaking_space)

The other 2% were the new implementation returning `false` and the old implementation returning `true`. This was due to UTF-8 decoding errors on files which were not UTF-8 encoded (e.g. simplified Chinese GB2312). As a result, the condition which failed on `utf8.RuneError` (`0xFFFD`) was removed.
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
