### PR TITLE
🌱 CI: Don't run PAT E2E on dependabot merges

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -72,7 +72,7 @@ jobs:
          verbose: true
      - name: Run PAT Token E2E  #using retry because the GitHub token is being throttled.
        uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
-       if: ${{ github.event_name != 'pull_request' }}
+       if: ${{ github.event_name != 'pull_request' && github.actor != 'dependabot[bot]' }}
        env:
           GITHUB_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
        with:


### PR DESCRIPTION
Don't run GitHub PAT E2E tests on dependabot merges to the `main` branch since those merges don't have access to environment secrets. 

`github.actor` is dependabot when using `dependabot merge`; when the PR approver also merges the PR, they are the github.actor. 

See: https://github.blog/changelog/2021-02-19-github-actions-workflows-triggered-by-dependabot-prs-will-run-with-read-only-permissions/