### PR TITLE
:seedling: Temporarily skip OSS-Fuzz e2e test.

### DIFF
--- a/e2e/fuzzing_test.go
+++ b/e2e/fuzzing_test.go
@@ -31,6 +31,8 @@ import (
 var _ = Describe("E2E TEST:"+checks.CheckFuzzing, func() {
 	Context("E2E TEST:Validating use of fuzzing tools", func() {
 		It("Should return use of OSS-Fuzz", func() {
+			//nolint:lll
+			Skip("Skipping OSS-Fuzz test due to issues searching google/oss-fuzz with the REST API. https://github.com/ossf/scorecard/issues/2670")
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("tensorflow/tensorflow")
 			Expect(err).Should(BeNil())


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Temporary test change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The Oss-Fuzz e2e test is failing because the implementation isn't currently working, consuming extra e2e tokens due to the retry mechanism, before ultimately failing and blocking PRs.

#### What is the new behavior (if this is a feature change)?**
Temporarily skip the test until #2670 is resolved.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
