### PR TITLE
:seedling: performance: run integration tests only on approved PRs

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,7 +14,9 @@
 
 # Run secret-dependent integration tests only after approval
 name: Integration tests
-on: pull_request_target
+on:
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: read
@@ -22,6 +24,7 @@ permissions:
 
 jobs:
   approve:
+    if: github.event.review.state == 'approved'
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -50,14 +53,14 @@ jobs:
       - name: setup-go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v2.2.0
         with:
-          go-version: '1.19'
+          go-version: "1.19"
           check-latest: true
 
       - name: Prepare test env
         run: |
-            go mod download
+          go mod download
 
-      - name: Run GITHUB_TOKEN E2E  #using retry because the GitHub token is being throttled.
+      - name: Run GITHUB_TOKEN E2E #using retry because the GitHub token is being throttled.
         uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -68,7 +71,7 @@ jobs:
           timeout_minutes: 30
           command: make e2e-gh-token
 
-      - name: Run PAT E2E  #using retry because the GitHub token is being throttled.
+      - name: Run PAT E2E #using retry because the GitHub token is being throttled.
         uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
@@ -81,15 +84,15 @@ jobs:
       - name: codecov
         uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 2.1.0
         with:
-         files: ./e2e-coverage.out
-         verbose: true
+          files: ./e2e-coverage.out
+          verbose: true
 
       - name: find comment
         uses: peter-evans/find-comment@f4499a714d59013c74a08789b48abe4b704364a0 # v2.1.0
         id: fc
         with:
           issue-number: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
-          comment-author: 'github-actions[bot]'
+          comment-author: "github-actions[bot]"
           body-includes: Integration tests ran for
 
       - name: create or update comment


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This is a CI Performance Improvement. 


- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Currently, Integration tests take ~13m & every run on every PR (without approval).

#### What is the new behavior (if this is a feature change)?**

This Proposed changes will improve that & it would run Integration Test only on approved PRs.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #2603
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

No

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```

> Signed-off-by: Siddhant Khare <Siddhantkhare2694@gmail.com>