### PR TITLE
🐛  license check accumulates results

### DIFF
--- a/clients/githubrepo/branches.go
+++ b/clients/githubrepo/branches.go
@@ -127,6 +127,8 @@ func (handler *branchesHandler) init(ctx context.Context, repourl *repoURL) {
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
+	handler.defaultBranchRef = nil
+	handler.data = nil
 }
 
 func (handler *branchesHandler) setup() error {

--- a/clients/githubrepo/contributors.go
+++ b/clients/githubrepo/contributors.go
@@ -39,6 +39,7 @@ func (handler *contributorsHandler) init(ctx context.Context, repourl *repoURL) 
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
+	handler.contributors = nil
 }
 
 func (handler *contributorsHandler) setup() error {

--- a/clients/githubrepo/graphql.go
+++ b/clients/githubrepo/graphql.go
@@ -201,6 +201,8 @@ func (handler *graphqlHandler) init(ctx context.Context, repourl *repoURL, commi
 	handler.checkRuns = checkRunCache{}
 	handler.logger = log.NewLogger(log.DefaultLevel)
 	handler.commitDepth = commitDepth
+	handler.commits = nil
+	handler.issues = nil
 }
 
 func populateCommits(handler *graphqlHandler, vars map[string]interface{}) ([]clients.Commit, error) {

--- a/clients/githubrepo/languages.go
+++ b/clients/githubrepo/languages.go
@@ -39,6 +39,7 @@ func (handler *languagesHandler) init(ctx context.Context, repourl *repoURL) {
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
+	handler.languages = nil
 }
 
 // TODO: Can add support to parse the raw response JSON and mark languages that are not in

--- a/clients/githubrepo/licenses.go
+++ b/clients/githubrepo/licenses.go
@@ -40,6 +40,7 @@ func (handler *licensesHandler) init(ctx context.Context, repourl *repoURL) {
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
+	handler.licenses = nil
 }
 
 // TODO: Can add support to parse the raw response JSON and mark licenses that are not in

--- a/clients/githubrepo/releases.go
+++ b/clients/githubrepo/releases.go
@@ -40,6 +40,7 @@ func (handler *releasesHandler) init(ctx context.Context, repourl *repoURL) {
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
+	handler.releases = nil
 }
 
 func (handler *releasesHandler) setup() error {

--- a/clients/githubrepo/webhook.go
+++ b/clients/githubrepo/webhook.go
@@ -39,6 +39,7 @@ func (handler *webhookHandler) init(ctx context.Context, repourl *repoURL) {
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
+	handler.webhook = nil
 }
 
 func (handler *webhookHandler) setup() error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,22 +124,19 @@ func rootCmd(o *options.Options) error {
 		}
 	}
 
-	var repoResult pkg.ScorecardResult
-	for i := 1; i < 3; i++ {
-		repoResult, err = pkg.RunScorecard(
-			ctx,
-			repoURI,
-			o.Commit,
-			o.CommitDepth,
-			enabledChecks,
-			repoClient,
-			ossFuzzRepoClient,
-			ciiClient,
-			vulnsClient,
-		)
-		if err != nil {
-			return fmt.Errorf("RunScorecard: %w", err)
-		}
+	repoResult, err := pkg.RunScorecard(
+		ctx,
+		repoURI,
+		o.Commit,
+		o.CommitDepth,
+		enabledChecks,
+		repoClient,
+		ossFuzzRepoClient,
+		ciiClient,
+		vulnsClient,
+	)
+	if err != nil {
+		return fmt.Errorf("RunScorecard: %w", err)
 	}
 
 	repoResult.Metadata = append(repoResult.Metadata, o.Metadata...)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -124,20 +124,24 @@ func rootCmd(o *options.Options) error {
 		}
 	}
 
-	repoResult, err := pkg.RunScorecard(
-		ctx,
-		repoURI,
-		o.Commit,
-		o.CommitDepth,
-		enabledChecks,
-		repoClient,
-		ossFuzzRepoClient,
-		ciiClient,
-		vulnsClient,
-	)
-	if err != nil {
-		return fmt.Errorf("RunScorecard: %w", err)
+	var repoResult pkg.ScorecardResult
+	for i := 1; i < 3; i++ {
+		repoResult, err = pkg.RunScorecard(
+			ctx,
+			repoURI,
+			o.Commit,
+			o.CommitDepth,
+			enabledChecks,
+			repoClient,
+			ossFuzzRepoClient,
+			ciiClient,
+			vulnsClient,
+		)
+		if err != nil {
+			return fmt.Errorf("RunScorecard: %w", err)
+		}
 	}
+
 	repoResult.Metadata = append(repoResult.Metadata, o.Metadata...)
 
 	// Sort them by name


### PR DESCRIPTION
Signed-off-by: laurentsimon <laurentsimon@google.com>
closes https://github.com/ossf/scorecard/issues/2522

This PR fixes https://github.com/ossf/scorecard/issues/2522.

To avoid this type of problems in the future, we need to add check that runs scorecard twice (with the same clients) and verify the results are all the same: https://github.com/ossf/scorecard/issues/2533

```release-note
fix: license check accumulates results
```
