### PR TITLE
WIP: use chainguard's static (distroless v2) for scorecard image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,18 +13,16 @@
 # limitations under the License.
 
 # golang:1.19
-FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS base
+FROM golang@sha256:25de7b6b28219279a409961158c547aadd0960cf2dcbc533780224afa1157fd4 AS build
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./
 RUN go mod download
 COPY . ./
+RUN make build-scorecard
 
-FROM base AS build
-ARG TARGETOS
-ARG TARGETARCH
-RUN CGO_ENABLED=0 make build-scorecard
-
-FROM gcr.io/distroless/base:nonroot@sha256:99133cb0878bb1f84d1753957c6fd4b84f006f2798535de22ebf7ba170bbf434
+# https://github.com/chainguard-images/images/tree/main/images/static
+# latest
+FROM cgr.dev/chainguard/static:latest@sha256:17844d8faa68296eddddad9c1678edaf18cc556433d68c5bd3808a6efac200a8
 COPY --from=build /src/scorecard /
 ENTRYPOINT [ "/scorecard" ]


### PR DESCRIPTION
Signed-off-by: Batuhan Apaydın <batuhan.apaydin@trendyol.com>

#### What kind of change does this PR introduce?

This feature is about using the chainguard's static image instead of Google's static. I removed a few things from Dockerfile to simplify the process, as I saw that we don't need them.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
