### PR TITLE
🐛 Remove unnecessary Printf

### DIFF
--- a/checks/raw/branch_protection.go
+++ b/checks/raw/branch_protection.go
@@ -131,8 +131,6 @@ var addCodeownersFile fileparser.DoWhileTrueOnFileContent = func(
 	content []byte,
 	args ...interface{},
 ) (bool, error) {
-	fmt.Printf("got codeowners file at %s\n", path)
-
 	if len(args) != 1 {
 		return false, fmt.Errorf(
 			"addCodeownersFile requires exactly 1 arguments: got %v: %w",


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`scorecard` prints messages like `got codeowners file at .github/CODEOWNERS` which makes the result invalid, at least when using https://github.com/ossf/scorecard-action with sarif output

example: https://github.com/nginxinc/nginx-kubernetes-gateway/actions/runs/3744585459/jobs/6358515861#step:4:238

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->
NONE


#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
