### PR TITLE
🐛 Fix typo in CITests runtime errors causing duplicate Code-Review checks.

### DIFF
--- a/checks/ci_tests.go
+++ b/checks/ci_tests.go
@@ -40,7 +40,7 @@ func CITests(c *checker.CheckRequest) checker.CheckResult {
 	rawData, err := raw.CITests(c.RepoClient)
 	if err != nil {
 		e := sce.WithMessage(sce.ErrScorecardInternal, err.Error())
-		return checker.CreateRuntimeErrorResult(CheckCodeReview, e)
+		return checker.CreateRuntimeErrorResult(CheckCITests, e)
 	}
 
 	// Return raw results.

--- a/checks/ci_tests_test.go
+++ b/checks/ci_tests_test.go
@@ -1,0 +1,45 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/ossf/scorecard/v4/checker"
+	mockrepo "github.com/ossf/scorecard/v4/clients/mockclients"
+)
+
+func TestCITestsRuntimeError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+	//nolint:goerr113
+	mockRepoClient.EXPECT().ListCommits().Return(nil, fmt.Errorf("some runtime error")).AnyTimes()
+
+	req := checker.CheckRequest{
+		RepoClient: mockRepoClient,
+	}
+	res := CITests(&req)
+
+	want := "CI-Tests"
+	if res.Name != want {
+		t.Errorf("got: %q, want: %q", res.Name, want)
+	}
+	ctrl.Finish()
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?
bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Runtime errors in the `CI-Tests` check would return a `Code-Review` result due to a copy/paste typo.

#### What is the new behavior (if this is a feature change)?**
The typo is fixed and the function returns a `CI-Tests` result.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2686 #2746

Will also help https://github.com/ossf/scorecard-action/issues/1076 and https://github.com/ossf/scorecard-action/issues/1094 once a new release is cut
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
The CI-Tests check will show the correct check name when it encounters a runtime error.
```
