### PR TITLE
:bug: Fix broken go mod download check

### DIFF
--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -425,7 +425,6 @@ func isGoUnpinnedDownload(cmd []string) bool {
 	if !isBinaryName("go", cmd[0]) {
 		return false
 	}
-
 	// `Go install` will automatically look up the
 	// go.mod and go.sum, so we don't flag it.
 	if len(cmd) <= 2 {
@@ -456,6 +455,10 @@ func isGoUnpinnedDownload(cmd []string) bool {
 			i++
 		}
 
+		if i+1 >= len(cmd) {
+			// this is case go get -d -v
+			return false
+		}
 		// TODO check more than one package
 		pkg := cmd[i+1]
 		// Consider strings that are not URLs as local folders

--- a/checks/raw/shell_download_validate_test.go
+++ b/checks/raw/shell_download_validate_test.go
@@ -106,3 +106,36 @@ func TestValidateShellFile(t *testing.T) {
 		t.Errorf("failed to detect shell parsing error: %v", err)
 	}
 }
+
+func Test_isGoUnpinnedDownload(t *testing.T) {
+	type args struct {
+		cmd []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "go get",
+			args: args{
+				cmd: []string{"go", "get", "github.com/ossf/scorecard"},
+			},
+			want: true,
+		},
+		{
+			name: "go get with -d -v",
+			args: args{
+				cmd: []string{"go", "get", "-d", "-v"},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isGoUnpinnedDownload(tt.args.cmd); got != tt.want {
+				t.Errorf("isGoUnpinnedDownload() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Fixed the https://github.com/ossf/scorecard/issues/2549

- It was panicking because of this https://github.com/slsa-framework/slsa-github-generator/blob/9dc8c627749ae437f7759a3ecec9f740e677e3e1/.github/actions/detect-workflow/Dockerfile#L20

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>

