### PR TITLE
📖  update usage message of the scorecard --verbosity flag 

### DIFF
--- a/options/flags.go
+++ b/options/flags.go
@@ -99,7 +99,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		&o.LogLevel,
 		FlagLogLevel,
 		o.LogLevel,
-		"set the log level",
+		"Set the log level. Possible values are: 'info', 'debug', 'warn'. Add --show-details to see the results.",
 	)
 
 	cmd.Flags().StringVar(


### PR DESCRIPTION

Add the available argument strings for the ```--verbosity``` flag in the usage message of the scorecard cli.



- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### Currently: the usage message reads: ```set the log level```

#### Change proposal: the usage message reads ```Set the log level. Possible values are: 'info', 'debug', 'warn'. Add --show-details to see the results.```

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Fixes #3173

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
