### PR TITLE
🌱 Remove hard-coded resources to allow auto-scaling

### DIFF
--- a/cron/k8s/worker.release.yaml
+++ b/cron/k8s/worker.release.yaml
@@ -54,13 +54,6 @@ spec:
                   key: installation_id
             - name: "SCORECARD_API_RESULTS_BUCKET_URL"
               value: "gs://ossf-scorecard-cron-releasetest-results"
-          resources:
-            requests:
-              memory: 5Gi
-              ephemeral-storage: 100Gi
-            limits:
-              memory: 12Gi
-              ephemeral-storage: 500Gi
           volumeMounts:
             - name: config-volume
               mountPath: /etc/scorecard

--- a/cron/k8s/worker.yaml
+++ b/cron/k8s/worker.yaml
@@ -44,13 +44,6 @@ spec:
                 secretKeyRef:
                   name: github
                   key: installation_id
-          resources:
-            requests:
-              memory: 5Gi
-              ephemeral-storage: 100Gi
-            limits:
-              memory: 12Gi
-              ephemeral-storage: 500Gi
           volumeMounts:
             - name: config-volume
               mountPath: /etc/scorecard


### PR DESCRIPTION
The cron/k8s workers were initialized with hardcoded resources. Due to this GKE engine wasn't optimizing the worker load properly. Removed this hardcoding and confirmed that GKE engine optimization works as expected.

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
