### PR TITLE
:bug: Handle editable pip installs

### DIFF
--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -261,7 +261,7 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 		{
 			name:     "npm packages without verification",
 			filename: "./testdata/.github/workflows/github-workflow-pkg-managers.yaml",
-			warns:    45,
+			warns:    46,
 		},
 	}
 	for _, tt := range tests {

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -808,9 +808,15 @@ func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 					t:         checker.DependencyUseTypePipCommand,
 				},
 				{
+					snippet:   "pip install --no-deps -e . git+https://github.com/username/repo.git",
+					startLine: 53,
+					endLine:   53,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
 					snippet:   "python -m pip install --no-deps -e git+https://github.com/username/repo.git",
-					startLine: 54,
-					endLine:   54,
+					startLine: 56,
+					endLine:   56,
 					t:         checker.DependencyUseTypePipCommand,
 				},
 			},
@@ -1083,7 +1089,7 @@ func TestShellScriptDownload(t *testing.T) {
 		{
 			name:     "pkg managers",
 			filename: "./testdata/script-pkg-managers",
-			warns:    52,
+			warns:    53,
 		},
 		{
 			name:     "invalid shell script",

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -261,7 +261,7 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 		{
 			name:     "npm packages without verification",
 			filename: "./testdata/.github/workflows/github-workflow-pkg-managers.yaml",
-			warns:    36,
+			warns:    45,
 		},
 	}
 	for _, tt := range tests {

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -606,9 +606,15 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 					t:         checker.DependencyUseTypePipCommand,
 				},
 				{
+					snippet:   "pip install --no-deps -e . git+https://github.com/username/repo.git",
+					startLine: 61,
+					endLine:   61,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
 					snippet:   "python -m pip install --no-deps -e git+https://github.com/username/repo.git",
-					startLine: 62,
-					endLine:   62,
+					startLine: 64,
+					endLine:   64,
 					t:         checker.DependencyUseTypePipCommand,
 				},
 			},
@@ -959,7 +965,7 @@ func TestDockerfileScriptDownload(t *testing.T) {
 		{
 			name:     "pkg managers",
 			filename: "./testdata/Dockerfile-pkg-managers",
-			warns:    56,
+			warns:    57,
 		},
 		{
 			name:     "download with some python",

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -557,6 +557,60 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 					endLine:   42,
 					t:         checker.DependencyUseTypePipCommand,
 				},
+				{
+					snippet:   "pip install --no-deps -e hg+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 46,
+					endLine:   46,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e svn+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 47,
+					endLine:   47,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e bzr+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 48,
+					endLine:   48,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git",
+					startLine: 49,
+					endLine:   49,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git#egg=package",
+					startLine: 50,
+					endLine:   50,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git@v1.0",
+					startLine: 51,
+					endLine:   51,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git@v1.0#egg=package",
+					startLine: 52,
+					endLine:   52,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 60,
+					endLine:   60,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "python -m pip install --no-deps -e git+https://github.com/username/repo.git",
+					startLine: 62,
+					endLine:   62,
+					t:         checker.DependencyUseTypePipCommand,
+				},
 			},
 		},
 		{
@@ -851,7 +905,7 @@ func TestDockerfileScriptDownload(t *testing.T) {
 		{
 			name:     "pkg managers",
 			filename: "./testdata/Dockerfile-pkg-managers",
-			warns:    47,
+			warns:    56,
 		},
 		{
 			name:     "download with some python",

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -753,6 +753,60 @@ func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 					endLine:   31,
 					t:         checker.DependencyUseTypeChocoCommand,
 				},
+				{
+					snippet:   "pip install --no-deps -e hg+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 38,
+					endLine:   38,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e svn+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 39,
+					endLine:   39,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e bzr+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 40,
+					endLine:   40,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git",
+					startLine: 41,
+					endLine:   41,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git#egg=package",
+					startLine: 42,
+					endLine:   42,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git@v1.0",
+					startLine: 43,
+					endLine:   43,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install --no-deps -e git+https://github.com/username/repo.git@v1.0#egg=package",
+					startLine: 44,
+					endLine:   44,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package",
+					startLine: 52,
+					endLine:   52,
+					t:         checker.DependencyUseTypePipCommand,
+				},
+				{
+					snippet:   "python -m pip install --no-deps -e git+https://github.com/username/repo.git",
+					startLine: 54,
+					endLine:   54,
+					t:         checker.DependencyUseTypePipCommand,
+				},
 			},
 		},
 	}
