### PR TITLE
🌱 Switch from paths-ignore to changed-files action to skip required checks.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -21,24 +21,45 @@ on:
  push:
   branches:
   - main
-  paths-ignore:
-  - "*.md"
  pull_request:
   branches:
   - main
-  paths-ignore:
-  - "*.md"
 
 env:
   PROTOC_VERSION: 3.17.3
-  GO_VERSION: 1.17
+  GO_VERSION: 1.19
 
 jobs:
+  docs_only_check:
+    name: Check for docs-only change
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
+    steps:
+    - name: Check out code
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 2
+    - id: files
+      name: Get changed files
+      uses: tj-actions/changed-files@0626c3f94002c0a9d7491dd7fed7055bbdff6f92 #v35.1.0
+      with:
+        files_ignore: '**.md'
+    - id: docs_only_check
+      if: steps.files.outputs.any_changed != 'true'
+      name: Check for docs-only changes
+      run: echo "docs_only=true" >> $GITHUB_OUTPUT
+
   scorecard:
     name: scorecard-docker
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner
        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v1
@@ -84,6 +105,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner
        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v1
@@ -129,6 +153,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner
        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v1
@@ -174,6 +201,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner
        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v1
@@ -219,6 +249,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner
        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v1
@@ -264,6 +297,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner
        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v1
@@ -309,6 +345,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner
        uses: step-security/harden-runner@ebacdc22ef6c2cfb85ee5ded8f2e640f4c776dd5 # v1

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,9 +18,6 @@ permissions:
 name: docker-build
 
 on:
- push:
-  branches:
-  - main
  pull_request:
   branches:
   - main
@@ -39,7 +36,7 @@ jobs:
       docs_only: ${{ steps.docs_only_check.outputs.docs_only }}
     steps:
     - name: Check out code
-      uses: actions/checkout@v3
+      uses: actions/checkout@755da8c3cf115ac066823e79a1e1788f8940201b #v3.2.0
       with:
         fetch-depth: 2
     - id: files


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?

CI fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Due to path filtering, PRs which only change Markdown files will never run the steps in `docker.yml`:
https://github.com/ossf/scorecard/blob/c6d76807b76b7b72659525e103d6b1284c7b01b5/.github/workflows/docker.yml#L20-L30

Since these checks are (currently) required, PRs which only change Markdown files can never be merged. See #2565 and #2508. As long as these checks are required, there's no native way to solve this for reasons summarized well in [this blog post](https://blog.pantsbuild.org/skipping-github-actions-jobs-without-breaking-branch-protection/).

#### What is the new behavior (if this is a feature change)?**

A third party action is used to detect doc only changes. Since skipped checks count as passing for required checks, this allows for doc only changes to merge.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
I tested this with a few PRs in a fork here:
https://github.com/spencerschrock/scorecard-test/pull/3
https://github.com/spencerschrock/scorecard-test/pull/8

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
