### PR TITLE
🌱 Fix goreleaser

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -97,10 +97,6 @@ changelog:
   # Set it to true if you wish to skip the changelog generation.
   # This may result in an empty release notes on GitHub/GitLab/Gitea.
   skip: false
-signs:
-  - artifacts: checksum
-    args: ["--batch", "-u", "{{ .Env.GPG_FINGERPRINT }}", "--output", "${signature}", "--detach-sign", "${artifact}"]
-
 release:
   footer: |
     ### Thanks for all contributors!


### PR DESCRIPTION
- Remove GPG signing from .goreleaser.yml
- Set `skip` parameter to `false` in .goreleaser.yml

[.goreleaser.yml]
- Remove the GPG signing from the .goreleaser.yml file
- Change the `skip` parameter to `false` in the .goreleaser.yml file
```
  • starting release...
  • loading config file                              file=.goreleaser.yml
  • loading environment variables
  • getting and validating git state
    • building...                                    commit=9ad975764535b9753fbcb0c78335f826dbb213c4 latest tag=v4.10.3
  • parsing tag
  • setting defaults
  • running before hooks
    • running                                        hook=go mod download
  • checking distribution directory
    • --rm-dist is set, cleaning it up
  • loading go mod information
  • build prerequisites
  • proxying go module
    • proxying github.com/ossf/scorecard/v4@v4.10.3 to build github.com/ossf/scorecard/v4
    • proxying github.com/ossf/scorecard/v4@v4.10.3 to build github.com/ossf/scorecard/v4
    • proxying github.com/ossf/scorecard/v4@v4.10.3 to build github.com/ossf/scorecard/v4
  • writing effective config file
    • writing                                        config=dist/config.yaml
  • generating changelog
    • writing                                        changelog=dist/CHANGELOG.md
  • building binaries
    • building                                       binary=dist/scorecard-windows-arm64.exe
    • building                                       binary=dist/scorecard-darwin-arm64
    • building                                       binary=dist/scorecard-linux-amd64
    • building                                       binary=dist/scorecard-linux-arm64
    • building                                       binary=dist/scorecard-darwin-amd64
    • building                                       binary=dist/scorecard-windows-amd64.exe
    • took: 53s
  • archives
    • creating                                       archive=dist/scorecard_4.10.3_windows_arm64.tar.gz
    • creating                                       archive=dist/scorecard_4.10.3_linux_arm64.tar.gz
    • creating                                       archive=dist/scorecard_4.10.3_darwin_amd64.tar.gz
    • creating                                       archive=dist/scorecard_4.10.3_windows_amd64.tar.gz
    • creating                                       archive=dist/scorecard_4.10.3_linux_amd64.tar.gz
    • creating                                       archive=dist/scorecard_4.10.3_darwin_arm64.tar.gz
    • took: 3s
  • calculating checksums
  • storing release metadata
    • writing                                        file=dist/artifacts.json
    • writing                                        file=dist/metadata.json
  • release succeeded after 57s
  ```

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
