### PR TITLE
:seedling: Speed up Security-Policy e2e tests

### DIFF
--- a/e2e/security_policy_test.go
+++ b/e2e/security_policy_test.go
@@ -34,7 +34,7 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 	Context("E2E TEST:Validating security policy", func() {
 		It("Should return valid security policy", func() {
 			dl := scut.TestDetailLogger{}
-			repo, err := githubrepo.MakeGithubRepo("tensorflow/tensorflow")
+			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-security-policy-e2e")
 			Expect(err).Should(BeNil())
 			repoClient := githubrepo.CreateGithubRepoClient(context.Background(), logger)
 			err = repoClient.InitRepo(repo, clients.HeadSHA, 0)
@@ -60,62 +60,10 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 		})
 		It("Should return valid security policy at commitSHA", func() {
 			dl := scut.TestDetailLogger{}
-			repo, err := githubrepo.MakeGithubRepo("tensorflow/tensorflow")
+			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-security-policy-e2e")
 			Expect(err).Should(BeNil())
 			repoClient := githubrepo.CreateGithubRepoClient(context.Background(), logger)
-			err = repoClient.InitRepo(repo, "e0cb70344e46276b37d65824f95eca478080de4a", 0)
-			Expect(err).Should(BeNil())
-
-			req := checker.CheckRequest{
-				Ctx:        context.Background(),
-				RepoClient: repoClient,
-				Repo:       repo,
-				Dlogger:    &dl,
-			}
-			expected := scut.TestReturn{
-				Error:         nil,
-				Score:         checker.MaxResultScore,
-				NumberOfWarn:  0,
-				NumberOfInfo:  4,
-				NumberOfDebug: 0,
-			}
-			result := checks.SecurityPolicy(&req)
-			// New version.
-			Expect(scut.ValidateTestReturn(nil, "policy found", &expected, &result, &dl)).Should(BeTrue())
-			Expect(repoClient.Close()).Should(BeNil())
-		})
-		It("Should return valid security policy for rust repositories", func() {
-			dl := scut.TestDetailLogger{}
-			repo, err := githubrepo.MakeGithubRepo("randombit/botan")
-			Expect(err).Should(BeNil())
-			repoClient := githubrepo.CreateGithubRepoClient(context.Background(), logger)
-			err = repoClient.InitRepo(repo, clients.HeadSHA, 0)
-			Expect(err).Should(BeNil())
-
-			req := checker.CheckRequest{
-				Ctx:        context.Background(),
-				RepoClient: repoClient,
-				Repo:       repo,
-				Dlogger:    &dl,
-			}
-			expected := scut.TestReturn{
-				Error:         nil,
-				Score:         checker.MaxResultScore,
-				NumberOfWarn:  0,
-				NumberOfInfo:  4,
-				NumberOfDebug: 0,
-			}
-			result := checks.SecurityPolicy(&req)
-			// New version.
-			Expect(scut.ValidateTestReturn(nil, "policy found", &expected, &result, &dl)).Should(BeTrue())
-			Expect(repoClient.Close()).Should(BeNil())
-		})
-		It("Should return valid security policy for rust repositories at commitSHA", func() {
-			dl := scut.TestDetailLogger{}
-			repo, err := githubrepo.MakeGithubRepo("randombit/botan")
-			Expect(err).Should(BeNil())
-			repoClient := githubrepo.CreateGithubRepoClient(context.Background(), logger)
-			err = repoClient.InitRepo(repo, "bab40cdd29d19e0638cf1301dfd355c52b94d1c0", 0)
+			err = repoClient.InitRepo(repo, "46e9bc6538b2f788b6e3d18f8c8c174146565e93", 0)
 			Expect(err).Should(BeNil())
 
 			req := checker.CheckRequest{
@@ -144,7 +92,7 @@ var _ = Describe("E2E TEST:"+checks.CheckSecurityPolicy, func() {
 			defer os.RemoveAll(tmpDir)
 
 			_, e := git.PlainClone(tmpDir, false, &git.CloneOptions{
-				URL: "http://github.com/ossf-tests/botan",
+				URL: "http://github.com/ossf-tests/scorecard-check-security-policy-e2e",
 			})
 			Expect(e).Should(BeNil())
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

e2e test speedup

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
tensorflow/tensorflow is huge and was slowing down tests because the whole repo was downloaded to scan for a security policy file. 

#### What is the new behavior (if this is a feature change)?**
* The e2e tests now use https://github.com/ossf-tests/scorecard-check-security-policy-e2e, which is a much smaller repo and takes less time to clone.
* Also removed the rust e2e tests because they're already present as unit tests.

- [] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
