### PR TITLE
✨ Consider ko-build/setup-ko as a packaging workflow

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -559,6 +559,9 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 				{
 					Uses: "imjasonh/setup-ko",
 				},
+				{
+					Uses: "ko-build/setup-ko",
+				},
 			},
 			LogText: "candidate container publishing workflow using ko",
 		},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Slight feature / bug fix. The `imjasonh/setup-ko` workflow was moved to https://github.com/ko-build, and thanks to GitHub redirect magic, both names can be used in a workflow -- the imjasonh ref redirects to the ko-build one.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Workflows using the old `imjasonh/setup-ko` will not be matched as using a packaging workflow.

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

NONE

#### Does this PR introduce a user-facing change?

```release-note
ko-build/setup-ko is detected as a packaging workflow
```
