### PR TITLE
:sparkles: Consider 'src/test' test directories

### DIFF
--- a/checks/fileparser/listing.go
+++ b/checks/fileparser/listing.go
@@ -52,7 +52,9 @@ func isMatchingPath(fullpath string, matchPathTo PathMatcher) (bool, error) {
 func isTestdataFile(fullpath string) bool {
 	// testdata/ or /some/dir/testdata/some/other
 	return strings.HasPrefix(fullpath, "testdata/") ||
-		strings.Contains(fullpath, "/testdata/")
+		strings.Contains(fullpath, "/testdata/") ||
+		strings.HasPrefix(fullpath, "src/test/") ||
+		strings.Contains(fullpath, "/src/test/")
 }
 
 // PathMatcher represents a query for a filepath.

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -375,6 +375,13 @@ func Test_isTestdataFile(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "testdata file",
+			args: args{
+				fullpath: "archiva-modules/archiva-base/archiva-checksum/src/test/resources/examples/redback-authz-open.jar",
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Enhancement: improve the quality of the default scoring

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Files in `testdata` directories are ignored by default, but files in `src/test` directories are not.

#### What is the new behavior (if this is a feature change)?**

`src/test` is also recognized as a test directory

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

This directory is found in projects that follow the Maven [Standard Directory Layout](https://maven.apache.org/guides/introduction/introduction-to-the-standard-directory-layout.html), which is fairly widely used, not only in Maven but also in adjacent ecosystems like Gradle and clojure.

Longer-term this would become part of the default policy, see discussion at https://github.com/ossf/scorecard/pull/1408#issuecomment-999806097 etc.

#### Does this PR introduce a user-facing change?

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md

```release-note
`src/test` directories are now considered test directories by default.
```
