### PR TITLE
📖 Update checks.md to show the benefit of >=2 reviewers

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -73,10 +73,15 @@ result to meet most user needs.
 
 Different types of branch protection protect against different risks:
 
-  - Require code review: requires at least one reviewer, which greatly
+  - Require code review: 
+    - requires at least one reviewer, which greatly
     reduces the risk that a compromised contributor can inject malicious code.
     Review also increases the likelihood that an unintentional vulnerability in
     a contribution will be detected and fixed before the change is accepted.
+
+    - requiring two or more reviewers protects even more from the insider risk 
+    whereby a compromised contributor can be used by an attacker to LGTM 
+    the attacker PR and inject a malicious code as if it was legitm.
 
   - Prevent force push: prevents use of the `--force` command on public
     branches, which overwrites code irrevocably. This protection prevents the
@@ -182,8 +187,8 @@ However, note that in those overlapping cases, Scorecard can only report what it
 Risk: `High` (unintentional vulnerabilities or possible injection of malicious
 code)
 
-This check determines whether the project requires human code review before pull
-requests (merge requests) are merged.
+This check determines whether the project requires human code review
+before pull requests (merge requests) are merged.
 
 Reviews detect various unintentional problems, including vulnerabilities that
 can be fixed immediately before they are merged, which improves the quality of

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -162,10 +162,15 @@ checks:
 
       Different types of branch protection protect against different risks:
 
-        - Require code review: requires at least one reviewer, which greatly
+        - Require code review: 
+          - requires at least one reviewer, which greatly
           reduces the risk that a compromised contributor can inject malicious code.
           Review also increases the likelihood that an unintentional vulnerability in
           a contribution will be detected and fixed before the change is accepted.
+
+          - requiring two or more reviewers protects even more from the insider risk 
+          whereby a compromised contributor can be used by an attacker to LGTM 
+          the attacker PR and inject a malicious code as if it was legitm.
 
         - Prevent force push: prevents use of the `--force` command on public
           branches, which overwrites code irrevocably. This protection prevents the


### PR DESCRIPTION
#### What kind of change does this PR introduce?

docs update

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The current documentation explains why should be configured at least 1 reviewers as required but it does not mention the benefit of having 2 or more reviewers required. Since it is a requisite to maximize branch protection score and most projects would find it difficult to demand 2 reviewers to each PR, it might be a good idea to make it clear why should they require 2 instead of 1.

#### What is the new behavior (if this is a feature change)?**

Doc updated to explain the benefit of having 2 instead of 1 reviewers required.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

-->

Fixes #2472 

#### Special notes for your reviewer

None

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Update branch protection document to explain why it is recommended to have 2 or more reviewers
```
