### PR TITLE
🐛  Remove 32bit platforms from GoReleaser architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -31,8 +31,6 @@ builds:
   goarch:
     - amd64
     - arm64
-    - 386
-    - arm
   ldflags:
     - -s {{.Env.VERSION_LDFLAGS}} 
 
@@ -82,9 +80,7 @@ builds:
     - windows
   goarch:
     - amd64
-    - 386
     - arm64
-    - arm
   ldflags:
     - -buildmode=exe
     - -s {{.Env.VERSION_LDFLAGS}} 


### PR DESCRIPTION
Signed-off-by: laurentsimon <laurentsimon@google.com>

OSV-Scanner depends on a library that cannot be built for 32bit platforms, so this PR removes them from released binaries.

```release-note
Remove 32bit platforms from GoReleaser architectures
```
