### PR TITLE
✨ Add a `--details-format` Option to produce JSON-details

### DIFF
--- a/options/flags.go
+++ b/options/flags.go
@@ -57,10 +57,6 @@ const (
 	// FlagChecks is the flag name for specifying which checks to run.
 	FlagChecks = "checks"
 
-	// FlagChecksDefinitionFile is the flag name for specifying the file that
-	// defines the checks.
-	FlagChecksDefinitionFile = "checks-definition-file"
-
 	// FlagPolicyFile is the flag name for specifying a policy file.
 	FlagPolicyFile = "policy"
 
@@ -153,13 +149,6 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		FlagCommitDepth,
 		o.CommitDepth,
 		"number of commits to check, commits begin backwards from the HEAD",
-	)
-
-	cmd.Flags().StringVar(
-		&o.ChecksDefinitionFile,
-		FlagChecksDefinitionFile,
-		o.ChecksDefinitionFile,
-		"file defining the checks",
 	)
 
 	checkNames := []string{}

--- a/options/flags.go
+++ b/options/flags.go
@@ -51,8 +51,15 @@ const (
 	// FlagShowDetails is the flag name for outputting additional check info.
 	FlagShowDetails = "show-details"
 
+	// FlagDetailsFormat is the flag name for setting the format of the details.
+	FlagDetailsFormat = "details-format"
+
 	// FlagChecks is the flag name for specifying which checks to run.
 	FlagChecks = "checks"
+
+	// FlagChecksDefinitionFile is the flag name for specifying the file that
+	// defines the checks.
+	FlagChecksDefinitionFile = "checks-definition-file"
 
 	// FlagPolicyFile is the flag name for specifying a policy file.
 	FlagPolicyFile = "policy"
@@ -134,11 +141,25 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		"show extra details about each check",
 	)
 
+	cmd.Flags().StringVar(
+		&o.DetailsFormat,
+		FlagDetailsFormat,
+		o.DetailsFormat,
+		"format to display the details. One of \"string\", \"findings\"",
+	)
+
 	cmd.Flags().IntVar(
 		&o.CommitDepth,
 		FlagCommitDepth,
 		o.CommitDepth,
 		"number of commits to check, commits begin backwards from the HEAD",
+	)
+
+	cmd.Flags().StringVar(
+		&o.ChecksDefinitionFile,
+		FlagChecksDefinitionFile,
+		o.ChecksDefinitionFile,
+		"file defining the checks",
 	)
 
 	checkNames := []string{}

