### PR TITLE
🌱 Enable scorecard run on pull request

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -7,9 +7,8 @@ on:
   schedule:
     # Weekly on Saturdays.
     - cron:  '30 1 * * 6'
-  #pull_request:
-    # All branches are supported.
-  #  branches: [main]
+  pull_request:
+    branches: [main]
 
 permissions: read-all
 


### PR DESCRIPTION
Signed-off-by: laurentsimon <64505099+laurentsimon@users.noreply.github.com>

Enable scorecard to run on PR in our CI. Will help us test the Action and find low-hanging problems we can resolve to make pull request support official in the GitHub Action.

```release-note
Run scorecard on incoming pull requests for our CI
```
