### PR TITLE
✨ Add a new format for details

### DIFF
--- a/options/flags.go
+++ b/options/flags.go
@@ -54,6 +54,10 @@ const (
 	// FlagChecks is the flag name for specifying which checks to run.
 	FlagChecks = "checks"
 
+	// FlagChecksDefinitionFile is the flag name for specifying the file that
+	// defines the checks.
+	FlagChecksDefinitionFile = "checks-definition-file"
+
 	// FlagPolicyFile is the flag name for specifying a policy file.
 	FlagPolicyFile = "policy"
 
@@ -139,6 +143,13 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		FlagCommitDepth,
 		o.CommitDepth,
 		"number of commits to check, commits begin backwards from the HEAD",
+	)
+
+	cmd.Flags().StringVar(
+		&o.ChecksDefinitionFile,
+		FlagChecksDefinitionFile,
+		o.ChecksDefinitionFile,
+		"file defining the checks",
 	)
 
 	checkNames := []string{}

--- a/options/flags.go
+++ b/options/flags.go
@@ -54,10 +54,6 @@ const (
 	// FlagChecks is the flag name for specifying which checks to run.
 	FlagChecks = "checks"
 
-	// FlagChecksDefinitionFile is the flag name for specifying the file that
-	// defines the checks.
-	FlagChecksDefinitionFile = "checks-definition-file"
-
 	// FlagPolicyFile is the flag name for specifying a policy file.
 	FlagPolicyFile = "policy"
 
@@ -143,13 +139,6 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		FlagCommitDepth,
 		o.CommitDepth,
 		"number of commits to check, commits begin backwards from the HEAD",
-	)
-
-	cmd.Flags().StringVar(
-		&o.ChecksDefinitionFile,
-		FlagChecksDefinitionFile,
-		o.ChecksDefinitionFile,
-		"file defining the checks",
 	)
 
 	checkNames := []string{}

