### PR TITLE
:seedling: Use Go version as specified by our go.mod file for publishimage.

### DIFF
--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -20,12 +20,9 @@ on:
   push:
     branches:
       - main
-env:
-  GO_VERSION: 1.17
 
 jobs:
-  unit-test:
-    name: publishimage
+  publishimage:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -46,10 +43,10 @@ jobs:
      - name: Setup Go
        uses: actions/setup-go@4d34df0c2316fe8122ab82dc22947d607c0c91f9
        with:
-         go-version: ${{ env.GO_VERSION }}
+         go-version-file: go.mod # use version from go.mod so it stays in sync
          check-latest: true
      - name: install ko
-       uses: imjasonh/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa
+       uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6
      - name: publishimage
        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
        with:


### PR DESCRIPTION
#### What kind of change does this PR introduce?
fix workflow

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
this workflow uses go 1.17 which breaks because our dependencies rely on features in 1.18 or 1.19.
It's been broken for a while now

#### What is the new behavior (if this is a feature change)?**
Use the go version specified in our go.mod file (currently 1.19) so it stays up-to-date

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
The `imjasonh/setup-ko` repo was renamed. So https://github.com/imjasonh/setup-ko redirects to https://github.com/ko-build/setup-ko

This was tested locally with [act](https://github.com/nektos/act)
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
