### PR TITLE
🌱 Restore API quota metrics for the weekly cron job.

### DIFF
--- a/clients/githubrepo/roundtripper/transport.go
+++ b/clients/githubrepo/roundtripper/transport.go
@@ -17,9 +17,7 @@ package roundtripper
 import (
 	"fmt"
 	"net/http"
-	"strconv"
 
-	"go.opencensus.io/stats"
 	"go.opencensus.io/tag"
 
 	"github.com/ossf/scorecard/v4/clients/githubrepo/roundtripper/tokens"
@@ -54,15 +52,6 @@ func (gt *githubTransport) RoundTrip(r *http.Request) (*http.Response, error) {
 	resp, err := gt.innerTransport.RoundTrip(r)
 	if err != nil {
 		return nil, fmt.Errorf("error in HTTP: %w", err)
-	}
-
-	ctx, err = tag.New(r.Context(), tag.Upsert(githubstats.ResourceType, resp.Header.Get("X-RateLimit-Resource")))
-	if err != nil {
-		return nil, fmt.Errorf("error updating context: %w", err)
-	}
-	remaining, err := strconv.Atoi(resp.Header.Get("X-RateLimit-Remaining"))
-	if err == nil {
-		stats.Record(ctx, githubstats.RemainingTokens.M(int64(remaining)))
 	}
 
 	return resp, nil


### PR DESCRIPTION
#### What kind of change does this PR introduce?

cron update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The `X-RateLimit-Remaining` header value was reported by the `githubTransport` (e.g. `GITHUB_AUTH_TOKEN`, `GITHUB_TOKEN`, or a `GITHUB_AUTH_SERVER`).  This transport isn't used with GitHub Apps so the cron doesn't currently have stats for API quota usage.

#### What is the new behavior (if this is a feature change)?**
The `X-RateLimit-Remaining` `Record()`ing is moved to `rateLimitTransport` so the value is reported regardless of the kind of token used. This seems like the better place for it anyway.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

`TokenIndex` is one of the grouping tags for GitHub token view:
https://github.com/ossf/scorecard/blob/9358843a7f1b85617aa222c17acde2536bf3da8a/clients/githubrepo/stats/stats.go#L35-L42

The docs didn't have a clear answer on what happens if one of the `TagKeys` tags isn't set (the GitHub App transport doesn't set `TokenIndex` since it's not our code), but the code which [groups by sample](https://github.com/census-instrumentation/opencensus-go/blob/v0.24.0/stats/view/view.go#L156-L162) doesn't seem to care if a tag is missing (they ignore the `ok` field [here](https://github.com/census-instrumentation/opencensus-go/blob/b1a01ee95db0e690d91d7193d037447816fae4c5/stats/view/collector.go#L72-L75)).

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
