### PR TITLE
:seedling: Re-enable skipped e2e tests. Switch to smaller code review repo.

### DIFF
--- a/e2e/attestor_policy_test.go
+++ b/e2e/attestor_policy_test.go
@@ -111,78 +111,72 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 					},
 					expected: policy.Pass,
 				},
-				// TODO(https://github.com/ossf/scorecard/issues/3129) temporarily skipping code review tests
-				//
-				// {
-				// 	name:    "test repo with simple code review requirements",
-				// 	repoURL: "https://github.com/ossf/scorecard",
-				// 	commit:  "fa0592fab28aa92560f04e1ae8649dfff566ae2b",
-				// 	policy: policy.AttestationPolicy{
-				// 		EnsureCodeReviewed: true,
-				// 		CodeReviewRequirements: policy.CodeReviewRequirements{
-				// 			MinReviewers: 1,
-				// 		},
-				// 	},
-				// 	expected: policy.Pass,
-				// },
-				// {
-				// 	name:    "test code reviews required but repo doesn't have code reviews",
-				// 	repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-				// 	policy: policy.AttestationPolicy{
-				// 		PreventBinaryArtifacts:      true,
-				// 		PreventKnownVulnerabilities: true,
-				// 		PreventUnpinnedDependencies: true,
-				// 		EnsureCodeReviewed:          true,
-				// 	},
-				// 	expected: policy.Fail,
-				// },
-				// {
-				// 	name:    "test code reviews required with min reviewers",
-				// 	repoURL: "https://github.com/ossf/scorecard",
-				// 	commit:  "fa0592fab28aa92560f04e1ae8649dfff566ae2b",
-				// 	policy: policy.AttestationPolicy{
-				// 		PreventBinaryArtifacts:      true,
-				// 		PreventKnownVulnerabilities: false,
-				// 		PreventUnpinnedDependencies: true,
-				// 		EnsureCodeReviewed:          true,
-				// 		CodeReviewRequirements: policy.CodeReviewRequirements{
-				// 			MinReviewers: 1,
-				// 		},
-				// 	},
-				// 	expected: policy.Pass,
-				// },
-				// {
-				// 	name:    "test code reviews required with min reviewers and required reviewers",
-				// 	repoURL: "https://github.com/ossf/scorecard",
-				// 	commit:  "fa0592fab28aa92560f04e1ae8649dfff566ae2b",
-				// 	policy: policy.AttestationPolicy{
-				// 		PreventBinaryArtifacts:      true,
-				// 		PreventKnownVulnerabilities: false,
-				// 		PreventUnpinnedDependencies: true,
-				// 		EnsureCodeReviewed:          true,
-				// 		CodeReviewRequirements: policy.CodeReviewRequirements{
-				// 			MinReviewers:      1,
-				// 			RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38"},
-				// 		},
-				// 	},
-				// 	expected: policy.Pass,
-				// },
-				// {
-				// 	name:    "test code reviews required with too many min reviewers but matching required reviewers",
-				// 	repoURL: "https://github.com/ossf/scorecard",
-				// 	commit:  "fa0592fab28aa92560f04e1ae8649dfff566ae2b",
-				// 	policy: policy.AttestationPolicy{
-				// 		PreventBinaryArtifacts:      true,
-				// 		PreventKnownVulnerabilities: false,
-				// 		PreventUnpinnedDependencies: true,
-				// 		EnsureCodeReviewed:          true,
-				// 		CodeReviewRequirements: policy.CodeReviewRequirements{
-				// 			MinReviewers:      2,
-				// 			RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38"},
-				// 		},
-				// 	},
-				// 	expected: policy.Fail,
-				// },
+				{
+					name:    "test repo with simple code review requirements",
+					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
+					policy: policy.AttestationPolicy{
+						EnsureCodeReviewed: true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers: 1,
+						},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name:    "test code reviews required but repo doesn't have code reviews",
+					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
+					policy: policy.AttestationPolicy{
+						PreventBinaryArtifacts:      true,
+						PreventKnownVulnerabilities: true,
+						PreventUnpinnedDependencies: true,
+						EnsureCodeReviewed:          true,
+					},
+					expected: policy.Fail,
+				},
+				{
+					name:    "test code reviews required with min reviewers",
+					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
+					policy: policy.AttestationPolicy{
+						PreventBinaryArtifacts:      true,
+						PreventKnownVulnerabilities: false,
+						PreventUnpinnedDependencies: true,
+						EnsureCodeReviewed:          true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers: 1,
+						},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name:    "test code reviews required with min reviewers and required reviewers",
+					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
+					policy: policy.AttestationPolicy{
+						PreventBinaryArtifacts:      true,
+						PreventKnownVulnerabilities: false,
+						PreventUnpinnedDependencies: true,
+						EnsureCodeReviewed:          true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers:      1,
+							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},
+						},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name:    "test code reviews required with too many min reviewers but matching required reviewers",
+					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
+					policy: policy.AttestationPolicy{
+						PreventBinaryArtifacts:      true,
+						PreventKnownVulnerabilities: false,
+						PreventUnpinnedDependencies: true,
+						EnsureCodeReviewed:          true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers:      2,
+							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},
+						},
+					},
+					expected: policy.Fail,
+				},
 			}
 
 			for _, tc := range tt {

--- a/e2e/attestor_policy_test.go
+++ b/e2e/attestor_policy_test.go
@@ -126,10 +126,7 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 					name:    "test code reviews required but repo doesn't have code reviews",
 					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
 					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts:      true,
-						PreventKnownVulnerabilities: true,
-						PreventUnpinnedDependencies: true,
-						EnsureCodeReviewed:          true,
+						EnsureCodeReviewed: true,
 					},
 					expected: policy.Fail,
 				},
