### PR TITLE
🐛 Add tie breaker when sorting changesets by RevisionID in tests.

### DIFF
--- a/checks/raw/code_review_test.go
+++ b/checks/raw/code_review_test.go
@@ -93,11 +93,11 @@ func Test_getChangesets(t *testing.T) {
 
 		gerritCommitB = clients.Commit{
 			Message: "first change\nReviewed-on: server.url \nReviewed-by:user-123",
-			SHA:     "abc",
+			SHA:     "abcg",
 		}
 		gerritCommitA = clients.Commit{
 			Message: "followup\nReviewed-on: server.url \nReviewed-by:user-123",
-			SHA:     "def",
+			SHA:     "defg",
 		}
 	)
 
@@ -289,12 +289,12 @@ func Test_getChangesets(t *testing.T) {
 			expected: []checker.Changeset{
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "abc",
+					RevisionID:     "abcg",
 					Commits:        []clients.Commit{gerritCommitB},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "def",
+					RevisionID:     "defg",
 					Commits:        []clients.Commit{gerritCommitA},
 				},
 			},
@@ -330,12 +330,12 @@ func Test_getChangesets(t *testing.T) {
 			expected: []checker.Changeset{
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "abc",
+					RevisionID:     "abcg",
 					Commits:        []clients.Commit{gerritCommitB},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "def",
+					RevisionID:     "defg",
 					Commits:        []clients.Commit{gerritCommitA},
 				},
 				{

--- a/checks/raw/code_review_test.go
+++ b/checks/raw/code_review_test.go
@@ -87,7 +87,7 @@ func Test_getChangesets(t *testing.T) {
 			SHA:     "fab",
 		}
 		phabricatorCommitD = clients.Commit{
-			Message: "\nDifferential Revision: 2\nReviewed By: user-456",
+			Message: "\nDifferential Revision: 3\nReviewed By: user-456",
 			SHA:     "d",
 		}
 
@@ -310,7 +310,7 @@ func Test_getChangesets(t *testing.T) {
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					RevisionID:     "2",
+					RevisionID:     "3",
 					Commits:        []clients.Commit{phabricatorCommitD},
 				},
 				{

--- a/checks/raw/code_review_test.go
+++ b/checks/raw/code_review_test.go
@@ -87,17 +87,17 @@ func Test_getChangesets(t *testing.T) {
 			SHA:     "fab",
 		}
 		phabricatorCommitD = clients.Commit{
-			Message: "\nDifferential Revision: 3\nReviewed By: user-456",
+			Message: "\nDifferential Revision: 2\nReviewed By: user-456",
 			SHA:     "d",
 		}
 
 		gerritCommitB = clients.Commit{
 			Message: "first change\nReviewed-on: server.url \nReviewed-by:user-123",
-			SHA:     "abcg",
+			SHA:     "abc",
 		}
 		gerritCommitA = clients.Commit{
 			Message: "followup\nReviewed-on: server.url \nReviewed-by:user-123",
-			SHA:     "defg",
+			SHA:     "def",
 		}
 	)
 
@@ -289,12 +289,12 @@ func Test_getChangesets(t *testing.T) {
 			expected: []checker.Changeset{
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "abcg",
+					RevisionID:     "abc",
 					Commits:        []clients.Commit{gerritCommitB},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "defg",
+					RevisionID:     "def",
 					Commits:        []clients.Commit{gerritCommitA},
 				},
 			},
@@ -310,7 +310,7 @@ func Test_getChangesets(t *testing.T) {
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformPhabricator,
-					RevisionID:     "3",
+					RevisionID:     "2",
 					Commits:        []clients.Commit{phabricatorCommitD},
 				},
 				{
@@ -330,12 +330,12 @@ func Test_getChangesets(t *testing.T) {
 			expected: []checker.Changeset{
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "abcg",
+					RevisionID:     "abc",
 					Commits:        []clients.Commit{gerritCommitB},
 				},
 				{
 					ReviewPlatform: checker.ReviewPlatformGerrit,
-					RevisionID:     "defg",
+					RevisionID:     "def",
 					Commits:        []clients.Commit{gerritCommitA},
 				},
 				{

--- a/checks/raw/code_review_test.go
+++ b/checks/raw/code_review_test.go
@@ -358,6 +358,9 @@ func Test_getChangesets(t *testing.T) {
 		changesets := getChangesets(tt.commits)
 		if !cmp.Equal(tt.expected, changesets,
 			cmpopts.SortSlices(func(x, y checker.Changeset) bool {
+				if x.RevisionID == y.RevisionID {
+					return x.ReviewPlatform < y.ReviewPlatform
+				}
 				return x.RevisionID < y.RevisionID
 			}),
 			cmpopts.SortSlices(func(x, y clients.Commit) bool {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
`phabricatorCommitD` and `commitB` both have `RevisionID` of 2.
Both of these commits are used in the `mixed: phabricator + gh` test

The map iteration order isn't deterministic and sorting the slices isn't good enough when the revision IDs are equal.

This is causing the unit-tests to fail intermittently on unrelated PRs. e.g. #2780 
https://github.com/ossf/scorecard/actions/runs/4494760078/jobs/7907638544?pr=2780#step:7:138

#### What is the new behavior (if this is a feature change)?**
review platform is used as a tie breaker when sorting in the test code

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
