### PR TITLE
🐛  Retain tag when remediating unpinned docker images.

### DIFF
--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -141,7 +141,7 @@ func generateRemediation(remediaitonMd remediation.RemediationMetadata, rr *chec
 	case checker.DependencyUseTypeGHAction:
 		return remediaitonMd.CreateWorkflowPinningRemediation(rr.Location.Path)
 	case checker.DependencyUseTypeDockerfileContainerImage:
-		return remediation.CreateDockerfilePinningRemediation(rr.Name)
+		return remediation.CreateDockerfilePinningRemediation(rr, remediation.CraneDigester{})
 	default:
 		return nil
 	}
@@ -183,7 +183,6 @@ func generateOwnerToDisplay(gitHubOwned bool) string {
 }
 
 // TODO(laurent): need to support GCB pinning.
-//nolint
 func maxScore(s1, s2 int) int {
 	if s1 > s2 {
 		return s1

--- a/remediation/remediations_test.go
+++ b/remediation/remediations_test.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
+	"github.com/google/go-cmp/cmp"
 
 	"github.com/ossf/scorecard/v4/checker"
 	mockrepo "github.com/ossf/scorecard/v4/clients/mockclients"
@@ -47,5 +48,94 @@ func TestRepeatedSetup(t *testing.T) {
 		if rmd.repo != want {
 			t.Errorf("failed. expected: %v, got: %v", want, rmd.repo)
 		}
+	}
+}
+
+func asPointer(s string) *string {
+	return &s
+}
+
+type stubDigester struct{}
+
+func (s stubDigester) Digest(name string) (string, error) {
+	m := map[string]string{
+		"foo":               "2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+		"baz":               "fcde2b2edba56bf408601fb721fe9b5c338d10ee429ea04fae5511b68fbf8fb9",
+		"amazoncorretto:11": "b1a711069b801a325a30885f08f5067b2b102232379750dda4d25a016afd9a88",
+	}
+	hash, ok := m[name]
+	if !ok {
+		//nolint:goerr113
+		return "", fmt.Errorf("no hash for image: %q", name)
+	}
+	return fmt.Sprintf("sha256:%s", hash), nil
+}
+
+func TestCreateDockerfilePinningRemediation(t *testing.T) {
+	t.Parallel()
+
+	//nolint:govet,lll
+	tests := []struct {
+		name     string
+		dep      checker.Dependency
+		expected *checker.Remediation
+	}{
+		{
+			name:     "no depdendency",
+			dep:      checker.Dependency{},
+			expected: nil,
+		},
+		{
+			name: "image name no tag",
+			dep: checker.Dependency{
+				Name: asPointer("foo"),
+				Type: checker.DependencyUseTypeDockerfileContainerImage,
+			},
+			expected: &checker.Remediation{
+				HelpText:     "pin your Docker image by updating foo to foo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+				HelpMarkdown: "pin your Docker image by updating foo to foo@sha256:2c26b46b68ffc68ff99b453c1d30413413422d706483bfa0f98a5e886266e7ae",
+			},
+		},
+		{
+			// github.com/ossf/scorecard/issues/2581
+			name: "image name with tag",
+			dep: checker.Dependency{
+				Name:     asPointer("amazoncorretto"),
+				PinnedAt: asPointer("11"),
+				Type:     checker.DependencyUseTypeDockerfileContainerImage,
+			},
+			expected: &checker.Remediation{
+				HelpText:     "pin your Docker image by updating amazoncorretto:11 to amazoncorretto:11@sha256:b1a711069b801a325a30885f08f5067b2b102232379750dda4d25a016afd9a88",
+				HelpMarkdown: "pin your Docker image by updating amazoncorretto:11 to amazoncorretto:11@sha256:b1a711069b801a325a30885f08f5067b2b102232379750dda4d25a016afd9a88",
+			},
+		},
+		{
+			name: "unknown image",
+			dep: checker.Dependency{
+				Name: asPointer("not-found"),
+				Type: checker.DependencyUseTypeDockerfileContainerImage,
+			},
+			expected: nil,
+		},
+		{
+			name: "unknown tag",
+			dep: checker.Dependency{
+				Name:     asPointer("foo"),
+				PinnedAt: asPointer("not-found"),
+				Type:     checker.DependencyUseTypeDockerfileContainerImage,
+			},
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := CreateDockerfilePinningRemediation(&tt.dep, stubDigester{})
+			if !cmp.Equal(got, tt.expected) {
+				t.Errorf(cmp.Diff(got, tt.expected))
+			}
+		})
 	}
 }


### PR DESCRIPTION
Signed-off-by: Spencer Schrock <sschrock@google.com>

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Tagged and unpinned images are detected, but the remediation suggestion discards the tag which is problematic for reasons pointed out in #2581.

#### What is the new behavior (if this is a feature change)?**
The Docker remediation code now maintains the tag, based on whatever is in the `PinnedAt` field of the `checker.Dependency` struct.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2581
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Suggested remediations for unpinned Docker images now maintain any tags that were present.
```
