### PR TITLE
:sparkles: Add Azure Devops to CI checks

### DIFF
--- a/checks/evaluation/ci_tests.go
+++ b/checks/evaluation/ci_tests.go
@@ -128,7 +128,7 @@ func isTest(s string) bool {
 	for _, pattern := range []string{
 		"appveyor", "buildkite", "circleci", "e2e", "github-actions", "jenkins",
 		"mergeable", "packit-as-a-service", "semaphoreci", "test", "travis-ci",
-		"flutter-dashboard", "Cirrus CI",
+		"flutter-dashboard", "Cirrus CI", "azure-pipelines",
 	} {
 		if strings.Contains(l, pattern) {
 			return true

--- a/checks/evaluation/ci_tests_test.go
+++ b/checks/evaluation/ci_tests_test.go
@@ -102,6 +102,13 @@ func Test_isTest(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "azure-pipelines",
+			args: args{
+				s: "azure-pipelines",
+			},
+			want: true,
+		},
+		{
 			name: "non-existing",
 			args: args{
 				s: "non-existing",


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Adds Azure Devops as a valid CI system when running the CI check

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Repos that are tested with Azure Devops get 0 as a score, as it is not recognized

#### What is the new behavior (if this is a feature change)?**
Repos that are tested with Azure Devops are not penalized

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #2661 

#### Special notes for your reviewer
I removed an entry as well, as it did not seem to possibly have any effect and also had
no tests associated

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Azure Devops is now a recognized CI system
```
