### PR TITLE
🐛 Reset stored error when handler is re-inited or setup is re-run.

### DIFF
--- a/clients/githubrepo/checkruns.go
+++ b/clients/githubrepo/checkruns.go
@@ -89,10 +89,12 @@ func (handler *checkrunsHandler) init(ctx context.Context, repourl *repoURL, com
 	handler.checkData = new(checkRunsGraphqlData)
 	handler.setupOnce = new(sync.Once)
 	handler.checkRunsByRef = checkRunsByRef{}
+	handler.errSetup = nil
 }
 
 func (handler *checkrunsHandler) setup() error {
 	handler.setupOnce.Do(func() {
+		handler.errSetup = nil
 		commitExpression := handler.repourl.commitExpression()
 		vars := map[string]interface{}{
 			"owner":                 githubv4.String(handler.repourl.owner),

--- a/clients/githubrepo/checkruns_test.go
+++ b/clients/githubrepo/checkruns_test.go
@@ -1,0 +1,30 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubrepo
+
+import (
+	"context"
+	"testing"
+
+	sce "github.com/ossf/scorecard/v4/errors"
+)
+
+func Test_init_clearsErr(t *testing.T) {
+	handler := &checkrunsHandler{errSetup: sce.ErrScorecardInternal}
+	handler.init(context.Background(), nil, 0)
+	if handler.errSetup != nil {
+		t.Errorf("expected nil error, got %v", handler.errSetup)
+	}
+}


### PR DESCRIPTION

#### What kind of change does this PR introduce?
bug fix in the cron

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The checkruns handler never clears `errSetup`

#### What is the new behavior (if this is a feature change)?**
The checkruns handler clears `errSetup` when it's `init`'d again, or when `setup` is run.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2892 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