@@ -137,10 +134,7 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 					name:    "test code reviews required with min reviewers",
 					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
 					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts:      true,
-						PreventKnownVulnerabilities: false,
-						PreventUnpinnedDependencies: true,
-						EnsureCodeReviewed:          true,
+						EnsureCodeReviewed: true,
 						CodeReviewRequirements: policy.CodeReviewRequirements{
 							MinReviewers: 1,
 						},
@@ -151,10 +145,7 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 					name:    "test code reviews required with min reviewers and required reviewers",
 					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
 					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts:      true,
-						PreventKnownVulnerabilities: false,
-						PreventUnpinnedDependencies: true,
-						EnsureCodeReviewed:          true,
+						EnsureCodeReviewed: true,
 						CodeReviewRequirements: policy.CodeReviewRequirements{
 							MinReviewers:      1,
 							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},
@@ -166,10 +157,7 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 					name:    "test code reviews required with too many min reviewers but matching required reviewers",
 					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
 					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts:      true,
-						PreventKnownVulnerabilities: false,
-						PreventUnpinnedDependencies: true,
-						EnsureCodeReviewed:          true,
+						EnsureCodeReviewed: true,
 						CodeReviewRequirements: policy.CodeReviewRequirements{
 							MinReviewers:      2,
 							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},

--- a/e2e/attestor_policy_test.go
+++ b/e2e/attestor_policy_test.go
@@ -58,18 +58,16 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 					name:    "test bad repo with ignored binary artifact",
 					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
 					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts:      true,
-						AllowedBinaryArtifacts:      []string{"test-binary-artifact-*"},
-						PreventKnownVulnerabilities: true,
+						PreventBinaryArtifacts: true,
+						AllowedBinaryArtifacts: []string{"test-binary-artifact-*"},
 					},
 					expected: policy.Pass,
 				},
 				{
-					name:    "test bad repo with ignored binary artifact",
+					name:    "test bad repo with binary artifact",
 					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
 					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts:      true,
-						PreventKnownVulnerabilities: true,
+						PreventBinaryArtifacts: true,
 					},
 					expected: policy.Fail,
 				},

--- a/e2e/ci_tests_test.go
+++ b/e2e/ci_tests_test.go
@@ -79,7 +79,6 @@ var _ = Describe("E2E TEST:"+checks.CheckCITests, func() {
 			Expect(repoClient.Close()).Should(BeNil())
 		})
 		It("Should return absence of CI tests in a repo with unsquashed merges", func() {
-			Skip("TODO(https://github.com/ossf/scorecard/issues/3129) temporarily skipping")
 			dl := scut.TestDetailLogger{}
 			repo, err := githubrepo.MakeGithubRepo("duo-labs/parliament")
 			Expect(err).Should(BeNil())


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Follow up to #3130

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**
* Re-enables skipped tests

Reduced attestor e2e test times by ~50%
* Switches code-review attestor tests to a smaller repo in `ossf-tests`, instead of using `ossf/scorecard`
* trims un-needed policies from tests that aren't using them (code review tests don't need binary artifact policies, etc)

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #3129
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

It's hard to see changes with everything being uncommented. So a better comparison would be to the version before the tests were disabled (just scroll to the right file):
https://github.com/ossf/scorecard/compare/d961dda3b2350d1484948bd2b7efa46210c47e41...ossf:scorecard:a43601cc408a60f96e5a6e3d7e012a84c13a5239#diff-1eb6d0cf3162bc067afd6a66f7e7380fef3bab5185a2faa320edbe9ea2282453

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
