### PR TITLE
:seedling: [cron] Controller should only write to the rawBucket if the bucket is set in the config.

### DIFF
--- a/cron/internal/controller/main.go
+++ b/cron/internal/controller/main.go
@@ -168,14 +168,16 @@ func main() {
 		panic(fmt.Errorf("error writing to BlobStore: %w", err))
 	}
 
-	// Raw data.
-	*metadata.ShardLoc = rawBucket + "/" + data.GetBlobFilename("", t)
-	metadataJSON, err = protojson.Marshal(&metadata)
-	if err != nil {
-		panic(fmt.Errorf("error during protojson.Marshal raw: %w", err))
-	}
-	err = data.WriteToBlobStore(ctx, rawBucket, data.GetShardMetadataFilename(t), metadataJSON)
-	if err != nil {
-		panic(fmt.Errorf("error writing to BlobStore raw: %w", err))
+	if rawBucket != "" {
+		// Raw data.
+		*metadata.ShardLoc = rawBucket + "/" + data.GetBlobFilename("", t)
+		metadataJSON, err = protojson.Marshal(&metadata)
+		if err != nil {
+			panic(fmt.Errorf("error during protojson.Marshal raw: %w", err))
+		}
+		err = data.WriteToBlobStore(ctx, rawBucket, data.GetShardMetadataFilename(t), metadataJSON)
+		if err != nil {
+			panic(fmt.Errorf("error writing to BlobStore raw: %w", err))
+		}
 	}
 }


### PR DESCRIPTION
Signed-off-by: Caleb Brown <calebbrown@google.com>

#### What kind of change does this PR introduce?

This is a small bug fix to the cron controller

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

If the raw bucket is not specified in the controller the controller will crash (as is the case for criticality-score).

Previously the non-existent configuration setting would cause a panic, but since it was moved to the additional params section it is now only an empty value.

#### What is the new behavior (if this is a feature change)?**

Writing to the raw bucket will only happen if the value exists in the config.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

```release-note
NONE
```
