### PR TITLE
🌱 Limit integration tests to ones that work with the GITHUB_TOKEN.

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -14,11 +14,10 @@
 
 # Run secret-dependent integration tests only after approval
 name: Integration tests
-on: pull_request_target
+on: pull_request
 
 permissions:
   contents: read
-  pull-requests: write
 
 jobs:
   approve:
@@ -61,43 +60,14 @@ jobs:
         uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
         env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITLAB_AUTH_TOKEN: ${{ secrets.GITLAB_TOKEN }}
         with:
           max_attempts: 3
           retry_on: error
           timeout_minutes: 30
           command: make e2e-gh-token
 
-      - name: Run PAT E2E  #using retry because the GitHub token is being throttled.
-        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-        env:
-          GITHUB_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
-        with:
-          max_attempts: 3
-          retry_on: error
-          timeout_minutes: 30
-          command: make e2e-pat
-
       - name: codecov
         uses: codecov/codecov-action@81cd2dc8148241f03f5839d295e000b8f761e378 # 2.1.0
         with:
          files: ./e2e-coverage.out
          verbose: true
-
-      - name: find comment
-        uses: peter-evans/find-comment@85a676a52594b4481e0532825a2d8906ef96dac2 # v2.2.1
-        id: fc
-        with:
-          issue-number: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
-          comment-author: 'github-actions[bot]'
-          body-includes: Integration tests ran for
-
-      - name: create or update comment
-        uses: peter-evans/create-or-update-comment@5adcb0bb0f9fb3f95ef05400558bdb3f329ee808 # v1.4.5
-        with:
-          issue-number: ${{ github.event.pull_request.number || github.event.client_payload.pull_request.number }}
-          comment-id: ${{ steps.fc.outputs.comment-id }}
-          body: |
-            Integration tests ${{ job.status }} for
-            [${{ github.event.client_payload.slash_command.args.named.sha || github.event.pull_request.head.sha }}]
-            (https://github.com/ossf/scorecard/actions/runs/${{ github.run_id }})


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Integration test change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Some of the integration tests need access to GitHub secrets, specifically the branch protection e2e tests.

#### What is the new behavior (if this is a feature change)?**
The integration test trigger was changed to `pull_request` which does not have access to GitHub secrets.
The status message when integration tests finish was removed to reduce the permissions of the GITHUB_TOKEN

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
This was tested in another repo to verify the GITHUB_TOKEN was sufficient.
https://github.com/spencerschrock/scorecard-test/actions/runs/4188418627/jobs/7259527613

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
