### PR TITLE
:bug: Add nil check before accessing a step's uses value.

### DIFF
--- a/checks/sast.go
+++ b/checks/sast.go
@@ -262,7 +262,7 @@ var searchGitHubActionWorkflowCodeQL fileparser.DoWhileTrueOnFileContent = func(
 	for _, job := range workflow.Jobs {
 		for _, step := range job.Steps {
 			e, ok := step.Exec.(*actionlint.ExecAction)
-			if !ok {
+			if !ok || e == nil || e.Uses == nil {
 				continue
 			}
 			// Parse out repo / SHA.


### PR DESCRIPTION
#### What kind of change does this PR introduce?
bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
A workflow step with `env` or `with` set, but without a `uses` field causes the SAST check to panic.
https://github.com/nl-design-system/denhaag/blob/329158ae47a4bfafb424741b2699f8c254ffd671/.github/workflows/cicd.yml#L103-L112

#### What is the new behavior (if this is a feature change)?**
We check for nil pointers before deref

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
