### PR TITLE
🐛 Atomically load from accessState to avoid data race.

### DIFF
--- a/clients/githubrepo/roundtripper/tokens/round_robin.go
+++ b/clients/githubrepo/roundtripper/tokens/round_robin.go
@@ -36,7 +36,7 @@ func (tokens *roundRobinAccessor) Next() (uint64, string) {
 
 	// If selected accessToken is unavailable, wait.
 	for !atomic.CompareAndSwapInt64(&tokens.accessState[index], 0, time.Now().Unix()) {
-		currVal := tokens.accessState[index]
+		currVal := atomic.LoadInt64(&tokens.accessState[index])
 		expired := time.Now().After(time.Unix(currVal, 0).Add(expiryTimeInSec * time.Second))
 		if !expired {
 			continue


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
There's a data race in the main binary, which can be seen when built with `go build -race`
```
==================
WARNING: DATA RACE
Write at 0x00c0001204a8 by goroutine 43:
  sync/atomic.CompareAndSwapInt64()
      /usr/lib/go-1.19/src/runtime/race_amd64.s:316 +0xb
  sync/atomic.CompareAndSwapInt64()
      <autogenerated>:1 +0x24
  github.com/ossf/scorecard/v4/clients/githubrepo/roundtripper.(*githubTransport).RoundTrip()
      ~/go/src/github.com/spencerschrock/scorecard.git/clients/githubrepo/roundtripper/transport.go:44 +0x8e
      
Previous read at 0x00c0001204a8 by goroutine 60:
  github.com/ossf/scorecard/v4/clients/githubrepo/roundtripper/tokens.(*roundRobinAccessor).Next()
      ~/go/src/github.com/spencerschrock/scorecard.git/clients/githubrepo/roundtripper/tokens/round_robin.go:39 +0x1a6
```

#### What is the new behavior (if this is a feature change)?**
The load is done atomically to avoid the race.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Unblocks #2625 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
