### PR TITLE
🐛  Fixes cache miss bug from commit-depth feature 

### DIFF
--- a/clients/githubrepo/graphql.go
+++ b/clients/githubrepo/graphql.go
@@ -279,11 +279,6 @@ func (handler *graphqlHandler) setup() error {
 func (handler *graphqlHandler) setupCheckRuns() error {
 	// this function needs to be ran before setup so it has commits to query.
 	handler.setupCheckRunsOnce.Do(func() {
-		// this should never run first?
-		if handler.commits == nil {
-			handler.errSetupCheckRuns = fmt.Errorf("error during graphqlHandler.setupCheckRuns: no commits in handler to query.")
-			return
-		}
 		// looping over handler commit list to match each commit with checkrun.
 		for idx := range handler.commits {
 			commitExpression := handler.commits[idx].SHA


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Fixes cache miss issue from commit-depth feature #2224 
(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Currently when commits are greater than 99 and are paged, it causes the CI and SAST checks to throw cache miss informational print messages

#### What is the new behavior (if this is a feature change)?**
New behavior changes the query that is used when running setupChecks. The new query takes each commit that is held in the handler, (after setup is run, commits should be populated in the handler) and runs the checkSuites query against it, this results in a 1 to 1 relationship with commits in the handler, and the checkRuns. So no cache misses happen.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2224 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
