### PR TITLE
:seedling: Commit depth for GitLab

### DIFF
--- a/clients/gitlabrepo/client.go
+++ b/clients/gitlabrepo/client.go
@@ -91,7 +91,7 @@ func (client *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitD
 	client.contributors.init(client.repourl)
 
 	// Init commitsHandler
-	client.commits.init(client.repourl)
+	client.commits.init(client.repourl, client.commitDepth)
 
 	// Init branchesHandler
 	client.branches.init(client.repourl)

--- a/clients/gitlabrepo/commits.go
+++ b/clients/gitlabrepo/commits.go
@@ -44,7 +44,7 @@ func (handler *commitsHandler) init(repourl *repoURL, commitDepth int) {
 func (handler *commitsHandler) setup() error {
 	handler.once.Do(func() {
 		var commits []*gitlab.Commit
-		i := 0
+		i := 1
 
 		for {
 			c, _, err := handler.glClient.Commits.ListCommits(handler.repourl.project,

--- a/clients/gitlabrepo/commits.go
+++ b/clients/gitlabrepo/commits.go
@@ -25,26 +25,52 @@ import (
 )
 
 type commitsHandler struct {
-	glClient *gitlab.Client
-	once     *sync.Once
-	errSetup error
-	repourl  *repoURL
-	commits  []clients.Commit
+	glClient    *gitlab.Client
+	once        *sync.Once
+	errSetup    error
+	repourl     *repoURL
+	commits     []clients.Commit
+	commitDepth int
 }
 
-func (handler *commitsHandler) init(repourl *repoURL) {
+func (handler *commitsHandler) init(repourl *repoURL, commitDepth int) {
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
+	handler.commitDepth = commitDepth
 }
 
 // nolint: gocognit
 func (handler *commitsHandler) setup() error {
 	handler.once.Do(func() {
-		commits, _, err := handler.glClient.Commits.ListCommits(handler.repourl.project, &gitlab.ListCommitsOptions{})
-		if err != nil {
-			handler.errSetup = fmt.Errorf("request for commits failed with %w", err)
-			return
+		var commits []*gitlab.Commit
+		i := 0
+
+		for {
+			c, _, err := handler.glClient.Commits.ListCommits(handler.repourl.project,
+				&gitlab.ListCommitsOptions{
+					ListOptions: gitlab.ListOptions{
+						Page:    i,
+						PerPage: handler.commitDepth,
+					},
+				})
+
+			if err != nil {
+				handler.errSetup = fmt.Errorf("request for commits failed with %w", err)
+				return
+			}
+
+			if len(c) == 0 {
+				break
+			}
+			i++
+
+			commits = append(commits, c...)
+
+			if len(commits) >= handler.commitDepth {
+				commits = commits[:handler.commitDepth]
+				break
+			}
 		}
 
 		// To limit the number of user requests we are going to map every committer email

--- a/clients/gitlabrepo/commits.go
+++ b/clients/gitlabrepo/commits.go
@@ -54,7 +54,6 @@ func (handler *commitsHandler) setup() error {
 						PerPage: handler.commitDepth,
 					},
 				})
-
 			if err != nil {
 				handler.errSetup = fmt.Errorf("request for commits failed with %w", err)
 				return


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix for #2828 

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The new gitlab functionality is not using the parameter `--commit-depth` in querying the gitlab repo for commits. In addition the defaulted value of 30 was not being used either, for the same reason.

#### What is the new behavior (if this is a feature change)?**
When providing a value or using the defaults, the desired number of commits are being retrieved from gitlab repo

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2828 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
No
For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)


```release-note
NONE
```
