### PR TITLE
:seedling: Updated the coverage for tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -314,7 +314,7 @@ test: $(test-targets)
 unit-test: ## Runs unit test without e2e
 	# Run unit tests, ignoring e2e tests
 	# run the go tests and gen the file coverage-all used to do the integration with codecov
-	SKIP_GINKGO=1 go test -race -covermode=atomic  -coverprofile=unit-coverage.out `go list ./...`
+	SKIP_GINKGO=1 go test -race -covermode=atomic  -coverprofile=unit-coverage.out -coverpkg=./... `go list ./...`
 
 unit-test-attestor: ## Runs unit tests on scorecard-attestor
 	cd attestor; SKIP_GINKGO=1 go test -covermode=atomic -coverprofile=unit-coverage.out `go list ./...`; cd ..;


### PR DESCRIPTION
- Updated the `Makefile` to include the `-coverpkg=./...` flag when running tests.

[Makefile]
- Changed `SKIP_GINKGO=1 go test -race -covermode=atomic  -coverprofile=unit-coverage.out` to `SKIP_GINKGO=1 go test -race -covermode=atomic  -coverprofile=unit-coverage.out -coverpkg=./...` in the `Makefile`

https://github.com/ossf/scorecard/issues/2203
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)


```release-note
NONE
```
