### PR TITLE
🐛  Restore upload of existing raw result Big Query data

### DIFF
--- a/cron/internal/format/bq.raw.schema
+++ b/cron/internal/format/bq.raw.schema
@@ -331,6 +331,102 @@
         "mode": "REPEATED",
         "name": "defaultBranchCommits",
         "type": "RECORD"
+      },
+      {
+        "description": "",
+        "fields": [
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "number",
+            "type": "STRING"
+          },
+          {
+            "description": "",
+            "mode": "NULLABLE",
+            "name": "platform",
+            "type": "STRING"
+          },
+          {
+            "description": "",
+            "mode": "REPEATED",
+            "name": "reviews",
+            "type": "RECORD",
+            "fields": [
+              {
+                "description": "",
+                "mode": "NULLABLE",
+                "name": "reviewer",
+                "type": "RECORD",
+                "fields": [
+                  {
+                    "description": "",
+                    "mode": "NULLABLE",
+                    "name": "login",
+                    "type": "STRING"
+                  }
+                ]
+              },
+              {
+                "description": "",
+                "mode": "NULLABLE",
+                "name": "state",
+                "type": "STRING"
+              }
+            ]
+          },
+          {
+            "description": "",
+            "mode": "REPEATED",
+            "name": "authors",
+            "type": "RECORD",
+            "fields": [
+              {
+                "description": "",
+                "mode": "NULLABLE",
+                "name": "login",
+                "type": "STRING"
+              }
+            ]
+          },
+          {
+            "description": "",
+            "mode": "REPEATED",
+            "name": "commits",
+            "type": "RECORD",
+            "fields": [
+              {
+                "description": "",
+                "mode": "NULLABLE",
+                "name": "committer",
+                "type": "RECORD",
+                "fields": [
+                  {
+                    "description": "",
+                    "mode": "NULLABLE",
+                    "name": "login",
+                    "type": "STRING"
+                  }
+                ]
+              },
+              {
+                "description": "",
+                "mode": "NULLABLE",
+                "name": "message",
+                "type": "STRING"
+              },
+              {
+                "description": "",
+                "mode": "NULLABLE",
+                "name": "sha",
+                "type": "STRING"
+              }
+            ]
+          }
+        ],
+        "mode": "REPEATED",
+        "name": "defaultBranchChangesets",
+        "type": "RECORD"
       }
     ],
     "mode": "NULLABLE",


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The raw result BigQuery transfer has been failing for a while due to schema changes. The [raw results outputted by the cron](
https://github.com/ossf/scorecard/blob/dde9aa1aefb9e26196c03ef7401287ff2fd35b01/cron/internal/format/json_raw_results.go#L101-L115) is kept separate from the [raw results in the rest of Scorecard](https://github.com/ossf/scorecard/blob/dde9aa1aefb9e26196c03ef7401287ff2fd35b01/pkg/json_raw_results.go#L252). This was done intentionally to avoid changes breaking the cron, although the two have diverged quite a bit.

#### What is the new behavior (if this is a feature change)?**
The schema has been updated to include the new fields introduced to the cron version of the struct. Once applied to `openssf:scorecardcron.scorecard-rawdata`, the upload of raw results should resume, although there is further work to be done to get the cron copy to match the scorecard copy.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
This has been tested in the release test version of the table `openssf:scorecardcron.scorecard-rawdata-releasetest` and the transfers have resumed successfully.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
The schema for `openssf:scorecardcron.scorecard-rawdata` has been fixed to upload the new Code-Review Changeset data. As a reminder, the raw data table is experimental.
```