--- a/options/options.go
+++ b/options/options.go
@@ -29,16 +29,15 @@ import (
 
 // Options define common options for configuring scorecard.
 type Options struct {
-	Repo                 string
-	Local                string
-	Commit               string
-	LogLevel             string
-	Format               string
-	NPM                  string
-	PyPI                 string
-	RubyGems             string
-	PolicyFile           string
-	ChecksDefinitionFile string
+	Repo       string
+	Local      string
+	Commit     string
+	LogLevel   string
+	Format     string
+	NPM        string
+	PyPI       string
+	RubyGems   string
+	PolicyFile string
 	// TODO(action): Add logic for writing results to file
 	ResultsFile string
 	ChecksToRun []string
@@ -110,15 +109,13 @@ var (
 	// DefaultLogLevel retrieves the default log level.
 	DefaultLogLevel = log.DefaultLevel.String()
 
-	errCommitIsEmpty                    = errors.New("commit should be non-empty")
-	errFormatNotSupported               = errors.New("unsupported format")
-	errFormatSupportedWithExperimental  = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
-	errChecksDefinitionFileExperimental = errors.New("checks-definition-file supported only with SCORECARD_EXPERIMENTAL=1")
-	errChecksDefinitionFileNotSupported = errors.New("checks-definition-file only support format 'probe-json' and 'structured-json'")
-	errChecksMutuallyExclusive          = errors.New("--checks-definition-file and --checks are mutually exclusive")
-	errPolicyFileNotSupported           = errors.New("policy file is not supported yet")
-	errRawOptionNotSupported            = errors.New("raw option is not supported yet")
-	errRepoOptionMustBeSet              = errors.New(
+	errCommitIsEmpty                   = errors.New("commit should be non-empty")
+	errFormatNotSupported              = errors.New("unsupported format")
+	errFormatSupportedWithExperimental = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
+	errChecksMutuallyExclusive         = errors.New("--checks-definition-file and --checks are mutually exclusive")
+	errPolicyFileNotSupported          = errors.New("policy file is not supported yet")
+	errRawOptionNotSupported           = errors.New("raw option is not supported yet")
+	errRepoOptionMustBeSet             = errors.New(
 		"exactly one of `repo`, `npm`, `pypi`, `rubygems` or `local` must be set",
 	)
 	errSARIFNotSupported = errors.New("SARIF format is not supported yet")
@@ -177,12 +174,6 @@ func (o *Options) Validate() error {
 				errFormatSupportedWithExperimental,
 			)
 		}
-		if o.ChecksDefinitionFile != "" {
-			errs = append(
-				errs,
-				errChecksDefinitionFileExperimental,
-			)
-		}
 	}
 
 	// Validate format.
@@ -191,23 +182,6 @@ func (o *Options) Validate() error {
 			errs,
 			errFormatNotSupported,
 		)
-	}
-
-	// Validate check definition and format.
-	if o.ChecksDefinitionFile != "" {
-		if o.Format != FormatSJSON &&
-			o.Format != FormatPJSON {
-			errs = append(
-				errs,
-				errChecksDefinitionFileNotSupported,
-			)
-		}
-		if len(o.ChecksToRun) > 0 {
-			errs = append(
-				errs,
-				errChecksMutuallyExclusive,
-			)
-		}
 	}
 
 	// Validate `commit` is non-empty.

--- a/options/options.go
+++ b/options/options.go
@@ -80,11 +80,9 @@ const (
 	// FormatFJSON specifies that results should be output in JSON format,
 	// but with structured findings.
 	FormatFJSON = "finding"
-	// FormatPJSON specifies that results should be output in probe JSON format,
-	// i.e., with the structured results.
+	// FormatPJSON specifies that results should be output in probe JSON format.
 	FormatPJSON = "probe"
 	// FormatSJSON specifies that results should be output in structured JSON format,
-	// i.e., with the structured results.
 	FormatSJSON = "structured"
 	// FormatSarif specifies that results should be output in SARIF format.
 	FormatSarif = "sarif"
@@ -112,7 +110,6 @@ var (
 	errCommitIsEmpty                   = errors.New("commit should be non-empty")
 	errFormatNotSupported              = errors.New("unsupported format")
 	errFormatSupportedWithExperimental = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
-	errChecksMutuallyExclusive         = errors.New("--checks-definition-file and --checks are mutually exclusive")
 	errPolicyFileNotSupported          = errors.New("policy file is not supported yet")
 	errRawOptionNotSupported           = errors.New("raw option is not supported yet")
 	errRepoOptionMustBeSet             = errors.New(

--- a/options/options.go
+++ b/options/options.go
@@ -29,15 +29,16 @@ import (
 
 // Options define common options for configuring scorecard.
 type Options struct {
-	Repo       string
-	Local      string
-	Commit     string
-	LogLevel   string
-	Format     string
-	NPM        string
-	PyPI       string
-	RubyGems   string
-	PolicyFile string
+	Repo                 string
+	Local                string
+	Commit               string
+	LogLevel             string
+	Format               string
+	NPM                  string
+	PyPI                 string
+	RubyGems             string
+	PolicyFile           string
+	ChecksDefinitionFile string
 	// TODO(action): Add logic for writing results to file
 	ResultsFile string
 	ChecksToRun []string
@@ -77,9 +78,15 @@ const (
 	// Formats.
 	// FormatJSON specifies that results should be output in JSON format.
 	FormatJSON = "json"
+	// FormatFJSON specifies that results should be output in JSON format,
+	// but with structured findings.
+	FormatFJSON = "finding"
+	// FormatPJSON specifies that results should be output in probe JSON format,
+	// i.e., with the structured results.
+	FormatPJSON = "probe"
 	// FormatSJSON specifies that results should be output in structured JSON format,
 	// i.e., with the structured results.
-	FormatSJSON = "structured-json"
+	FormatSJSON = "structured"
 	// FormatSarif specifies that results should be output in SARIF format.
 	FormatSarif = "sarif"
 	// FormatDefault specifies that results should be output in default format.
@@ -103,12 +110,15 @@ var (
 	// DefaultLogLevel retrieves the default log level.
 	DefaultLogLevel = log.DefaultLevel.String()
 
-	errCommitIsEmpty                   = errors.New("commit should be non-empty")
-	errFormatNotSupported              = errors.New("unsupported format")
-	errFormatSupportedWithExperimental = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
-	errPolicyFileNotSupported          = errors.New("policy file is not supported yet")
-	errRawOptionNotSupported           = errors.New("raw option is not supported yet")
-	errRepoOptionMustBeSet             = errors.New(
+	errCommitIsEmpty                    = errors.New("commit should be non-empty")
+	errFormatNotSupported               = errors.New("unsupported format")
+	errFormatSupportedWithExperimental  = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
+	errChecksDefinitionFileExperimental = errors.New("checks-definition-file supported only with SCORECARD_EXPERIMENTAL=1")
+	errChecksDefinitionFileNotSupported = errors.New("checks-definition-file only support format 'probe-json' and 'structured-json'")
+	errChecksMutuallyExclusive          = errors.New("--checks-definition-file and --checks are mutually exclusive")
+	errPolicyFileNotSupported           = errors.New("policy file is not supported yet")
+	errRawOptionNotSupported            = errors.New("raw option is not supported yet")
+	errRepoOptionMustBeSet              = errors.New(
 		"exactly one of `repo`, `npm`, `pypi`, `rubygems` or `local` must be set",
 	)
 	errSARIFNotSupported = errors.New("SARIF format is not supported yet")
@@ -159,10 +169,18 @@ func (o *Options) Validate() error {
 	}
 
 	if !o.isExperimentalEnabled() {
-		if o.Format == FormatSJSON {
+		if o.Format == FormatSJSON ||
+			o.Format == FormatFJSON ||
+			o.Format == FormatPJSON {
 			errs = append(
 				errs,
 				errFormatSupportedWithExperimental,
+			)
+		}
+		if o.ChecksDefinitionFile != "" {
+			errs = append(
+				errs,
+				errChecksDefinitionFileExperimental,
 			)
 		}
 	}
@@ -173,6 +191,23 @@ func (o *Options) Validate() error {
 			errs,
 			errFormatNotSupported,
 		)
+	}
+
+	// Validate check definition and format.
+	if o.ChecksDefinitionFile != "" {
+		if o.Format != FormatSJSON &&
+			o.Format != FormatPJSON {
+			errs = append(
+				errs,
+				errChecksDefinitionFileNotSupported,
+			)
+		}
+		if len(o.ChecksToRun) > 0 {
+			errs = append(
+				errs,
+				errChecksMutuallyExclusive,
+			)
+		}
 	}
 
 	// Validate `commit` is non-empty.
@@ -190,7 +225,6 @@ func (o *Options) Validate() error {
 			errs,
 		)
 	}
-
 	return nil
 }
 
@@ -257,7 +291,8 @@ func (o *Options) isV6Enabled() bool {
 
 func validateFormat(format string) bool {
 	switch format {
-	case FormatJSON, FormatSJSON, FormatSarif, FormatDefault, FormatRaw:
+	case FormatJSON, FormatSJSON, FormatFJSON,
+		FormatPJSON, FormatSarif, FormatDefault, FormatRaw:
 		return true
 	default:
 		return false

--- a/options/options.go
+++ b/options/options.go
@@ -82,7 +82,7 @@ const (
 	FormatFJSON = "finding"
 	// FormatPJSON specifies that results should be output in probe JSON format.
 	FormatPJSON = "probe"
-	// FormatSJSON specifies that results should be output in structured JSON format,
+	// FormatSJSON specifies that results should be output in structured JSON format.
 	FormatSJSON = "structured"
 	// FormatSarif specifies that results should be output in SARIF format.
 	FormatSarif = "sarif"

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -22,7 +22,6 @@ import (
 
 	docs "github.com/ossf/scorecard/v4/docs/checks"
 	sce "github.com/ossf/scorecard/v4/errors"
-
 	"github.com/ossf/scorecard/v4/log"
 )
 

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -20,12 +20,10 @@ import (
 	"io"
 	"time"
 
-	"github.com/ossf/scorecard/v4/checker"
 	docs "github.com/ossf/scorecard/v4/docs/checks"
 	sce "github.com/ossf/scorecard/v4/errors"
-	"github.com/ossf/scorecard/v4/finding"
+
 	"github.com/ossf/scorecard/v4/log"
-	rules "github.com/ossf/scorecard/v4/rule"
 )
 
 // nolint: govet
@@ -84,32 +82,6 @@ type JSONScorecardResultV2 struct {
 	Scorecard      jsonScorecardV2     `json:"scorecard"`
 	AggregateScore jsonFloatScore      `json:"score"`
 	Checks         []jsonCheckResultV2 `json:"checks"`
-	Metadata       []string            `json:"metadata"`
-}
-
-// nolint: govet
-type jsonCheckResultV3 struct {
-	Risk     rules.Risk        `json:"risk"`
-	Outcome  finding.Outcome   `json:"outcome"`
-	Findings []finding.Finding `json:"findings"`
-	Score    int               `json:"score"`
-	Reason   string            `json:"reason"`
-	Name     string            `json:"name"`
-	// TODO(X): list of rules run.
-	// TODO(X): simplify the documentation for the overall check
-	// and add the rules that are used in the description.
-	Doc jsonCheckDocumentationV2 `json:"documentation"`
-}
-
-// JSONScorecardResultV3 exports results as JSON for structured detail format.
-//
-//nolint:govet
-type JSONScorecardResultV3 struct {
-	Date           string              `json:"date"`
-	Repo           jsonRepoV2          `json:"repo"`
-	Scorecard      jsonScorecardV2     `json:"scorecard"`
-	AggregateScore jsonFloatScore      `json:"score"`
-	Checks         []jsonCheckResultV3 `json:"checks"`
 	Metadata       []string            `json:"metadata"`
 }
 
@@ -196,6 +168,7 @@ func (r *ScorecardResult) AsJSON2(showDetails bool,
 		}
 		out.Checks = append(out.Checks, tmpResult)
 	}
+
 	if err := encoder.Encode(out); err != nil {
 		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("encoder.Encode: %v", err))
 	}
@@ -203,73 +176,8 @@ func (r *ScorecardResult) AsJSON2(showDetails bool,
 	return nil
 }
 
-func (r *ScorecardResult) AsSJSON(showDetails bool,
+func (r *ScorecardResult) AsFJSON(showDetails bool,
 	logLevel log.Level, checkDocs docs.Doc, writer io.Writer,
 ) error {
-	score, err := r.GetAggregateScore(checkDocs)
-	if err != nil {
-		return err
-	}
-
-	encoder := json.NewEncoder(writer)
-	out := JSONScorecardResultV3{
-		Repo: jsonRepoV2{
-			Name:   r.Repo.Name,
-			Commit: r.Repo.CommitSHA,
-		},
-		Scorecard: jsonScorecardV2{
-			Version: r.Scorecard.Version,
-			Commit:  r.Scorecard.CommitSHA,
-		},
-		Date:           r.Date.Format("2006-01-02"),
-		Metadata:       r.Metadata,
-		AggregateScore: jsonFloatScore(score),
-	}
-
-	for _, checkResult := range r.Checks {
-		doc, e := checkDocs.GetCheck(checkResult.Name)
-		if e != nil {
-			return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("GetCheck: %s: %v", checkResult.Name, e))
-		}
-
-		tmpResult := jsonCheckResultV3{
-			Name: checkResult.Name,
-			Doc: jsonCheckDocumentationV2{
-				URL:   doc.GetDocumentationURL(r.Scorecard.CommitSHA),
-				Short: doc.GetShort(),
-			},
-			Reason:  checkResult.Reason,
-			Score:   checkResult.Score,
-			Risk:    rules.RiskNone,
-			Outcome: finding.OutcomePositive,
-		}
-		if showDetails {
-			for i := range checkResult.Details {
-				if checkResult.Details[i].Type == checker.DetailDebug && logLevel != log.DebugLevel {
-					continue
-				}
-
-				f := checkResult.Details[i].Msg.Finding
-				if f == nil {
-					continue
-				}
-
-				if f.Risk.GreaterThan(tmpResult.Risk) {
-					tmpResult.Risk = f.Risk
-				}
-
-				if f.Outcome.WorseThan(tmpResult.Outcome) {
-					tmpResult.Outcome = f.Outcome
-				}
-
-				tmpResult.Findings = append(tmpResult.Findings, *f)
-			}
-		}
-		out.Checks = append(out.Checks, tmpResult)
-	}
-	if err := encoder.Encode(out); err != nil {
-		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("encoder.Encode: %v", err))
-	}
-
-	return nil
+	return sce.WithMessage(sce.ErrScorecardInternal, "WIP: not supported")
 }

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -117,8 +117,8 @@ func FormatResults(
 		err = results.AsSARIF(opts.ShowDetails, log.ParseLevel(opts.LogLevel), os.Stdout, doc, policy, opts)
 	case options.FormatJSON:
 		err = results.AsJSON2(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
-	case options.FormatSJSON:
-		err = results.AsSJSON(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
+	case options.FormatFJSON:
+		err = results.AsFJSON(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, os.Stdout)
 	case options.FormatRaw:
 		err = results.AsRawJSON(os.Stdout)
 	default:


### PR DESCRIPTION
This PR adds a new format `finding` to improve on the existing `json` format. This new format will be the same as `json`, but will display the details in a more structured format.

Note that this is *not* the final "structured" format. This is a simpler version of it.

I have named the format "finding" because it's the underlying structure that will be used to populate it, but please suggest a better name.

```release-note
Add a new format for details
```