--- a/options/options.go
+++ b/options/options.go
@@ -81,9 +81,6 @@ const (
 	// Formats.
 	// FormatJSON specifies that results should be output in JSON format.
 	FormatJSON = "json"
-	// FormatPJSON specifies that results should be output in probe JSON format,
-	// i.e., with the structured results.
-	FormatPJSON = "probe-json"
 	// FormatSJSON specifies that results should be output in structured JSON format,
 	// i.e., with the structured results.
 	FormatSJSON = "structured-json"
@@ -174,12 +171,6 @@ func (o *Options) Validate() error {
 
 	if !o.isExperimentalEnabled() {
 		if o.Format == FormatSJSON {
-			errs = append(
-				errs,
-				errFormatSupportedWithExperimental,
-			)
-		}
-		if o.Format == FormatPJSON {
 			errs = append(
 				errs,
 				errFormatSupportedWithExperimental,
@@ -290,7 +281,7 @@ func (o *Options) isV6Enabled() bool {
 
 func validateFormat(format string) bool {
 	switch format {
-	case FormatJSON, FormatSJSON, FormatPJSON, FormatSarif, FormatDefault, FormatRaw:
+	case FormatJSON, FormatSJSON, FormatSarif, FormatDefault, FormatRaw:
 		return true
 	default:
 		return false

--- a/options/options.go
+++ b/options/options.go
@@ -116,7 +116,6 @@ var (
 	errCommitIsEmpty                   = errors.New("commit should be non-empty")
 	errFormatNotSupported              = errors.New("unsupported format")
 	errFormatSupportedWithExperimental = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
-	errChecksMutuallyExclusive         = errors.New("--checks-definition-file and --checks are mutually exclusive")
 	errPolicyFileNotSupported          = errors.New("policy file is not supported yet")
 	errRawOptionNotSupported           = errors.New("raw option is not supported yet")
 	errRepoOptionMustBeSet             = errors.New(

--- a/options/options.go
+++ b/options/options.go
@@ -29,17 +29,16 @@ import (
 
 // Options define common options for configuring scorecard.
 type Options struct {
-	Repo                 string
-	Local                string
-	Commit               string
-	LogLevel             string
-	Format               string
-	NPM                  string
-	PyPI                 string
-	RubyGems             string
-	PolicyFile           string
-	ChecksDefinitionFile string
-	DetailsFormat        string
+	Repo          string
+	Local         string
+	Commit        string
+	LogLevel      string
+	Format        string
+	NPM           string
+	PyPI          string
+	RubyGems      string
+	PolicyFile    string
+	DetailsFormat string
 	// TODO(action): Add logic for writing results to file
 	ResultsFile string
 	ChecksToRun []string
@@ -117,15 +116,13 @@ var (
 	// DefaultLogLevel retrieves the default log level.
 	DefaultLogLevel = log.DefaultLevel.String()
 
-	errCommitIsEmpty                    = errors.New("commit should be non-empty")
-	errFormatNotSupported               = errors.New("unsupported format")
-	errFormatSupportedWithExperimental  = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
-	errChecksDefinitionFileExperimental = errors.New("checks-definition-file supported only with SCORECARD_EXPERIMENTAL=1")
-	errChecksDefinitionFileNotSupported = errors.New("checks-definition-file only support format 'probe-json' and 'structured-json'")
-	errChecksMutuallyExclusive          = errors.New("--checks-definition-file and --checks are mutually exclusive")
-	errPolicyFileNotSupported           = errors.New("policy file is not supported yet")
-	errRawOptionNotSupported            = errors.New("raw option is not supported yet")
-	errRepoOptionMustBeSet              = errors.New(
+	errCommitIsEmpty                   = errors.New("commit should be non-empty")
+	errFormatNotSupported              = errors.New("unsupported format")
+	errFormatSupportedWithExperimental = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
+	errChecksMutuallyExclusive         = errors.New("--checks-definition-file and --checks are mutually exclusive")
+	errPolicyFileNotSupported          = errors.New("policy file is not supported yet")
+	errRawOptionNotSupported           = errors.New("raw option is not supported yet")
+	errRepoOptionMustBeSet             = errors.New(
 		"exactly one of `repo`, `npm`, `pypi`, `rubygems` or `local` must be set",
 	)
 	errSARIFNotSupported = errors.New("SARIF format is not supported yet")
@@ -188,12 +185,6 @@ func (o *Options) Validate() error {
 				errFormatSupportedWithExperimental,
 			)
 		}
-		if o.ChecksDefinitionFile != "" {
-			errs = append(
-				errs,
-				errChecksDefinitionFileExperimental,
-			)
-		}
 		if o.DetailsFormat != DetailsFormatString {
 			errs = append(
 				errs,
@@ -216,23 +207,6 @@ func (o *Options) Validate() error {
 			errs,
 			errFormatNotSupported,
 		)
-	}
-
-	// Validate check definition and format.
-	if o.ChecksDefinitionFile != "" {
-		if o.Format != FormatSJSON &&
-			o.Format != FormatPJSON {
-			errs = append(
-				errs,
-				errChecksDefinitionFileNotSupported,
-			)
-		}
-		if len(o.ChecksToRun) > 0 {
-			errs = append(
-				errs,
-				errChecksMutuallyExclusive,
-			)
-		}
 	}
 
 	// Validate `commit` is non-empty.

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Cannot run parallel tests because of the ENV variables.
-//nolint
+// nolint
 func TestOptions_Validate(t *testing.T) {
 	type fields struct {
 		Repo              string
@@ -37,6 +37,7 @@ func TestOptions_Validate(t *testing.T) {
 		ChecksToRun       []string
 		Metadata          []string
 		ShowDetails       bool
+		DetailsFormat     string
 		EnableSarif       bool
 		EnableScorecardV6 bool
 	}
@@ -53,36 +54,40 @@ func TestOptions_Validate(t *testing.T) {
 		{
 			name: "format sarif but the enable sarif flag is not set",
 			fields: fields{
-				Format: "sarif",
+				Format:        "sarif",
+				DetailsFormat: "string",
 			},
 			wantErr: true,
 		},
 		{
 			name: "format sarif and the enable sarif flag is set",
 			fields: fields{
-				Repo:        "github.com/oss/scorecard",
-				Commit:      "HEAD",
-				Format:      "sarif",
-				EnableSarif: true,
-				PolicyFile:  "testdata/policy.yaml",
+				Repo:          "github.com/oss/scorecard",
+				Commit:        "HEAD",
+				Format:        "sarif",
+				DetailsFormat: "string",
+				EnableSarif:   true,
+				PolicyFile:    "testdata/policy.yaml",
 			},
 			wantErr: false,
 		},
 		{
 			name: "format sarif and the disabled but the policy file is set",
 			fields: fields{
-				Repo:       "github.com/oss/scorecard",
-				Commit:     "HEAD",
-				PolicyFile: "testdata/policy.yaml",
+				Repo:          "github.com/oss/scorecard",
+				Commit:        "HEAD",
+				PolicyFile:    "testdata/policy.yaml",
+				DetailsFormat: "string",
 			},
 			wantErr: true,
 		},
 		{
 			name: "format raw is not supported when V6 is not enabled",
 			fields: fields{
-				Repo:   "github.com/oss/scorecard",
-				Commit: "HEAD",
-				Format: "raw",
+				Repo:          "github.com/oss/scorecard",
+				Commit:        "HEAD",
+				Format:        "raw",
+				DetailsFormat: "string",
 			},
 			wantErr: true,
 		},
@@ -104,6 +109,7 @@ func TestOptions_Validate(t *testing.T) {
 				ChecksToRun:       tt.fields.ChecksToRun,
 				Metadata:          tt.fields.Metadata,
 				ShowDetails:       tt.fields.ShowDetails,
+				DetailsFormat:     tt.fields.DetailsFormat,
 				EnableSarif:       tt.fields.EnableSarif,
 				EnableScorecardV6: tt.fields.EnableScorecardV6,
 			}

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -25,6 +25,7 @@ import (
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/finding"
 	"github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/options"
 	rules "github.com/ossf/scorecard/v4/rule"
 )
 
@@ -146,7 +147,17 @@ func (r *ScorecardResult) AsJSON(showDetails bool, logLevel log.Level, writer io
 }
 
 // AsJSON2 exports results as JSON for new detail format.
-func (r *ScorecardResult) AsJSON2(showDetails bool,
+func (r *ScorecardResult) AsJSON2(opts *options.Options,
+	logLevel log.Level, checkDocs docs.Doc, writer io.Writer,
+) error {
+	if opts != nil && opts.DetailsFormat != options.DetailsFormatString {
+		return r.withFindings(opts, logLevel, checkDocs, writer)
+	}
+
+	return r.withString(opts, logLevel, checkDocs, writer)
+}
+
+func (r *ScorecardResult) withString(opts *options.Options,
 	logLevel log.Level, checkDocs docs.Doc, writer io.Writer,
 ) error {
 	score, err := r.GetAggregateScore(checkDocs)
@@ -184,7 +195,7 @@ func (r *ScorecardResult) AsJSON2(showDetails bool,
 			Reason: checkResult.Reason,
 			Score:  checkResult.Score,
 		}
-		if showDetails {
+		if opts != nil && opts.ShowDetails {
 			for i := range checkResult.Details {
 				d := checkResult.Details[i]
 				m := DetailToString(&d, logLevel)
@@ -196,11 +207,18 @@ func (r *ScorecardResult) AsJSON2(showDetails bool,
 		}
 		out.Checks = append(out.Checks, tmpResult)
 	}
+
 	if err := encoder.Encode(out); err != nil {
 		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("encoder.Encode: %v", err))
 	}
 
 	return nil
+}
+
+func (r *ScorecardResult) withFindings(opts *options.Options,
+	logLevel log.Level, checkDocs docs.Doc, writer io.Writer,
+) error {
+	return sce.WithMessage(sce.ErrScorecardInternal, "WIP: not supported")
 }
 
 func (r *ScorecardResult) AsSJSON(showDetails bool,

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -147,7 +147,15 @@ func (r *ScorecardResult) AsJSON(showDetails bool, logLevel log.Level, writer io
 }
 
 // AsJSON2 exports results as JSON for new detail format.
-func (r *ScorecardResult) AsJSON2(opts *options.Options,
+func (r *ScorecardResult) AsJSON2(showDetails bool,
+	logLevel log.Level, checkDocs docs.Doc, writer io.Writer,
+) error {
+	return r.withString(&options.Options{ShowDetails: showDetails},
+		logLevel, checkDocs, writer)
+}
+
+// AsJSON3 exports results as JSON for several detail format.
+func (r *ScorecardResult) AsJSON3(opts *options.Options,
 	logLevel log.Level, checkDocs docs.Doc, writer io.Writer,
 ) error {
 	if opts != nil && opts.DetailsFormat != options.DetailsFormatString {

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -116,7 +116,7 @@ func FormatResults(
 		// TODO: support config files and update checker.MaxResultScore.
 		err = results.AsSARIF(opts.ShowDetails, log.ParseLevel(opts.LogLevel), os.Stdout, doc, policy, opts)
 	case options.FormatJSON:
-		err = results.AsJSON2(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
+		err = results.AsJSON2(opts, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
 	case options.FormatSJSON:
 		err = results.AsSJSON(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
 	case options.FormatRaw:

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -116,7 +116,7 @@ func FormatResults(
 		// TODO: support config files and update checker.MaxResultScore.
 		err = results.AsSARIF(opts.ShowDetails, log.ParseLevel(opts.LogLevel), os.Stdout, doc, policy, opts)
 	case options.FormatJSON:
-		err = results.AsJSON2(opts, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
+		err = results.AsJSON3(opts, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
 	case options.FormatSJSON:
 		err = results.AsSJSON(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
 	case options.FormatRaw:


### PR DESCRIPTION
This PR:
- part of https://github.com/ossf/scorecard/issues/1874
- adds a `--details-format` option to the CLI, gated on `SCORECARD_EXPERIMENTAL=1`.

```release-note
Add a `--details-format` Option to produce JSON-details
```
