### PR TITLE
:sparkles: Consider haskell-actions/hlint-scan a code scanning action

### DIFF
--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -313,6 +313,17 @@ func TestGithubTokenPermissions(t *testing.T) {
 			},
 		},
 		{
+			name:      "security-events write, known actions",
+			filenames: []string{"./testdata/.github/workflows/github-workflow-permissions-secevent-known-actions.yaml"},
+			expected: scut.TestReturn{
+				Error:         nil,
+				Score:         checker.MaxResultScore,
+				NumberOfWarn:  0,
+				NumberOfInfo:  2,  // This is constant.
+				NumberOfDebug: 8,  // This is 4 + (number of actions)
+			},
+		},
+		{
 			name: "two files mix run-level and top-level",
 			filenames: []string{
 				"./testdata/.github/workflows/github-workflow-permissions-top-level-only.yaml",

--- a/checks/raw/permissions.go
+++ b/checks/raw/permissions.go
@@ -372,6 +372,10 @@ func isAllowedWorkflow(workflow *actionlint.Workflow, fp string, pdata *permissi
 		// allow our own action, which writes sarif files
 		// https://github.com/ossf/scorecard-action
 		"ossf/scorecard-action": true,
+
+		// Code scanning with HLint uploads a SARIF file to GitHub.
+		// https://github.com/haskell-actions/hlint-scan
+		"haskell-actions/hlint-scan": true,
 	}
 
 	tokenPermissions := checker.TokenPermission{

--- a/checks/testdata/.github/workflows/github-workflow-permissions-secevent-known-actions.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-permissions-secevent-known-actions.yaml
@@ -1,0 +1,48 @@
+# Copyright 2021 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: write-and-read workflow
+on: [push]
+permissions: read-all
+
+# All of the actions below are known to upload SARIF.
+# They should not trigger a warning about the security-events
+# write permission being enabled.
+jobs:
+  codeql-analyze:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: github/codeql-action/analyze@v1
+
+  codeql-upload:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: github/codeql-action/upload-sarif@v1
+
+  scorecard:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: ossf/scorecard-action@v1
+
+  haskell-hlint:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: haskell-actions/hlint-scan@v1


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Recognizes that [haskell-actions/hlint-scan](https://github.com/haskell-actions/hlint-scan) is supposed to upload SARIF files and hence needs the `security-events: write` permission.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

haskell-actions/hlint-scan is not recognized as a code scanning action which uploads SARIF, so Scorecard reports a `Token-Permissions` alert.

#### What is the new behavior (if this is a feature change)?**

haskell-actions/hlint-scan is now recognized as a code scanning action which uploads SARIF. Unit tests were added that cover not only this addition, but also existing code scanning actions that had no corresponding unit tests.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes https://github.com/ossf/scorecard/issues/2840

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

```release-note
haskell-actions/hlint-scan is recognized as a code scanning action which uploads SARIF.
```
