### PR TITLE
:seedling: cron: expose the stackdriver prefix as a config variable so it can be changed.

### DIFF
--- a/cron/config/config.go
+++ b/cron/config/config.go
@@ -42,19 +42,20 @@ const (
 	configUsage       string = "Location of config file. Required"
 	inputBucketParams string = "input-bucket"
 
-	projectID              string = "SCORECARD_PROJECT_ID"
-	requestTopicURL        string = "SCORECARD_REQUEST_TOPIC_URL"
-	requestSubscriptionURL string = "SCORECARD_REQUEST_SUBSCRIPTION_URL"
-	bigqueryDataset        string = "SCORECARD_BIGQUERY_DATASET"
-	completionThreshold    string = "SCORECARD_COMPLETION_THRESHOLD"
-	shardSize              string = "SCORECARD_SHARD_SIZE"
-	webhookURL             string = "SCORECARD_WEBHOOK_URL"
-	metricExporter         string = "SCORECARD_METRIC_EXPORTER"
-	bigqueryTable          string = "SCORECARD_BIGQUERY_TABLE"
-	resultDataBucketURL    string = "SCORECARD_DATA_BUCKET_URL"
-	apiResultsBucketURL    string = "SCORECARD_API_RESULTS_BUCKET_URL"
-	inputBucketURL         string = "SCORECARD_INPUT_BUCKET_URL"
-	inputBucketPrefix      string = "SCORECARD_INPUT_BUCKET_PREFIX"
+	projectID               string = "SCORECARD_PROJECT_ID"
+	requestTopicURL         string = "SCORECARD_REQUEST_TOPIC_URL"
+	requestSubscriptionURL  string = "SCORECARD_REQUEST_SUBSCRIPTION_URL"
+	bigqueryDataset         string = "SCORECARD_BIGQUERY_DATASET"
+	completionThreshold     string = "SCORECARD_COMPLETION_THRESHOLD"
+	shardSize               string = "SCORECARD_SHARD_SIZE"
+	webhookURL              string = "SCORECARD_WEBHOOK_URL"
+	metricExporter          string = "SCORECARD_METRIC_EXPORTER"
+	metricStackdriverPrefix string = "SCORECARD_METRIC_STACKDRIVER_PREFIX"
+	bigqueryTable           string = "SCORECARD_BIGQUERY_TABLE"
+	resultDataBucketURL     string = "SCORECARD_DATA_BUCKET_URL"
+	apiResultsBucketURL     string = "SCORECARD_API_RESULTS_BUCKET_URL"
+	inputBucketURL          string = "SCORECARD_INPUT_BUCKET_URL"
+	inputBucketPrefix       string = "SCORECARD_INPUT_BUCKET_PREFIX"
 )
 
 var (
@@ -71,19 +72,20 @@ var (
 
 //nolint:govet
 type config struct {
-	ProjectID              string                       `yaml:"project-id"`
-	ResultDataBucketURL    string                       `yaml:"result-data-bucket-url"`
-	RequestTopicURL        string                       `yaml:"request-topic-url"`
-	RequestSubscriptionURL string                       `yaml:"request-subscription-url"`
-	BigQueryDataset        string                       `yaml:"bigquery-dataset"`
-	BigQueryTable          string                       `yaml:"bigquery-table"`
-	CompletionThreshold    float32                      `yaml:"completion-threshold"`
-	WebhookURL             string                       `yaml:"webhook-url"`
-	MetricExporter         string                       `yaml:"metric-exporter"`
-	ShardSize              int                          `yaml:"shard-size"`
-	InputBucketURL         string                       `yaml:"input-bucket-url"`
-	InputBucketPrefix      string                       `yaml:"input-bucket-prefix"`
-	AdditionalParams       map[string]map[string]string `yaml:"additional-params"`
+	ProjectID               string                       `yaml:"project-id"`
+	ResultDataBucketURL     string                       `yaml:"result-data-bucket-url"`
+	RequestTopicURL         string                       `yaml:"request-topic-url"`
+	RequestSubscriptionURL  string                       `yaml:"request-subscription-url"`
+	BigQueryDataset         string                       `yaml:"bigquery-dataset"`
+	BigQueryTable           string                       `yaml:"bigquery-table"`
+	CompletionThreshold     float32                      `yaml:"completion-threshold"`
+	WebhookURL              string                       `yaml:"webhook-url"`
+	MetricExporter          string                       `yaml:"metric-exporter"`
+	MetricStackdriverPrefix string                       `yaml:"metric-stackdriver-prefix"`
+	ShardSize               int                          `yaml:"shard-size"`
+	InputBucketURL          string                       `yaml:"input-bucket-url"`
+	InputBucketPrefix       string                       `yaml:"input-bucket-prefix"`
+	AdditionalParams        map[string]map[string]string `yaml:"additional-params"`
 }
 
 func getParsedConfigFromFile(byteValue []byte) (config, error) {
@@ -292,6 +294,11 @@ func GetBlacklistedChecks() ([]string, error) {
 // GetMetricExporter returns the opencensus exporter type.
 func GetMetricExporter() (string, error) {
 	return getStringConfigValue(metricExporter, configYAML, "MetricExporter", "metric-exporter")
+}
+
+// GetMetricStackdriverPrefix returns the prefix for stackdriver opencensus exporter.
+func GetMetricStackdriverPrefix() (string, error) {
+	return getStringConfigValue(metricStackdriverPrefix, configYAML, "MetricStackdriverPrefix", "metric-stackdriver-prefix")
 }
 
 // GetAPIResultsBucketURL returns the bucket URL for storing cron job results.

--- a/cron/config/config.go
+++ b/cron/config/config.go
@@ -298,7 +298,8 @@ func GetMetricExporter() (string, error) {
 
 // GetMetricStackdriverPrefix returns the prefix for stackdriver opencensus exporter.
 func GetMetricStackdriverPrefix() (string, error) {
-	return getStringConfigValue(metricStackdriverPrefix, configYAML, "MetricStackdriverPrefix", "metric-stackdriver-prefix")
+	return getStringConfigValue(
+		metricStackdriverPrefix, configYAML, "MetricStackdriverPrefix", "metric-stackdriver-prefix")
 }
 
 // GetAPIResultsBucketURL returns the bucket URL for storing cron job results.

--- a/cron/config/config.yaml
+++ b/cron/config/config.yaml
@@ -21,6 +21,7 @@ completion-threshold: 0.99
 shard-size: 10
 webhook-url: 
 metric-exporter: stackdriver
+metric-stackdriver-prefix: scorecard-cron
 result-data-bucket-url: gs://ossf-scorecard-data2
 
 # TODO temporarily leaving old variables until changes propagate to production

--- a/cron/config/config_test.go
+++ b/cron/config/config_test.go
@@ -24,19 +24,20 @@ import (
 )
 
 const (
-	testEnvVar              string = "TEST_ENV_VAR"
-	prodProjectID                  = "openssf"
-	prodBucket                     = "gs://ossf-scorecard-data2"
-	prodTopic                      = "gcppubsub://projects/openssf/topics/scorecard-batch-requests"
-	prodSubscription               = "gcppubsub://projects/openssf/subscriptions/scorecard-batch-worker"
-	prodBigQueryDataset            = "scorecardcron"
-	prodBigQueryTable              = "scorecard-v2"
-	prodCompletionThreshold        = 0.99
-	prodWebhookURL                 = ""
-	prodCIIDataBucket              = "gs://ossf-scorecard-cii-data"
-	prodBlacklistedChecks          = "CI-Tests,Contributors"
-	prodShardSize           int    = 10
-	prodMetricExporter      string = "stackdriver"
+	testEnvVar                  string = "TEST_ENV_VAR"
+	prodProjectID                      = "openssf"
+	prodBucket                         = "gs://ossf-scorecard-data2"
+	prodTopic                          = "gcppubsub://projects/openssf/topics/scorecard-batch-requests"
+	prodSubscription                   = "gcppubsub://projects/openssf/subscriptions/scorecard-batch-worker"
+	prodBigQueryDataset                = "scorecardcron"
+	prodBigQueryTable                  = "scorecard-v2"
+	prodCompletionThreshold            = 0.99
+	prodWebhookURL                     = ""
+	prodCIIDataBucket                  = "gs://ossf-scorecard-cii-data"
+	prodBlacklistedChecks              = "CI-Tests,Contributors"
+	prodShardSize               int    = 10
+	prodMetricExporter          string = "stackdriver"
+	prodMetricStackdriverPrefix string = "scorecard-cron"
 	// Raw results.
 	prodRawBucket             = "gs://ossf-scorecard-rawdata"
 	prodRawBigQueryTable      = "scorecard-rawdata"
@@ -94,22 +95,22 @@ func TestYAMLParsing(t *testing.T) {
 			name:     "validate",
 			filename: "config.yaml",
 			expectedConfig: config{
-				ProjectID:              prodProjectID,
-				ResultDataBucketURL:    prodBucket,
-				RequestTopicURL:        prodTopic,
-				RequestSubscriptionURL: prodSubscription,
-				BigQueryDataset:        prodBigQueryDataset,
-				BigQueryTable:          prodBigQueryTable,
-				CompletionThreshold:    prodCompletionThreshold,
-				WebhookURL:             prodWebhookURL,
-				ShardSize:              prodShardSize,
-				MetricExporter:         prodMetricExporter,
-				InputBucketURL:         prodInputBucketURL,
-				InputBucketPrefix:      prodInputBucketPrefix,
-				AdditionalParams:       prodAdditionalParams,
+				ProjectID:               prodProjectID,
+				ResultDataBucketURL:     prodBucket,
+				RequestTopicURL:         prodTopic,
+				RequestSubscriptionURL:  prodSubscription,
+				BigQueryDataset:         prodBigQueryDataset,
+				BigQueryTable:           prodBigQueryTable,
+				CompletionThreshold:     prodCompletionThreshold,
+				WebhookURL:              prodWebhookURL,
+				ShardSize:               prodShardSize,
+				MetricExporter:          prodMetricExporter,
+				MetricStackdriverPrefix: prodMetricStackdriverPrefix,
+				InputBucketURL:          prodInputBucketURL,
+				InputBucketPrefix:       prodInputBucketPrefix,
+				AdditionalParams:        prodAdditionalParams,
 			},
 		},
-
 		{
 			name:     "basic",
 			filename: "testdata/basic.yaml",
@@ -389,6 +390,20 @@ func TestGetMetricExporter(t *testing.T) {
 		}
 		if exporter != prodMetricExporter {
 			t.Errorf("test failed: expected - %s, got = %s", prodMetricExporter, exporter)
+		}
+	})
+}
+
+//nolint:paralleltest // Since os.Setenv is used.
+func TestGetMetricStackdriverPrefix(t *testing.T) {
+	t.Run("GetMetricStackdriverPrefix", func(t *testing.T) {
+		os.Unsetenv(metricStackdriverPrefix)
+		prefix, err := GetMetricStackdriverPrefix()
+		if err != nil {
+			t.Errorf("failed to get production metric stackdriver prefix from config: %v", err)
+		}
+		if prefix != prodMetricStackdriverPrefix {
+			t.Errorf("test failed: expected - %s, got = %s", prodMetricStackdriverPrefix, prefix)
 		}
 	})
 }

--- a/cron/internal/monitoring/exporter.go
+++ b/cron/internal/monitoring/exporter.go
@@ -32,7 +32,6 @@ var errorUndefinedExporter = errors.New("unsupported exporterType")
 type exporterType string
 
 const (
-	stackdriverMetricPrefix                 = "scorecard-cron"
 	stackdriverTimeSeriesQuota              = 200
 	stackdriverTimeoutMinutes               = 10
 	stackDriver                exporterType = "stackdriver"
@@ -69,9 +68,13 @@ func newStackDriverExporter() (*stackdriver.Exporter, error) {
 	if err != nil {
 		return nil, fmt.Errorf("error getting ProjectID: %w", err)
 	}
+	prefix, err := config.GetMetricStackdriverPrefix()
+	if err != nil {
+		return nil, fmt.Errorf("error getting stackdriver prefix: %w", err)
+	}
 	exporter, err := stackdriver.NewExporter(stackdriver.Options{
 		ProjectID:         projectID,
-		MetricPrefix:      stackdriverMetricPrefix,
+		MetricPrefix:      prefix,
 		MonitoredResource: gcp.Autodetect(),
 		Timeout:           stackdriverTimeoutMinutes * time.Minute,
 		// Stackdriver specific quotas based on https://cloud.google.com/monitoring/quotas


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This is a minor change to configuration to support alternative infrastructure deployments, in particular the criticality score project.

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The stackdriver prefix is hardcoded and cannot be overridden.

#### What is the new behavior (if this is a feature change)?**

The stackdriver prefix is now exposed in the config via a `metric-stackdriver-prefix` key.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

```release-note
NONE
```
