### PR TITLE
:book: Fix copyright notices

### DIFF
--- a/checks/evaluation/cii_best_practices.go
+++ b/checks/evaluation/cii_best_practices.go
@@ -1,4 +1,4 @@
-// Copyright OpenSSF Scorecard Authors
+// Copyright 2022 OpenSSF Scorecard Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/checks/raw/maintained.go
+++ b/checks/raw/maintained.go
@@ -1,4 +1,4 @@
-// Copyright OpenSSF Scorecard Authors
+// Copyright 2022 OpenSSF Scorecard Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -1,4 +1,4 @@
-// Copyright OpenSSF Scorecard Authors
+// Copyright 2022 OpenSSF Scorecard Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/options/flags.go
+++ b/options/flags.go
@@ -1,4 +1,4 @@
-// Copyright OpenSSF Authors.
+// Copyright 2022 OpenSSF Scorecard Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Signed-off-by: Arnaud J Le Hors <lehors@us.ibm.com>

#### What kind of change does this PR introduce?

Fixes a few malformed copyright notices.

#### What is the current behavior?

A few copyright notices are missing the year and one uses the wrong name for the attribution.

#### What is the new behavior (if this is a feature change)?**

All copyright notices have the same format and specify a year (the missing ones were added based on git commit history).

#### Which issue(s) this PR fixes

NONE


#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Only in source code.

```release-note

```
