### PR TITLE
✨ Enable ResultsFile Switch for cli

### DIFF
--- a/options/flags.go
+++ b/options/flags.go
@@ -64,6 +64,9 @@ const (
 	FlagFormat = "format"
 
 	FlagCommitDepth = "commit-depth"
+
+	// FlagResultsFile is the flag name for storing stdout and stderr output.
+	FlagResultsFile = "resultsfile"
 )
 
 // Command is an interface for handling options for command-line utilities.
@@ -160,6 +163,13 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		FlagChecks,
 		o.ChecksToRun,
 		fmt.Sprintf("Checks to run. Possible values are: %s", strings.Join(checkNames, ",")),
+	)
+
+	cmd.Flags().StringVar(
+		&o.ResultsFile,
+		FlagResultsFile,
+		o.ResultsFile,
+		"Output results and errors to file",
 	)
 
 	// TODO(options): Extract logic

--- a/options/flags_test.go
+++ b/options/flags_test.go
@@ -43,6 +43,7 @@ func TestOptions_AddFlags(t *testing.T) {
 				ChecksToRun: []string{"check1", "check2"},
 				PolicyFile:  "policy-file",
 				Format:      "json",
+				ResultsFile: "resultsFile.log",
 			},
 		},
 	}
@@ -87,6 +88,11 @@ func TestOptions_AddFlags(t *testing.T) {
 			// check FlagRubyGems
 			if cmd.Flag(FlagRubyGems).Value.String() != tt.opts.RubyGems {
 				t.Errorf("expected FlagRubyGems to be %q, but got %q", tt.opts.RubyGems, cmd.Flag(FlagRubyGems).Value.String())
+			}
+
+			// check ResultsFile
+			if cmd.Flag(FlagResultsFile).Value.String() != tt.opts.ResultsFile {
+				t.Errorf("expected ResultsFile to be %q, but got %q", tt.opts.ResultsFile, cmd.Flag(FlagResultsFile).Value.String())
 			}
 
 			var e1 []string

--- a/options/options.go
+++ b/options/options.go
@@ -29,17 +29,16 @@ import (
 
 // Options define common options for configuring scorecard.
 type Options struct {
-	Repo       string
-	Local      string
-	Commit     string
-	LogLevel   string
-	Format     string
-	NPM        string
-	PyPI       string
-	RubyGems   string
-	Nuget      string
-	PolicyFile string
-	// TODO(action): Add logic for writing results to file
+	Repo        string
+	Local       string
+	Commit      string
+	LogLevel    string
+	Format      string
+	NPM         string
+	PyPI        string
+	RubyGems    string
+	Nuget       string
+	PolicyFile  string
 	ResultsFile string
 	ChecksToRun []string
 	Metadata    []string


### PR DESCRIPTION
`--resultsfile <string filename>`

#### What kind of change does this PR introduce?

feature

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Switch has a TODO but hasn't been enabled

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

#3191 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
Enables use of the resultsfile switch that outputs the stdout and stderr to the file specified in the switch `--resultsfile`
For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
`--resultsfile` switch is used to populate a file with the stdout and stderr for the cli operation.
```
