### PR TITLE
✨ Detect SECURITY.markdown in addition to SECURITY.md

### DIFF
--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -143,6 +143,9 @@ func isSecurityPolicyFilename(name string) bool {
 	return strings.EqualFold(name, "security.md") ||
 		strings.EqualFold(name, ".github/security.md") ||
 		strings.EqualFold(name, "docs/security.md") ||
+		strings.EqualFold(name, "security.markdown") ||
+		strings.EqualFold(name, ".github/security.markdown") ||
+		strings.EqualFold(name, "docs/security.markdown") ||
 		strings.EqualFold(name, "security.adoc") ||
 		strings.EqualFold(name, ".github/security.adoc") ||
 		strings.EqualFold(name, "docs/security.adoc") ||

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -94,6 +94,27 @@ func TestSecurityPolicy(t *testing.T) {
 			path: "",
 		},
 		{
+			name: "security.markdown",
+			files: []string{
+				"security.markdown",
+			},
+			path: "",
+		},
+		{
+			name: ".github/security.markdown",
+			files: []string{
+				".github/security.markdown",
+			},
+			path: "",
+		},
+		{
+			name: "docs/security.markdown",
+			files: []string{
+				"docs/security.markdown",
+			},
+			path: "",
+		},
+		{
 			name: "docs/security.rst",
 			files: []string{
 				"docs/security.rst",


### PR DESCRIPTION
GitHub probably supports many more file extensions for Markdown files, but at very least `.md` and `.markdown` have been standardized in RFC 7763.

Signed-off-by: favonia <favonia@gmail.com>

#### What kind of change does this PR introduce?

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

`SECURITY.markdown`, `.github/SECURITY.markdown`, or `docs/SECURITY.markdown` will be detected as a security policy.

#### What is the current behavior?

`SECURITY.markdown`, `.github/SECURITY.markdown`, and `docs/SECURITY.markdown` are ignored.

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
