### PR TITLE
✨ Disable scorecard on PRs

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -7,8 +7,8 @@ on:
   schedule:
     # Weekly on Saturdays.
     - cron:  '30 1 * * 6'
-  pull_request:
-    branches: [main]
+#   pull_request:
+#     branches: [main]
 
 permissions: read-all
 


### PR DESCRIPTION
We keep hit rate limits on PRs, so let's disable anything that's not necessary for now.

```release-note
Disable scorecard on PRs
```
