### PR TITLE
✨ Support for GitHub's internal integration

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -113,7 +113,7 @@ func rootCmd(o *options.Options) error {
 	if !strings.EqualFold(o.Commit, clients.HeadSHA) {
 		requiredRequestTypes = append(requiredRequestTypes, checker.CommitBased)
 	}
-	enabledChecks, err := policy.GetEnabled(pol, o.ChecksToRun, requiredRequestTypes)
+	enabledChecks, err := policy.GetEnabled(pol, o.Checks(), requiredRequestTypes)
 	if err != nil {
 		return fmt.Errorf("GetEnabled: %w", err)
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -223,7 +223,7 @@ func (o *Options) IsInternalGitHubIntegrationEnabled() bool {
 func (o *Options) Checks() []string {
 	if o.IsInternalGitHubIntegrationEnabled() {
 		// Overwrite the list of checks.
-		s := os.Getenv("SCORECARD_INTERNAL_GITHUB_CHECKS")
+		s := strings.TrimSpace(os.Getenv("SCORECARD_INTERNAL_GITHUB_CHECKS"))
 		return strings.Split(s, ",")
 	}
 	return o.ChecksToRun

--- a/options/options.go
+++ b/options/options.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/caarlos0/env/v6"
 
@@ -204,6 +205,29 @@ func boolSum(bools ...bool) int {
 }
 
 // Feature flags.
+
+// GitHub integration support.
+// See https://github.com/ossf/scorecard-action/issues/1107.
+// NOTE: We don't add a field to to the Option structure to simplify
+// integration. If we did, the Action would also need to be aware
+// of the integration and pass the relevant values. This
+// would add redundancy and complicate maintenance.
+func (o *Options) IsInternalGitHubIntegrationEnabled() bool {
+	return (os.Getenv("CI") == "true") &&
+		(os.Getenv("SCORECARD_INTERNAL_GITHUB_INTEGRATION") == "1") &&
+		(os.Getenv("GITHUB_EVENT_NAME") == "<todo>")
+}
+
+// Checks returns the list of checks and honours the
+// GitHub integration.
+func (o *Options) Checks() []string {
+	if o.IsInternalGitHubIntegrationEnabled() {
+		// Overwrite the list of checks.
+		s := os.Getenv("SCORECARD_INTERNAL_GITHUB_CHECKS")
+		return strings.Split(s, ",")
+	}
+	return o.ChecksToRun
+}
 
 // isExperimentalEnabled returns true if experimental features were enabled via
 // environment variable.

--- a/options/options.go
+++ b/options/options.go
@@ -223,8 +223,12 @@ func (o *Options) IsInternalGitHubIntegrationEnabled() bool {
 func (o *Options) Checks() []string {
 	if o.IsInternalGitHubIntegrationEnabled() {
 		// Overwrite the list of checks.
-		s := strings.TrimSpace(os.Getenv("SCORECARD_INTERNAL_GITHUB_CHECKS"))
-		return strings.Split(s, ",")
+		s := os.Getenv("SCORECARD_INTERNAL_GITHUB_CHECKS")
+		l := strings.Split(s, ",")
+		for i := range l {
+			l[i] = strings.TrimSpace(l[i])
+		}
+		return l
 	}
 	return o.ChecksToRun
 }

--- a/options/options.go
+++ b/options/options.go
@@ -215,7 +215,7 @@ func boolSum(bools ...bool) int {
 func (o *Options) IsInternalGitHubIntegrationEnabled() bool {
 	return (os.Getenv("CI") == "true") &&
 		(os.Getenv("SCORECARD_INTERNAL_GITHUB_INTEGRATION") == "1") &&
-		(os.Getenv("GITHUB_EVENT_NAME") == "<todo>")
+		(os.Getenv("GITHUB_EVENT_NAME") == "dynamic")
 }
 
 // Checks returns the list of checks and honours the

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -608,8 +608,8 @@ func createDefaultLocationMessage(check *checker.CheckResult, score int) string 
 	return messageWithScore(check.Reason, score)
 }
 
-func toolName() string {
-	if options.IsInternalGitHubIntegrationEnabled() {
+func toolName(opts *options.Options) string {
+	if opts.IsInternalGitHubIntegrationEnabled() {
 		return strings.TrimSpace(os.Getenv("SCORECARD_INTERNAL_SARIF_TOOL_NAME"))
 	}
 	return "scorecard"
@@ -618,6 +618,7 @@ func toolName() string {
 // AsSARIF outputs ScorecardResult in SARIF 2.1.0 format.
 func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 	writer io.Writer, checkDocs docs.Doc, policy *spol.ScorecardPolicy,
+	opts *options.Options,
 ) error {
 	//nolint
 	// https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html.
@@ -644,7 +645,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 		if err != nil {
 			return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("computeCategory: %v: %s", err, check.Name))
 		}
-		run := getOrCreateSARIFRun(runs, category, "https://github.com/ossf/scorecard", toolName(),
+		run := getOrCreateSARIFRun(runs, category, "https://github.com/ossf/scorecard", toolName(opts),
 			r.Scorecard.Version, r.Scorecard.CommitSHA, r.Date, "supply-chain")
 
 		// Always add rules to indicate which checks were run.

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -610,7 +610,7 @@ func createDefaultLocationMessage(check *checker.CheckResult, score int) string 
 
 func toolName() string {
 	if options.IsInternalGitHubIntegrationEnabled() {
-		return os.Getenv("SCORECARD_INTERNAL_SARIF_TOOL_NAME")
+		return strings.TrimSpace(os.Getenv("SCORECARD_INTERNAL_SARIF_TOOL_NAME"))
 	}
 	return "scorecard"
 }

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -31,6 +32,7 @@ import (
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/finding"
 	"github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/options"
 	spol "github.com/ossf/scorecard/v4/policy"
 )
 
@@ -606,6 +608,13 @@ func createDefaultLocationMessage(check *checker.CheckResult, score int) string 
 	return messageWithScore(check.Reason, score)
 }
 
+func toolName() string {
+	if options.IsInternalGitHubIntegrationEnabled() {
+		return os.Getenv("SCORECARD_INTERNAL_SARIF_TOOL_NAME")
+	}
+	return "scorecard"
+}
+
 // AsSARIF outputs ScorecardResult in SARIF 2.1.0 format.
 func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 	writer io.Writer, checkDocs docs.Doc, policy *spol.ScorecardPolicy,
@@ -635,7 +644,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 		if err != nil {
 			return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("computeCategory: %v: %s", err, check.Name))
 		}
-		run := getOrCreateSARIFRun(runs, category, "https://github.com/ossf/scorecard", "scorecard",
+		run := getOrCreateSARIFRun(runs, category, "https://github.com/ossf/scorecard", toolName(),
 			r.Scorecard.Version, r.Scorecard.CommitSHA, r.Date, "supply-chain")
 
 		// Always add rules to indicate which checks were run.

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -610,7 +610,7 @@ func createDefaultLocationMessage(check *checker.CheckResult, score int) string 
 
 func toolName(opts *options.Options) string {
 	if opts.IsInternalGitHubIntegrationEnabled() {
-		return strings.TrimSpace(os.Getenv("SCORECARD_INTERNAL_SARIF_TOOL_NAME"))
+		return strings.TrimSpace(os.Getenv("SCORECARD_INTERNAL_GITHUB_SARIF_TOOL_NAME"))
 	}
 	return "scorecard"
 }

--- a/pkg/sarif_test.go
+++ b/pkg/sarif_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
 	"github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/options"
 	spol "github.com/ossf/scorecard/v4/policy"
 	rules "github.com/ossf/scorecard/v4/rule"
 )
@@ -847,7 +848,7 @@ func TestSARIFOutput(t *testing.T) {
 
 			var result bytes.Buffer
 			err = tt.result.AsSARIF(tt.showDetails, tt.logLevel, &result,
-				checkDocs, &tt.policy)
+				checkDocs, &tt.policy, &options.Options{})
 			if err != nil {
 				t.Fatalf("%s: AsSARIF: %v", tt.name, err)
 			}

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -114,7 +114,7 @@ func FormatResults(
 		err = results.AsString(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
 	case options.FormatSarif:
 		// TODO: support config files and update checker.MaxResultScore.
-		err = results.AsSARIF(opts.ShowDetails, log.ParseLevel(opts.LogLevel), os.Stdout, doc, policy)
+		err = results.AsSARIF(opts.ShowDetails, log.ParseLevel(opts.LogLevel), os.Stdout, doc, policy, opts)
 	case options.FormatJSON:
 		err = results.AsJSON2(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
 	case options.FormatSJSON:


### PR DESCRIPTION
See discussion at https://github.com/ossf/scorecard-action/issues/1107

Set 
- `SCORECARD_INTERNAL_GITHUB_INTEGRATION=1`
- `SCORECARD_INTERNAL_GITHUB_SARIF_TOOL_NAME=<tool-name>`
- `SCORECARD_INTERNAL_GITHUB_CHECKS=check1,check2,<others>`

The GitHub team will be able to create a workflow:
```yaml
- uses: ossf/scorecard-action@<ref>
  env:
     SCORECARD_INTERNAL_GITHUB_INTEGRATION: 1
     SCORECARD_INTERNAL_GITHUB_SARIF_TOOL_NAME: <the-name>
     SCORECARD_INTERNAL_GITHUB_CHECKS: check1,check2,check3
```

Note that this is a "hidden feature" and that's why we don't expose it via a proper Action input.

```release-note
Add internal flags to support GitHub's internal scans
```
