### PR TITLE
🌱 Remove unused code from changeset creation

### DIFF
--- a/checks/raw/code_review.go
+++ b/checks/raw/code_review.go
@@ -183,19 +183,7 @@ func getChangesets(commits []clients.Commit) []checker.Changeset {
 
 	// Changesets are returned in map order (i.e. randomized)
 	for ri := range changesetsByRevInfo {
-		// Ungroup all commits that don't have revision info
-		cs := changesetsByRevInfo[ri]
-		missing := revisionInfo{}
-		if ri == missing {
-			for i := range cs.Commits {
-				c := cs.Commits[i]
-				changesets = append(changesets, checker.Changeset{
-					Commits: []clients.Commit{c},
-				})
-			}
-		} else {
-			changesets = append(changesets, cs)
-		}
+		changesets = append(changesets, changesetsByRevInfo[ri])
 	}
 
 	return changesets

--- a/checks/raw/code_review_test.go
+++ b/checks/raw/code_review_test.go
@@ -15,84 +15,91 @@
 package raw
 
 import (
-	"strings"
 	"testing"
 	"time"
 
-	"golang.org/x/exp/slices"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/clients"
 )
 
-//nolint:gocritic
-func assertCommitEq(t *testing.T, actual clients.Commit, expected clients.Commit) {
-	t.Helper()
-
-	if actual.SHA != expected.SHA {
-		t.Fatalf("commit shas mismatched\na.sha: %s\nb.sha %s", actual.SHA, expected.SHA)
-	}
-}
-
-func assertChangesetEq(t *testing.T, actual, expected *checker.Changeset) {
-	t.Helper()
-
-	if actual.ReviewPlatform != expected.ReviewPlatform {
-		t.Fatalf(
-			"changeset review platform mismatched\na.platform: %s\nb.platform: %s",
-			actual.ReviewPlatform,
-			expected.ReviewPlatform,
-		)
-	}
-
-	if actual.RevisionID != expected.RevisionID {
-		t.Fatalf(
-			"changeset revisionID mismatched\na.revid: %s\nb.revid %s",
-			actual.RevisionID,
-			expected.RevisionID,
-		)
-	}
-
-	if len(actual.Commits) != len(expected.Commits) {
-		t.Fatalf(
-			"changesets contain different numbers of commits\na:%d\nb:%d",
-			len(actual.Commits),
-			len(expected.Commits),
-		)
-	}
-
-	for i := range actual.Commits {
-		assertCommitEq(t, actual.Commits[i], expected.Commits[i])
-	}
-}
-
-//nolint:gocritic
-func csless(a, b checker.Changeset) bool {
-	if cmp := strings.Compare(a.RevisionID, b.RevisionID); cmp != 0 {
-		return cmp < 0
-	}
-
-	return a.ReviewPlatform < b.ReviewPlatform
-}
-
-func assertChangesetArrEq(t *testing.T, actual, expected []checker.Changeset) {
-	t.Helper()
-
-	if len(actual) != len(expected) {
-		t.Fatalf("different number of changesets\na:%d\nb:%d", len(actual), len(expected))
-	}
-
-	slices.SortFunc(actual, csless)
-	slices.SortFunc(expected, csless)
-
-	for i := range actual {
-		assertChangesetEq(t, &actual[i], &expected[i])
-	}
-}
-
 // TestCodeReviews tests the CodeReviews function.
 func Test_getChangesets(t *testing.T) {
 	t.Parallel()
+	var (
+		commitC = clients.Commit{
+			SHA: "c",
+			AssociatedMergeRequest: clients.PullRequest{
+				Number: 3,
+				MergedAt: time.Date(2023 /*year*/, time.March, 21, /*day*/
+					13 /*hour*/, 42 /*min*/, 0 /*sec*/, 0 /*nsec*/, time.UTC),
+			},
+			Message: "merge commitSHA c form GitHub",
+		}
+		commitB = clients.Commit{
+			SHA: "b",
+			AssociatedMergeRequest: clients.PullRequest{
+				Number: 2,
+				MergedAt: time.Date(2023 /*year*/, time.March, 21, /*day*/
+					13 /*hour*/, 41 /*min*/, 0 /*sec*/, 0 /*nsec*/, time.UTC),
+			},
+			Message: "merge commitSHA b from GitHub",
+		}
+		commitBUnsquashed = clients.Commit{
+			SHA: "b_unsquashed",
+			AssociatedMergeRequest: clients.PullRequest{
+				Number: 2,
+				MergedAt: time.Date(2023 /*year*/, time.March, 21, /*day*/
+					13 /*hour*/, 40 /*min*/, 0 /*sec*/, 0 /*nsec*/, time.UTC),
+			},
+			Message: "unsquashed commitSHA b_unsquashed from GitHub",
+		}
+		commitA = clients.Commit{
+			SHA: "a",
+			AssociatedMergeRequest: clients.PullRequest{
+				Number: 1,
+				MergedAt: time.Date(2023 /*year*/, time.March, 21, /*day*/
+					13 /*hour*/, 39 /*min*/, 0 /*sec*/, 0 /*nsec*/, time.UTC),
+			},
+			Message: "merge commitSHA a from GitHub",
+		}
+
+		phabricatorCommitA = clients.Commit{
+			Message: "\nDifferential Revision: 123\nReviewed By: user-123",
+			SHA:     "abc",
+		}
+		phabricatorCommitAUnsquashed = clients.Commit{
+			Message: "\nDifferential Revision: 123\nReviewed By: user-123",
+			SHA:     "adef",
+		}
+		phabricatorCommitAUnsquashed2 = clients.Commit{
+			Message: "\nDifferential Revision: 123\nReviewed By: user-456",
+			SHA:     "afab",
+		}
+		phabricatorCommitB = clients.Commit{
+			Message: "\nDifferential Revision: 158\nReviewed By: user-123",
+			SHA:     "def",
+		}
+		phabricatorCommitC = clients.Commit{
+			Message: "\nDifferential Revision: 2000\nReviewed By: user-456",
+			SHA:     "fab",
+		}
+		phabricatorCommitD = clients.Commit{
+			Message: "\nDifferential Revision: 2\nReviewed By: user-456",
+			SHA:     "d",
+		}
+
+		gerritCommitB = clients.Commit{
+			Message: "first change\nReviewed-on: server.url \nReviewed-by:user-123",
+			SHA:     "abc",
+		}
+		gerritCommitA = clients.Commit{
+			Message: "followup\nReviewed-on: server.url \nReviewed-by:user-123",
+			SHA:     "def",
+		}
+	)
 
 	tests := []struct {
 		name     string
@@ -100,280 +107,247 @@ func Test_getChangesets(t *testing.T) {
 		expected []checker.Changeset
 	}{
 		{
-			name: "commit history squashed during merge",
-			commits: []clients.Commit{
-				{
-					SHA:                    "a",
-					AssociatedMergeRequest: clients.PullRequest{Number: 3, MergedAt: time.Now()},
-				},
-				{
-					SHA:                    "b",
-					AssociatedMergeRequest: clients.PullRequest{Number: 2, MergedAt: time.Now()},
-				},
-				{
-					SHA:                    "c",
-					AssociatedMergeRequest: clients.PullRequest{Number: 1, MergedAt: time.Now()},
-				},
-			},
+			name:    "github: merge with squash",
+			commits: []clients.Commit{commitC, commitB, commitA},
 			expected: []checker.Changeset{
 				{
 					ReviewPlatform: checker.ReviewPlatformGitHub,
 					RevisionID:     "3",
-					Commits:        []clients.Commit{{SHA: "a"}},
-				},
-				{
-					ReviewPlatform: checker.ReviewPlatformGitHub,
-					RevisionID:     "2",
-					Commits:        []clients.Commit{{SHA: "b"}},
-				},
-				{
-					ReviewPlatform: checker.ReviewPlatformGitHub,
-					RevisionID:     "1",
-					Commits:        []clients.Commit{{SHA: "c"}},
-				},
-			},
-		},
-		{
-			name: "commits in reverse chronological order",
-			commits: []clients.Commit{
-				{
-					SHA:                    "a",
-					AssociatedMergeRequest: clients.PullRequest{Number: 1, MergedAt: time.Now()},
-				},
-				{
-					SHA:                    "b",
-					AssociatedMergeRequest: clients.PullRequest{Number: 2, MergedAt: time.Now()},
-				},
-				{
-					SHA:                    "c",
-					AssociatedMergeRequest: clients.PullRequest{Number: 3, MergedAt: time.Now()},
-				},
-			},
-			expected: []checker.Changeset{
-				{
-					ReviewPlatform: checker.ReviewPlatformGitHub,
-					RevisionID:     "1",
-					Commits: []clients.Commit{
+					Commits:        []clients.Commit{commitC},
+					Reviews: []clients.Review{
 						{
-							SHA:                    "a",
-							AssociatedMergeRequest: clients.PullRequest{Number: 1},
+							Author: &clients.User{},
+							State:  "APPROVED",
 						},
 					},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGitHub,
 					RevisionID:     "2",
-					Commits: []clients.Commit{
+					Commits:        []clients.Commit{commitB},
+					Reviews: []clients.Review{
 						{
-							SHA:                    "b",
-							AssociatedMergeRequest: clients.PullRequest{Number: 2},
+							Author: &clients.User{},
+							State:  "APPROVED",
 						},
 					},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGitHub,
-					RevisionID:     "3",
-					Commits: []clients.Commit{
+					RevisionID:     "1",
+					Commits:        []clients.Commit{commitA},
+					Reviews: []clients.Review{
 						{
-							SHA:                    "c",
-							AssociatedMergeRequest: clients.PullRequest{Number: 3},
+							Author: &clients.User{},
+							State:  "APPROVED",
 						},
 					},
 				},
 			},
 		},
 		{
-			name: "without commit squashing",
-			commits: []clients.Commit{
-				{
-					SHA:                    "foo",
-					AssociatedMergeRequest: clients.PullRequest{Number: 1, MergedAt: time.Now()},
-				},
-				{
-					SHA:                    "bar",
-					AssociatedMergeRequest: clients.PullRequest{Number: 2, MergedAt: time.Now()},
-				},
-				{
-					SHA:                    "baz",
-					AssociatedMergeRequest: clients.PullRequest{Number: 2, MergedAt: time.Now()},
-				},
-			},
+			name:    "github: merge with squash reverse chronological order",
+			commits: []clients.Commit{commitA, commitB, commitC},
 			expected: []checker.Changeset{
 				{
 					ReviewPlatform: checker.ReviewPlatformGitHub,
 					RevisionID:     "1",
-					Commits: []clients.Commit{
+					Commits:        []clients.Commit{commitA},
+					Reviews: []clients.Review{
 						{
-							SHA:                    "foo",
-							AssociatedMergeRequest: clients.PullRequest{Number: 1},
+							Author: &clients.User{},
+							State:  "APPROVED",
 						},
 					},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGitHub,
 					RevisionID:     "2",
-					Commits: []clients.Commit{
+					Commits:        []clients.Commit{commitB},
+					Reviews: []clients.Review{
 						{
-							SHA:                    "bar",
-							AssociatedMergeRequest: clients.PullRequest{Number: 2},
-						},
-						{
-							SHA:                    "baz",
-							AssociatedMergeRequest: clients.PullRequest{Number: 2},
+							Author: &clients.User{},
+							State:  "APPROVED",
 						},
 					},
-				},
-			},
-		},
-		{
-			name: "some commits from external scm",
-			commits: []clients.Commit{
-				{
-					Message: "\nDifferential Revision: 123\nReviewed By: user-123",
-					SHA:     "abc",
-				},
-				{
-					Message: "\nDifferential Revision: 158\nReviewed By: user-456",
-					SHA:     "def",
-				},
-				{
-					Message:                "this one from github, but unrelated to prev",
-					AssociatedMergeRequest: clients.PullRequest{Number: 158, MergedAt: time.Now()},
-					SHA:                    "fab",
-				},
-				{
-					Message:                "another from gh",
-					AssociatedMergeRequest: clients.PullRequest{Number: 158, MergedAt: time.Now()},
-					SHA:                    "dab",
-				},
-			},
-			expected: []checker.Changeset{
-				{
-					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					RevisionID:     "123",
-					Commits:        []clients.Commit{{SHA: "abc"}},
-				},
-				{
-					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					RevisionID:     "158",
-					Commits:        []clients.Commit{{SHA: "def"}},
-				},
-				{
-					ReviewPlatform: checker.ReviewPlatformGitHub,
-					RevisionID:     "158",
-					Commits: []clients.Commit{
-						{SHA: "fab"},
-						{SHA: "dab"},
-					},
-				},
-			},
-		},
-		{
-			name: "some commits from external scm with no revision id",
-			commits: []clients.Commit{
-				{
-					Message: "first change\nReviewed-on: server.url \nReviewed-by:user-123",
-					SHA:     "abc",
-				},
-				{
-					Message: "followup\nReviewed-on: server.url \nReviewed-by:user-123",
-					SHA:     "def",
-				},
-				{
-					Message:                "commit thru gh",
-					AssociatedMergeRequest: clients.PullRequest{Number: 3, MergedAt: time.Now()},
-					SHA:                    "fab",
-				},
-			},
-			expected: []checker.Changeset{
-				{
-					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "abc",
-					Commits:        []clients.Commit{{SHA: "abc"}},
-				},
-				{
-					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "def",
-					Commits:        []clients.Commit{{SHA: "def"}},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGitHub,
 					RevisionID:     "3",
-					Commits:        []clients.Commit{{SHA: "fab"}},
+					Commits:        []clients.Commit{commitC},
+					Reviews: []clients.Review{
+						{
+							Author: &clients.User{},
+							State:  "APPROVED",
+						},
+					},
 				},
 			},
 		},
 		{
-			name: "external scm mirrored to github",
-			commits: []clients.Commit{
+			name:    "github: merge without squash",
+			commits: []clients.Commit{commitC, commitB, commitBUnsquashed},
+			expected: []checker.Changeset{
 				{
-					Message: "\nDifferential Revision: 123\nReviewed By: user-123",
-					SHA:     "abc",
+					ReviewPlatform: checker.ReviewPlatformGitHub,
+					RevisionID:     "3",
+					Commits:        []clients.Commit{commitC},
+					Reviews: []clients.Review{
+						{
+							Author: &clients.User{},
+							State:  "APPROVED",
+						},
+					},
 				},
 				{
-					Message: "\nDifferential Revision: 158\nReviewed By: user-123",
-					SHA:     "def",
-				},
-				{
-					Message: "\nDifferential Revision: 2000\nReviewed By: user-456",
-					SHA:     "fab",
+					ReviewPlatform: checker.ReviewPlatformGitHub,
+					RevisionID:     "2",
+					Commits:        []clients.Commit{commitB, commitBUnsquashed},
+					Reviews: []clients.Review{
+						{
+							Author: &clients.User{},
+							State:  "APPROVED",
+						},
+					},
 				},
 			},
+		},
+		{
+			name:    "github: merge without squash reverse chronological order",
+			commits: []clients.Commit{commitA, commitBUnsquashed, commitB, commitC},
+			expected: []checker.Changeset{
+				{
+					ReviewPlatform: checker.ReviewPlatformGitHub,
+					RevisionID:     "1",
+					Commits:        []clients.Commit{commitA},
+					Reviews: []clients.Review{
+						{
+							Author: &clients.User{},
+							State:  "APPROVED",
+						},
+					},
+				},
+				{
+					ReviewPlatform: checker.ReviewPlatformGitHub,
+					RevisionID:     "2",
+					Commits:        []clients.Commit{commitB, commitBUnsquashed},
+					Reviews: []clients.Review{
+						{
+							Author: &clients.User{},
+							State:  "APPROVED",
+						},
+					},
+				},
+				{
+					ReviewPlatform: checker.ReviewPlatformGitHub,
+					RevisionID:     "3",
+					Commits:        []clients.Commit{commitC},
+					Reviews: []clients.Review{
+						{
+							Author: &clients.User{},
+							State:  "APPROVED",
+						},
+					},
+				},
+			},
+		},
+		{
+			name:    "phabricator: merge with squash",
+			commits: []clients.Commit{phabricatorCommitA, phabricatorCommitB, phabricatorCommitC},
 			expected: []checker.Changeset{
 				{
 					RevisionID:     "123",
 					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					Commits:        []clients.Commit{{SHA: "abc"}},
+					Commits:        []clients.Commit{phabricatorCommitA},
 				},
 				{
 					RevisionID:     "158",
 					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					Commits:        []clients.Commit{{SHA: "def"}},
+					Commits:        []clients.Commit{phabricatorCommitB},
 				},
 				{
 					RevisionID:     "2000",
 					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					Commits:        []clients.Commit{{SHA: "fab"}},
+					Commits:        []clients.Commit{phabricatorCommitC},
 				},
 			},
 		},
 		{
-			name: "external scm no squash",
-			commits: []clients.Commit{
-				{
-					Message: "\nDifferential Revision: 123\nReviewed By: user-123",
-					SHA:     "abc",
-				},
-				{
-					Message: "\nDifferential Revision: 123\nReviewed By: user-123",
-					SHA:     "def",
-				},
-				{
-					Message: "\nDifferential Revision: 123\nReviewed By: user-456",
-					SHA:     "fab",
-				},
-			},
+			name:    "phabricator: merge without squash",
+			commits: []clients.Commit{phabricatorCommitA, phabricatorCommitAUnsquashed, phabricatorCommitAUnsquashed2},
 			expected: []checker.Changeset{
 				{
 					RevisionID:     "123",
 					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					Commits:        []clients.Commit{{SHA: "abc"}, {SHA: "def"}, {SHA: "fab"}},
+					Commits:        []clients.Commit{phabricatorCommitA, phabricatorCommitAUnsquashed, phabricatorCommitAUnsquashed2},
 				},
 			},
 		},
 		{
-			name: "single changeset",
-			commits: []clients.Commit{
-				{
-					SHA:                    "abc",
-					AssociatedMergeRequest: clients.PullRequest{Number: 1, MergedAt: time.Now()},
-				},
-			},
+			name:    "gerrit: merge with squash",
+			commits: []clients.Commit{gerritCommitB, gerritCommitA},
 			expected: []checker.Changeset{
 				{
+					ReviewPlatform: checker.ReviewPlatformGerrit,
+					RevisionID:     "abc",
+					Commits:        []clients.Commit{gerritCommitB},
+				},
+				{
+					ReviewPlatform: checker.ReviewPlatformGerrit,
+					RevisionID:     "def",
+					Commits:        []clients.Commit{gerritCommitA},
+				},
+			},
+		},
+		{
+			name:    "mixed: phabricator + gh",
+			commits: []clients.Commit{phabricatorCommitA, phabricatorCommitD, commitB, commitBUnsquashed},
+			expected: []checker.Changeset{
+				{
+					ReviewPlatform: checker.ReviewPlatformPhabricator,
+					RevisionID:     "123",
+					Commits:        []clients.Commit{phabricatorCommitA},
+				},
+				{
+					ReviewPlatform: checker.ReviewPlatformPhabricator,
+					RevisionID:     "2",
+					Commits:        []clients.Commit{phabricatorCommitD},
+				},
+				{
 					ReviewPlatform: checker.ReviewPlatformGitHub,
-					RevisionID:     "1",
-					Commits:        []clients.Commit{{SHA: "abc"}},
+					RevisionID:     "2",
+					Commits:        []clients.Commit{commitB, commitBUnsquashed},
+					Reviews: []clients.Review{{
+						Author: &clients.User{},
+						State:  "APPROVED",
+					}},
+				},
+			},
+		},
+		{
+			name:    "mixed: gerrit + gh",
+			commits: []clients.Commit{gerritCommitB, gerritCommitA, commitC},
+			expected: []checker.Changeset{
+				{
+					ReviewPlatform: checker.ReviewPlatformGerrit,
+					RevisionID:     "abc",
+					Commits:        []clients.Commit{gerritCommitB},
+				},
+				{
+					ReviewPlatform: checker.ReviewPlatformGerrit,
+					RevisionID:     "def",
+					Commits:        []clients.Commit{gerritCommitA},
+				},
+				{
+					ReviewPlatform: checker.ReviewPlatformGitHub,
+					RevisionID:     "3",
+					Commits:        []clients.Commit{commitC},
+					Reviews: []clients.Review{
+						{
+							Author: &clients.User{},
+							State:  "APPROVED",
+						},
+					},
 				},
 			},
 		},
@@ -382,6 +356,15 @@ func Test_getChangesets(t *testing.T) {
 	for _, tt := range tests {
 		t.Logf("test: %s", tt.name)
 		changesets := getChangesets(tt.commits)
-		assertChangesetArrEq(t, changesets, tt.expected)
+		if !cmp.Equal(tt.expected, changesets,
+			cmpopts.SortSlices(func(x, y checker.Changeset) bool {
+				return x.RevisionID < y.RevisionID
+			}),
+			cmpopts.SortSlices(func(x, y clients.Commit) bool {
+				return x.SHA < y.SHA
+			})) {
+			t.Log(cmp.Diff(tt.expected, changesets))
+			t.Fail()
+		}
 	}
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Remove unused code from changeset creation logic.

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
