### PR TITLE
:seedling: Remove parallel tests because of rate limiting issues.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -49,7 +49,6 @@ linters:
     - misspell
     - nakedret
     - nestif
-    - paralleltest
     - predeclared
     - staticcheck
     - stylecheck

--- a/dependencydiff/dependencydiff_test.go
+++ b/dependencydiff/dependencydiff_test.go
@@ -27,8 +27,7 @@ import (
 
 // Test_fetchRawDependencyDiffData is a test function for fetchRawDependencyDiffData.
 func Test_fetchRawDependencyDiffData(t *testing.T) {
-	t.Parallel()
-
+	//nolint
 	tests := []struct {
 		name      string
 		dCtx      dependencydiffContext
@@ -69,7 +68,6 @@ func Test_fetchRawDependencyDiffData(t *testing.T) {
 }
 
 func Test_initRepoAndClientByChecks(t *testing.T) {
-	t.Parallel()
 	//nolint
 	tests := []struct {
 		name                           string
@@ -129,8 +127,7 @@ func Test_initRepoAndClientByChecks(t *testing.T) {
 }
 
 func Test_getScorecardCheckResults(t *testing.T) {
-	t.Parallel()
-
+	//nolint
 	tests := []struct {
 		name    string
 		dCtx    dependencydiffContext
@@ -161,7 +158,6 @@ func Test_getScorecardCheckResults(t *testing.T) {
 }
 
 func Test_mapDependencyEcosystemNaming(t *testing.T) {
-	t.Parallel()
 	//nolint
 	tests := []struct {
 		name      string
@@ -217,7 +213,7 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			//nolint
 			err := mapDependencyEcosystemNaming(tt.deps)
 			if tt.errWanted != nil && errors.Is(tt.errWanted, err) {
 				t.Errorf("not a wanted error, want:%v, got:%v", tt.errWanted, err)
@@ -228,8 +224,7 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 }
 
 func Test_isSpecifiedByUser(t *testing.T) {
-	t.Parallel()
-
+	//nolint
 	tests := []struct {
 		name               string
 		ct                 pkg.ChangeType
@@ -267,7 +262,7 @@ func Test_isSpecifiedByUser(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
+			//nolint
 			result := isSpecifiedByUser(tt.ct, tt.changeTypesToCheck)
 			if result != tt.resultWanted {
 				t.Errorf("result (%v) != result wanted (%v)", result, tt.resultWanted)

--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -29,7 +29,6 @@ func TestE2e(t *testing.T) {
 	if val, exists := os.LookupEnv("SKIP_GINKGO"); exists && val == "1" {
 		t.Skip()
 	}
-	t.Parallel()
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "E2e Suite")
 }


### PR DESCRIPTION
- Remove parallel tests because of rate limiting.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

