### PR TITLE
✨ Accept Go modules with semantic versions

### DIFF
--- a/checks/raw/permissions.go
+++ b/checks/raw/permissions.go
@@ -180,7 +180,7 @@ func typeOfPermission(val string) checker.PermissionLevel {
 	switch val {
 	case "read", "read-all":
 		return checker.PermissionLevelRead
-	case "none":
+	case "none": //nolint:goconst
 		return checker.PermissionLevelNone
 	}
 	return checker.PermissionLevelUnknown

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -888,7 +888,7 @@ func TestShellScriptDownload(t *testing.T) {
 		{
 			name:     "pkg managers",
 			filename: "./testdata/script-pkg-managers",
-			warns:    38,
+			warns:    43,
 		},
 		{
 			name:     "invalid shell script",

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -888,7 +888,7 @@ func TestShellScriptDownload(t *testing.T) {
 		{
 			name:     "pkg managers",
 			filename: "./testdata/script-pkg-managers",
-			warns:    36,
+			warns:    38,
 		},
 		{
 			name:     "invalid shell script",

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -180,7 +180,7 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 		{
 			name:     "npm packages without verification",
 			filename: "./testdata/.github/workflows/github-workflow-pkg-managers.yaml",
-			warns:    28,
+			warns:    36,
 		},
 	}
 	for _, tt := range tests {

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -770,7 +770,7 @@ func TestDockerfileScriptDownload(t *testing.T) {
 		{
 			name:     "pkg managers",
 			filename: "./testdata/Dockerfile-pkg-managers",
-			warns:    39,
+			warns:    47,
 		},
 		{
 			name:     "download with some python",

--- a/checks/raw/testdata/.github/workflows/github-workflow-pkg-managers.yaml
+++ b/checks/raw/testdata/.github/workflows/github-workflow-pkg-managers.yaml
@@ -60,6 +60,18 @@ jobs:
         run: go get github.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999
       - name:
         run: go get github.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999
+      - run: go get somerepo.com/org/name@v1.2.3
+      - run: go get somerepo.com/org/name@v1.2.3-semver
+      - run: go get somerepo.com/org/name@v1.2.3-semver+great
+      - run: go get -insecure somerepo.com/org/name@v1.2.3
+      - run: go get -insecure somerepo.com/org/name@v1.2.3-semver
+      - run: go get -insecure somerepo.com/org/name@v1.2.3-semver+great
+      - run: go get somerepo.com/org/name@v1
+      - run: go get somerepo.com/org/name@v1.2
+      - run: go get somerepo.com/org/name@none
+      - run: go get somerepo.com/org/name@latest
+      - run: go get somerepo.com/org/name@patch
+      - run: go get somerepo.com/org/name@upgrade
       - name:
         run: go mod download
       - name:

--- a/checks/raw/testdata/Dockerfile-pkg-managers
+++ b/checks/raw/testdata/Dockerfile-pkg-managers
@@ -23,6 +23,18 @@ RUN go get github.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999
 RUN go get github.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999
 RUN ["go", "install", "-Y", "github.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999"]
 RUN ["go", "get", "github.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999"]
+RUN ["go", "get", "somerepo.com/org/name@v1.2.3"]
+RUN ["go", "get", "somerepo.com/org/name@v1.2.3-semver"]
+RUN ["go", "get", "somerepo.com/org/name@v1.2.3-semver+great"]
+RUN ["go", "get", "-insecure", "somerepo.com/org/name@v1.2.3"]
+RUN ["go", "get", "-insecure", "somerepo.com/org/name@v1.2.3-semver"]
+RUN ["go", "get", "-insecure", "somerepo.com/org/name@v1.2.3-semver+great"]
+RUN ["go", "get", "somerepo.com/org/name@v1"]
+RUN ["go", "get", "somerepo.com/org/name@v1.2"]
+RUN ["go", "install", "somerepo.com/org/name@none"]
+RUN ["go", "install", "somerepo.com/org/name@latest"]
+RUN ["go", "install", "somerepo.com/org/name@patch"]
+RUN ["go", "install", "somerepo.com/org/name@upgrade"]
 
 RUN go install /some/local/path
 RUN go mod download

--- a/checks/raw/testdata/Dockerfile-pkg-managers
+++ b/checks/raw/testdata/Dockerfile-pkg-managers
@@ -31,10 +31,10 @@ RUN ["go", "get", "-insecure", "somerepo.com/org/name@v1.2.3-semver"]
 RUN ["go", "get", "-insecure", "somerepo.com/org/name@v1.2.3-semver+great"]
 RUN ["go", "get", "somerepo.com/org/name@v1"]
 RUN ["go", "get", "somerepo.com/org/name@v1.2"]
-RUN ["go", "install", "somerepo.com/org/name@none"]
-RUN ["go", "install", "somerepo.com/org/name@latest"]
-RUN ["go", "install", "somerepo.com/org/name@patch"]
-RUN ["go", "install", "somerepo.com/org/name@upgrade"]
+RUN ["go", "get", "somerepo.com/org/name@none"]
+RUN ["go", "get", "somerepo.com/org/name@latest"]
+RUN ["go", "get", "somerepo.com/org/name@patch"]
+RUN ["go", "get", "somerepo.com/org/name@upgrade"]
 
 RUN go install /some/local/path
 RUN go mod download

--- a/checks/raw/testdata/script-pkg-managers
+++ b/checks/raw/testdata/script-pkg-managers
@@ -30,10 +30,10 @@ go get -insecure somerepo.com/org/name@v1.2.3-semver
 go get -insecure somerepo.com/org/name@v1.2.3-semver+great
 go get somerepo.com/org/name@v1
 go get somerepo.com/org/name@v1.2
-go install somerepo.com/org/name@none
-go install somerepo.com/org/name@latest
-go install somerepo.com/org/name@patch
-go install somerepo.com/org/name@upgrade
+go get somerepo.com/org/name@none
+go get somerepo.com/org/name@latest
+go get somerepo.com/org/name@patch
+go get somerepo.com/org/name@upgrade
 go get another-repo.com/org/name@release
 go get local-folder
 go get ./local-folder

--- a/checks/raw/testdata/script-pkg-managers
+++ b/checks/raw/testdata/script-pkg-managers
@@ -28,6 +28,12 @@ go get somerepo.com/org/name@v1.2.3-semver+great
 go get -insecure somerepo.com/org/name@v1.2.3
 go get -insecure somerepo.com/org/name@v1.2.3-semver
 go get -insecure somerepo.com/org/name@v1.2.3-semver+great
+go get somerepo.com/org/name@v1
+go get somerepo.com/org/name@v1.2
+go install somerepo.com/org/name@none
+go install somerepo.com/org/name@latest
+go install somerepo.com/org/name@patch
+go install somerepo.com/org/name@upgrade
 go get another-repo.com/org/name@release
 go get local-folder
 go get ./local-folder

--- a/checks/raw/testdata/script-pkg-managers
+++ b/checks/raw/testdata/script-pkg-managers
@@ -23,6 +23,11 @@ go get github.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999
 go get somerepo.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999
 go get another-repo.com/org/name@1111111111ccccccccccaaaaaaaaaa9999999999
 go get somerepo.com/org/name@v1.2.3
+go get somerepo.com/org/name@v1.2.3-semver
+go get somerepo.com/org/name@v1.2.3-semver+great
+go get -insecure somerepo.com/org/name@v1.2.3
+go get -insecure somerepo.com/org/name@v1.2.3-semver
+go get -insecure somerepo.com/org/name@v1.2.3-semver+great
 go get another-repo.com/org/name@release
 go get local-folder
 go get ./local-folder

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -465,6 +465,8 @@ other source hosting repositories (i.e., Forges).
 
 The check works by looking for unpinned dependencies in Dockerfiles, shell scripts, and GitHub workflows
 which are used during the build and release process of a project.
+Special considerations for Go modules treat full semantic versions as pinned
+due to how the Go tool verifies downloaded content against the hashes when anyone first downloaded the module.
 
 Pinned dependencies reduce several security risks:
 

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -465,6 +465,8 @@ checks:
 
       The check works by looking for unpinned dependencies in Dockerfiles, shell scripts, and GitHub workflows
       which are used during the build and release process of a project.
+      Special considerations for Go modules treat full semantic versions as pinned
+      due to how the Go tool verifies downloaded content against the hashes when anyone first downloaded the module.
 
       Pinned dependencies reduce several security risks:
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR accepts commands like `go install blah@v1.0.0`, considering fully versioned Go modules pinned.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`go install blah@v1.0.0` is currently considered unpinned, but it is effectively pinned in practice.

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #2491.

#### Special notes for your reviewer

* This also fixes the current parser in two ways:
   1. Do not detect `go INSTALL` but only `go install`.
   1. Skip flags between `get`/`install` and packages but record the flag `-insecure`.

* `goconst` is turned off for `"none"` because the string has very different meanings in different places in the package.

#### Does this PR introduce a user-facing change?

```release-note
Go modules with full semantic versions are now considered pinned.
```
