### PR TITLE
:seedling: Skip e2e-pat target on pull requests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,6 +72,7 @@ jobs:
          verbose: true
      - name: Run PAT Token E2E  #using retry because the GitHub token is being throttled.
        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+       if: ${{ github.event_name != 'pull_request' }}
        env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
        with:
@@ -81,6 +82,7 @@ jobs:
           command: make e2e-pat
      - name: codecov
        uses: codecov/codecov-action@eaaf4bedf32dbdc6b720b63067d99c4d77d6047d # 2.1.0
+       if: ${{ github.event_name != 'pull_request' }}
        with:
          files: "*e2e-coverage.out"
          verbose: true


### PR DESCRIPTION
#### What kind of change does this PR introduce?

ci fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
e2e-pat was being ran against PRs and causing ci to fail since the PAT is inaccessible from a `pull_request` target.
#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
follow up of #3046 and #3054 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

This is to quickly get the CI working again. Still might be a better separation of jobs/workflows, but this should get it working. 

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
