### PR TITLE
:seedling: Skip cosign confirmation prompt during publishimage action.

### DIFF
--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -61,4 +61,4 @@ jobs:
        uses: sigstore/cosign-installer@204a51a57a74d190b284a0ce69b44bc37201f343
      - name: Sign image
        run: |
-          cosign sign ghcr.io/${{github.repository_owner}}/scorecard/v4:${{ github.sha }}
+          cosign sign --yes ghcr.io/${{github.repository_owner}}/scorecard/v4:${{ github.sha }}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
the cosign step fails since it asks for a confirmation prompt:
```
By typing 'y', you attest that (1) you are not submitting the personal data of any other person; and (2) you understand and agree to the statement and the Agreement terms at the URLs listed above.
Are you sure you would like to continue? [y/N] Error: signing [ghcr.io/ossf/scorecard/v4:f3b777086fb670ed5b10b4d1d7257786d0daa6d6]: recursively signing: signing digest: should upload to tlog: user declined the prompt
main.go:74: error during command execution: signing [ghcr.io/ossf/scorecard/v4:f3b777086fb670ed5b10b4d1d7257786d0daa6d6]: recursively signing: signing digest: should upload to tlog: user declined the prompt
Error: Process completed with exit code 1.
```

#### What is the new behavior (if this is a feature change)?**
`cosign sign` is called with the `--yes` flag.
```
  -y, --yes   skip confirmation prompts for non-destructive operations
  ```
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
