### PR TITLE
✨  Add simple accessor to avoid atomics in a single token scenario.

### DIFF
--- a/clients/githubrepo/roundtripper/tokens/accessor.go
+++ b/clients/githubrepo/roundtripper/tokens/accessor.go
@@ -43,7 +43,11 @@ func readGitHubTokens() (string, bool) {
 // MakeTokenAccessor is a factory function of TokenAccessor.
 func MakeTokenAccessor() TokenAccessor {
 	if value, exists := readGitHubTokens(); exists {
-		return makeRoundRobinAccessor(strings.Split(value, ","))
+		tokens := strings.Split(value, ",")
+		if len(tokens) == 1 {
+			return makeSimpleAccessor(tokens[0])
+		}
+		return makeRoundRobinAccessor(tokens)
 	}
 	if value, exists := os.LookupEnv(githubAuthServer); exists {
 		return makeRPCAccessor(value)

--- a/clients/githubrepo/roundtripper/tokens/simple.go
+++ b/clients/githubrepo/roundtripper/tokens/simple.go
@@ -1,0 +1,33 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokens
+
+type simpleAccessor struct {
+	accessToken string
+}
+
+// Next implements TokenAccessor.Next.
+func (s *simpleAccessor) Next() (uint64, string) {
+	return 0, s.accessToken
+}
+
+// Release implements TokenAccessor.Release.
+func (s *simpleAccessor) Release(id uint64) {}
+
+func makeSimpleAccessor(accessToken string) TokenAccessor {
+	return &simpleAccessor{
+		accessToken: accessToken,
+	}
+}

--- a/clients/githubrepo/roundtripper/tokens/simple_test.go
+++ b/clients/githubrepo/roundtripper/tokens/simple_test.go
@@ -1,0 +1,33 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package tokens
+
+import (
+	"testing"
+)
+
+func TestSimpleAccessor(t *testing.T) {
+	const token = "foo"
+	const id = 0
+	s := makeSimpleAccessor(token)
+	gotID, gotToken := s.Next()
+	s.Release(gotID)
+	if gotID != id {
+		t.Logf("got ID: %d wanted: %d", gotID, id)
+	}
+	if gotToken != token {
+		t.Logf("got token: %q wanted: %q", gotToken, token)
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

feature

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
When provided a single token, the round robin accessor still manages state and uses expensive atomic operations and resource contention.

#### What is the new behavior (if this is a feature change)?**
A new simple accessor is provided for when only one token is provided.
This speeds up running scorecard

before:
```
time ./scorecard --repo ossf/scorecard --format json
real	0m38.171s
user	1m15.050s
sys	0m1.269s
```

after
```
real	0m23.237s
user	0m2.837s
sys	0m1.145s
```

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

Aside from the expensive atomic operations, there is a design decision here which I don't have context for:

https://github.com/ossf/scorecard/blob/5f13a66c271ed810560c1fd96a04630f67afed2e/clients/githubrepo/roundtripper/transport.go#L43-L45

Based on this code, every HTTP request will rotate through a different token. In the round robin case with a single token, this meant rotating through the same token, but there was some resource contention.  Each graphQL call and REST call is essentially serialized. 

Is this an intentional decision to limit concurrent usages of the same token (essentially one at a time with a 30s timeout)?
If so, this PR probably should be closed instead of merged.

@azeemshaikh38 FYI

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