@@ -1023,7 +1077,7 @@ func TestShellScriptDownload(t *testing.T) {
 		{
 			name:     "pkg managers",
 			filename: "./testdata/script-pkg-managers",
-			warns:    43,
+			warns:    52,
 		},
 		{
 			name:     "invalid shell script",

--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -495,13 +495,10 @@ func isPinnedEditableSource(pkgSource string) bool {
 	}
 	regexGitSource := regexp.MustCompile(`^git(\+(https?|ssh|git))?\:\/\/.*(.git)?@[a-fA-F0-9]{40}(#egg=.*)?$`)
 	// Is VCS install from Git and it's pinned
-	if regexGitSource.MatchString(pkgSource) {
-		return true
-	}
+	return regexGitSource.MatchString(pkgSource)
 	// Disclaimer: We are not handling if Subversion (svn),
 	// Mercurial (hg) or Bazaar (bzr) remote sources are pinned
 	// because they are not common on GitHub repos
-	return false
 }
 
 func isUnpinnedPipInstall(cmd []string) bool {

--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -487,6 +487,23 @@ func isGoUnpinnedDownload(cmd []string) bool {
 	return found
 }
 
+func isPinnedEditableSource(pkgSource string) bool {
+	regexRemoteSource := regexp.MustCompile(`^(git|svn|hg|bzr).+$`)
+	// Is from local source
+	if !regexRemoteSource.MatchString(pkgSource) {
+		return true
+	}
+	regexGitSource := regexp.MustCompile(`^git(\+(https?|ssh|git))?\:\/\/.*(.git)?@[a-fA-F0-9]{40}(#egg=.*)?$`)
+	// Is VCS install from Git and it's pinned
+	if regexGitSource.MatchString(pkgSource) {
+		return true
+	}
+	// Disclaimer: We are not handling if Subversion (svn),
+	// Mercurial (hg) or Bazaar (bzr) remote sources are pinned
+	// because they are not common on GitHub repos
+	return false
+}
+
 func isUnpinnedPipInstall(cmd []string) bool {
 	if !isBinaryName("pip", cmd[0]) && !isBinaryName("pip3", cmd[0]) {
 		return false
@@ -520,21 +537,8 @@ func isUnpinnedPipInstall(cmd []string) bool {
 			if i+1 < len(cmd) {
 				i++
 				pkgSource := cmd[i]
-				regexRemoteSource := regexp.MustCompile(`^(git|svn|hg|bzr).+$`)
-				// Is from local source
-				if !regexRemoteSource.MatchString(pkgSource) {
-					isPinnedEditableInstall = true
-					continue
-				}
-				regexGitSource := regexp.MustCompile(`^git(\+(https?|ssh|git))?\:\/\/.*(.git)?@[a-fA-F0-9]{40}(#egg=.*)?$`)
-				// Is VCS install from Git and it's pinned
-				if regexGitSource.MatchString(pkgSource) {
-					isPinnedEditableInstall = true
-					continue
-				}
-				// Disclaimer: We are not handling if Subversion (svn),
-				// Mercurial (hg) or Bazaar (bzr) remote sources are pinned
-				// because they are not common on GitHub repos
+				isPinnedEditableInstall = isPinnedEditableSource(pkgSource)
+				continue
 			}
 			continue
 		}

--- a/checks/raw/testdata/.github/workflows/github-workflow-pkg-managers.yaml
+++ b/checks/raw/testdata/.github/workflows/github-workflow-pkg-managers.yaml
@@ -125,6 +125,10 @@ jobs:
       - name:
         run: pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
       - name:
+        run: pip install --no-deps -e . git+https://github.com/username/repo.git
+      - name:
+        run: pip install --no-deps -e . git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
         run: python -m notpip -X bla
       - name:
         run: python2.7 -m pip install -X -H somepkg 'some-ther==1.2.3' 'somebla<3.4.5'

--- a/checks/raw/testdata/.github/workflows/github-workflow-pkg-managers.yaml
+++ b/checks/raw/testdata/.github/workflows/github-workflow-pkg-managers.yaml
@@ -91,6 +91,40 @@ jobs:
       - name:
         run: /bin/pip3 install -X -H somepkg
       - name:
+        run: pip install --no-deps --editable .
+      - name:
+        run: pip install --no-deps -e .
+      - name:
+        run: pip install --no-deps -e hg+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e svn+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e bzr+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e git+https://github.com/username/repo.git
+      - name:
+        run: pip install --no-deps -e git+https://github.com/username/repo.git#egg=package
+      - name:
+        run: pip install --no-deps -e git+https://github.com/username/repo.git@v1.0
+      - name:
+        run: pip install --no-deps -e git+https://github.com/username/repo.git@v1.0#egg=package
+      - name:
+        run: pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567
+      - name:
+        run: pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e git+https://github.com/username/repo@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e git+http://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
+        run: pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+      - name:
         run: python -m notpip -X bla
       - name:
         run: python2.7 -m pip install -X -H somepkg 'some-ther==1.2.3' 'somebla<3.4.5'
@@ -108,6 +142,10 @@ jobs:
         run: python -m pip install 'some-pkg==1.2.3'
       - name:
         run: python -m pip install 'some-pkg>1.2.3'
+      - name:
+        run: python -m pip install --no-deps -e git+https://github.com/username/repo.git
+      - name:
+        run: python -m pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
       - name:
         run: pip3 install -r bla-requirements.txt --require-hashes && pip3 install --require-hashes -r bla-requirements.txt
       - name:

--- a/checks/raw/testdata/Dockerfile-download-lines
+++ b/checks/raw/testdata/Dockerfile-download-lines
@@ -40,3 +40,24 @@ RUN echo hello && \
 #    pip install -r requirements.txt -i https://pypi.doubanio.com/simple --trusted-host pypi.doubanio.com || \
 RUN bla && \
 	pip install -r requirements.txt
+
+RUN pip install --no-deps --editable .
+RUN pip install --no-deps -e .
+RUN pip install --no-deps -e hg+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e svn+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e bzr+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo.git
+RUN pip install --no-deps -e git+https://github.com/username/repo.git#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@v1.0
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@v1.0#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+http://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+
+RUN python -m pip install --no-deps -e git+https://github.com/username/repo.git
+RUN python -m pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package

--- a/checks/raw/testdata/Dockerfile-download-lines
+++ b/checks/raw/testdata/Dockerfile-download-lines
@@ -58,6 +58,8 @@ RUN pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789ab
 RUN pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 RUN pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 RUN pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e . git+https://github.com/username/repo.git
+RUN pip install --no-deps -e . git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 
 RUN python -m pip install --no-deps -e git+https://github.com/username/repo.git
 RUN python -m pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package

--- a/checks/raw/testdata/Dockerfile-pkg-managers
+++ b/checks/raw/testdata/Dockerfile-pkg-managers
@@ -78,6 +78,8 @@ RUN pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789ab
 RUN pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 RUN pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 RUN pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e . git+https://github.com/username/repo.git
+RUN pip install --no-deps -e . git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 
 RUN python -m notpip -X bla
 

--- a/checks/raw/testdata/Dockerfile-pkg-managers
+++ b/checks/raw/testdata/Dockerfile-pkg-managers
@@ -61,6 +61,24 @@ RUN pip install somepkg
 RUN pip3 install somepkg==1.2.3
 RUN /bin/pip3 install -X -H somepkg
 
+RUN pip install --no-deps --editable .
+RUN pip install --no-deps -e .
+RUN pip install --no-deps -e hg+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e svn+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e bzr+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo.git
+RUN pip install --no-deps -e git+https://github.com/username/repo.git#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@v1.0
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@v1.0#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567
+RUN pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+https://github.com/username/repo@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+http://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+RUN pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+
 RUN python -m notpip -X bla
 
 RUN python2.7 -m pip install -X -H somepkg \
@@ -83,6 +101,9 @@ RUN python -m pip install bla3.whl
 RUN python -m pip install -r file
 RUN python -m pip install 'some-pkg==1.2.3'
 RUN python -m pip install 'some-pkg>1.2.3'
+
+RUN python -m pip install --no-deps -e git+https://github.com/username/repo.git
+RUN python -m pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 
 RUN npm install typescript
 RUN npm install -g typescript

--- a/checks/raw/testdata/script-pkg-managers
+++ b/checks/raw/testdata/script-pkg-managers
@@ -60,6 +60,24 @@ pip install somepkg
 pip3 install somepkg==1.2.3
 /bin/pip3 install -X -H somepkg
 
+pip install --no-deps --editable .
+pip install --no-deps -e .
+pip install --no-deps -e hg+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e svn+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e bzr+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+https://github.com/username/repo.git
+pip install --no-deps -e git+https://github.com/username/repo.git#egg=package
+pip install --no-deps -e git+https://github.com/username/repo.git@v1.0
+pip install --no-deps -e git+https://github.com/username/repo.git@v1.0#egg=package
+pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567
+pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+https://github.com/username/repo@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+http://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+
 python -m notpip -X bla
 
 python -m pip install -r file
@@ -84,6 +102,8 @@ python3 -m pip install -X -H somepkg \
     'some-ther==1.2.3' \
     'somebla<3.4.5'
 
+python -m pip install --no-deps -e git+https://github.com/username/repo.git
+python -m pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 
 npm install typescript
 npm install -g typescript

--- a/checks/raw/testdata/script-pkg-managers
+++ b/checks/raw/testdata/script-pkg-managers
@@ -77,6 +77,8 @@ pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789abcdef
 pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e . git+https://github.com/username/repo.git
+pip install --no-deps -e . git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 
 python -m notpip -X bla
 

--- a/checks/raw/testdata/shell-download-lines.sh
+++ b/checks/raw/testdata/shell-download-lines.sh
@@ -32,3 +32,24 @@ choco install 'some-other-package'
 choco install --requirechecksum 'some-package'
 choco install --requirechecksums 'some-package'
 choco install --require-checksums 'some-package'
+
+pip install --no-deps --editable .
+pip install --no-deps -e .
+pip install --no-deps -e hg+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e svn+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e bzr+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+https://github.com/username/repo.git
+pip install --no-deps -e git+https://github.com/username/repo.git#egg=package
+pip install --no-deps -e git+https://github.com/username/repo.git@v1.0
+pip install --no-deps -e git+https://github.com/username/repo.git@v1.0#egg=package
+pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567
+pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+https://github.com/username/repo@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+http://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+
+python -m pip install --no-deps -e git+https://github.com/username/repo.git
+python -m pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package

--- a/checks/raw/testdata/shell-download-lines.sh
+++ b/checks/raw/testdata/shell-download-lines.sh
@@ -50,6 +50,8 @@ pip install --no-deps -e git+ssh://github.com/username/repo.git@0123456789abcdef
 pip install --no-deps -e git+git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 pip install --no-deps -e git://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
+pip install --no-deps -e . git+https://github.com/username/repo.git
+pip install --no-deps -e . git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package
 
 python -m pip install --no-deps -e git+https://github.com/username/repo.git
 python -m pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Handle editable pip installs in Pinned-Dependencies check.

##### Description

When performing `pip install -e <pkg>`, the install can be considered secure if the package and it's dependencies are hash-pinned. The package can come from a local or remote source (VCS install). If the package is local, it is considered secure. If the package is remote, it needs to pinned by commit hash to be secure. We have no way to identify if the dependencies installed from requirements are hash-pinned. The flag `--require-hashes` does not work with `-e` flag. To guarantee we are not installing malicious dependencies, we can use `--no-deps` flag to not install the dependencies. That way the install can be considered secure.

##### Examples
| | |
| -- | -- |
| secure | pip install --no-deps -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package" |
| secure | pip install --no-deps -e . |
| not secure | pip install -e git+https://github.com/username/repo.git@0123456789abcdef0123456789abcdef01234567#egg=package" |
| not secure | pip install --no-deps -e git+https://github.com/username/repo.git#egg=package" |

##### References
- pip install syntax: https://pip.pypa.io/en/stable/cli/pip_install/#pip-install
- secure pip install: https://pip.pypa.io/en/stable/topics/secure-installs/#do-not-use-setuptools-directly
- what is editable pip install: https://setuptools.pypa.io/en/latest/userguide/development_mode.html
- pip VCS install syntax: https://pip.pypa.io/en/latest/topics/vcs-support/#vcs-support
- https://github.com/pypa/pip/issues/4995

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Currently, we don't handle editable pip installs. We suggest using `--require-hashes` as remediation but it's not possible.

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Closes https://github.com/ossf/scorecard/issues/2228

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Accept pip installs with `-e` flag along with `--no-deps` flag in Pinned-Dependencies check. Editable pip installs will be accepted if coming from a local source or a remote Git source pinned by hash, as long as it's not installing dependencies.
```