### PR TITLE
📖 specify that classic personal access tokens are needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ requests before running Scorecard. There are two ways to authenticate your
 requests: either create a GitHub personal access token, or create a GitHub App
 Installation.
 
--   [Create a GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token).
+-   [Create a classic GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token#creating-a-personal-access-token-classic).
     When creating the personal access token, we suggest you choose the
     `public_repo` scope. Set the token in an environment variable called
     `GITHUB_AUTH_TOKEN`, `GITHUB_TOKEN`, `GH_AUTH_TOKEN` or `GH_TOKEN` using the


### PR DESCRIPTION
Signed-off-by: Mike Maraya <mmaraya@users.noreply.github.com>

#### What kind of change does this PR introduce? 

Doc update to clarify that classic, not fine-grained, personal access tokens are required for the scorecard CLI to work

(Is it a bug fix, feature, docs update, something else?) docs update

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior? documentation currently links to the creation of a fine-grained access token, which produces this error:
```
Error: RunScorecard: internal error: ListCommits:error during graphqlHandler.setup: internal error: githubv4.Query: non-200 OK status code: 401 Unauthorized body: "{\"message\":\"Personal access tokens with fine grained access do not support the GraphQL API\",\"documentation_url\":\"https://docs.github.com/graphql/guides/forming-calls-with-graphql#authenticating-with-graphql\"}"
```

#### What is the new behavior (if this is a feature change)?** n/a, doc change only

- [ ] Tests for the changes have been added (for bug fixes/features): n/a

#### Which issue(s) this PR fixes

NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)
 
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
