### PR TITLE
🐛  Pass proper commit depth to github checkrun handler.

### DIFF
--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -72,10 +72,9 @@ func (client *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitD
 		return sce.WithMessage(sce.ErrRepoUnreachable, err.Error())
 	}
 	if commitDepth <= 0 {
-		client.commitDepth = 30 // default
-	} else {
-		client.commitDepth = commitDepth
+		commitDepth = 30 // default
 	}
+	client.commitDepth = commitDepth
 	client.repo = repo
 	client.repourl = &repoURL{
 		owner:         repo.Owner.GetLogin(),
@@ -103,7 +102,7 @@ func (client *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitD
 	client.workflows.init(client.ctx, client.repourl)
 
 	// Setup checkrunsHandler.
-	client.checkruns.init(client.ctx, client.repourl, commitDepth)
+	client.checkruns.init(client.ctx, client.repourl, client.commitDepth)
 
 	// Setup statusesHandler.
 	client.statuses.init(client.ctx, client.repourl)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
A small typo during a refactor (#2710) caused the checkRun graphQL query to be run with a commit depth of 0 when no commit depth is specified, so the query returned no data. This was causing more SAST checks to be cache misses.

```
go run main.go --repo ossf/scorecard --checks SAST --format json
INFO[0023] listCheckRunsForRef cache miss: ossf/scorecard:476a246ebbafa7f8785505621010f76123bd5059 
INFO[0024] listCheckRunsForRef cache miss: ossf/scorecard:f26282c2f3b3bcc099c1167cf62a87cfd79afbf8 
INFO[0024] listCheckRunsForRef cache miss: ossf/scorecard:227bb4a7df92eb217670c46893ac25cb19dbed25

... etc
```

#### What is the new behavior (if this is a feature change)?**
The proper value is passed to the checkrun handler, so the graphQL query populates data and there are fewer cache misses.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
