### PR TITLE
:sparkles: scdiff: generate cmd skeleton

### DIFF
--- a/cmd/internal/scdiff/app/format/format.go
+++ b/cmd/internal/scdiff/app/format/format.go
@@ -1,0 +1,20 @@
+package format
+
+import (
+	"os"
+
+	"github.com/ossf/scorecard/v4/docs/checks"
+	"github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/pkg"
+)
+
+//nolint:wrapcheck
+func JSON(r *pkg.ScorecardResult) error {
+	const details = true
+	docs, err := checks.Read()
+	if err != nil {
+		return err
+	}
+	// TODO standardize the input, and output it to a file
+	return r.AsJSON2(details, log.DefaultLevel, docs, os.Stdout)
+}

--- a/cmd/internal/scdiff/app/format/format.go
+++ b/cmd/internal/scdiff/app/format/format.go
@@ -1,3 +1,17 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package format
 
 import (

--- a/cmd/internal/scdiff/app/generate.go
+++ b/cmd/internal/scdiff/app/generate.go
@@ -15,13 +15,39 @@
 package app
 
 import (
+	"bufio"
+	"fmt"
+	"os"
+
 	"github.com/spf13/cobra"
 )
 
-var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generate Scorecard results for diffing",
-	Long:  `Generate Scorecard results for diffing`,
-	Run: func(cmd *cobra.Command, args []string) {
-	},
+//nolint:gochecknoinits // common for cobra apps
+func init() {
+	rootCmd.AddCommand(generateCmd)
+	generateCmd.PersistentFlags().StringVarP(&repoFile, "repos", "r", "", "path to newline-delimited repo file")
 }
+
+var (
+	repoFile string
+
+	generateCmd = &cobra.Command{
+		Use:   "generate [flags] repofile",
+		Short: "Generate Scorecard results for diffing",
+		Long:  `Generate Scorecard results for diffing`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			f, err := os.Open(repoFile)
+			if err != nil {
+				return fmt.Errorf("unable to open repo file: %w", err)
+			}
+			scanner := bufio.NewScanner(f)
+			for scanner.Scan() {
+				fmt.Fprintf(os.Stdout, "running for repo: %v\n", scanner.Text())
+			}
+			if err := scanner.Err(); err != nil {
+				return fmt.Errorf("reading repo file: %w", err)
+			}
+			return nil
+		},
+	}
+)

--- a/cmd/internal/scdiff/app/generate.go
+++ b/cmd/internal/scdiff/app/generate.go
@@ -15,28 +15,13 @@
 package app
 
 import (
-	"fmt"
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
-//nolint:gochecknoinits
-func init() {
-	rootCmd.AddCommand(generateCmd)
-}
-
-var rootCmd = &cobra.Command{
-	Use:   "scdiff",
-	Short: "Scorecard Diff",
-	Long:  `Scorecard result diffing command line interface tool`,
+var generateCmd = &cobra.Command{
+	Use:   "generate",
+	Short: "Generate Scorecard results for diffing",
+	Long:  `Generate Scorecard results for diffing`,
 	Run: func(cmd *cobra.Command, args []string) {
 	},
-}
-
-func Execute() {
-	if err := rootCmd.Execute(); err != nil {
-		fmt.Fprintln(os.Stderr, err)
-		os.Exit(1)
-	}
 }

--- a/cmd/internal/scdiff/app/generate.go
+++ b/cmd/internal/scdiff/app/generate.go
@@ -20,6 +20,9 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+
+	"github.com/ossf/scorecard/v4/cmd/internal/scdiff/app/format"
+	"github.com/ossf/scorecard/v4/cmd/internal/scdiff/app/runner"
 )
 
 //nolint:gochecknoinits // common for cobra apps
@@ -40,9 +43,17 @@ var (
 			if err != nil {
 				return fmt.Errorf("unable to open repo file: %w", err)
 			}
+			scorecardRunner := runner.New()
 			scanner := bufio.NewScanner(f)
 			for scanner.Scan() {
-				fmt.Fprintf(os.Stdout, "running for repo: %v\n", scanner.Text())
+				results, err := scorecardRunner.Run(scanner.Text())
+				if err != nil {
+					return fmt.Errorf("running scorecard on %s: %w", scanner.Text(), err)
+				}
+				err = format.JSON(&results)
+				if err != nil {
+					return fmt.Errorf("formatting results: %w", err)
+				}
 			}
 			if err := scanner.Err(); err != nil {
 				return fmt.Errorf("reading repo file: %w", err)

--- a/cmd/internal/scdiff/app/root.go
+++ b/cmd/internal/scdiff/app/root.go
@@ -1,0 +1,37 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+var rootCmd = &cobra.Command{
+	Use:   "scdiff",
+	Short: "Scorecard Diff",
+	Long:  `Scorecard result diffing command line interface tool`,
+	Run: func(cmd *cobra.Command, args []string) {
+	},
+}
+
+func Execute() {
+	if err := rootCmd.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/cmd/internal/scdiff/app/root.go
+++ b/cmd/internal/scdiff/app/root.go
@@ -25,12 +25,9 @@ var rootCmd = &cobra.Command{
 	Use:   "scdiff",
 	Short: "Scorecard Diff",
 	Long:  `Scorecard result diffing command line interface tool`,
-	Run: func(cmd *cobra.Command, args []string) {
-	},
 }
 
 func Execute() {
-	rootCmd.AddCommand(generateCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/internal/scdiff/app/root.go
+++ b/cmd/internal/scdiff/app/root.go
@@ -21,11 +21,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-//nolint:gochecknoinits
-func init() {
-	rootCmd.AddCommand(generateCmd)
-}
-
 var rootCmd = &cobra.Command{
 	Use:   "scdiff",
 	Short: "Scorecard Diff",
@@ -35,6 +30,7 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	rootCmd.AddCommand(generateCmd)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)

--- a/cmd/internal/scdiff/app/runner/runner.go
+++ b/cmd/internal/scdiff/app/runner/runner.go
@@ -33,6 +33,7 @@ const (
 	commitDepth = 0 // default
 )
 
+// Runner holds the clients and configuration needed to run Scorecard on multiple repos.
 type Runner struct {
 	ctx           context.Context
 	enabledChecks checker.CheckNameToFnMap

--- a/cmd/internal/scdiff/app/runner/runner.go
+++ b/cmd/internal/scdiff/app/runner/runner.go
@@ -1,0 +1,53 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/checks"
+	"github.com/ossf/scorecard/v4/clients"
+	"github.com/ossf/scorecard/v4/clients/githubrepo"
+	"github.com/ossf/scorecard/v4/clients/ossfuzz"
+	"github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/pkg"
+)
+
+const (
+	commit      = clients.HeadSHA
+	commitDepth = 0 // default
+)
+
+type Runner struct {
+	ctx           context.Context
+	enabledChecks checker.CheckNameToFnMap
+	repoClient    clients.RepoClient
+	ossFuzz       clients.RepoClient
+	cii           clients.CIIBestPracticesClient
+	vuln          clients.VulnerabilitiesClient
+}
+
+func New() Runner {
+	ctx := context.Background()
+	logger := log.NewLogger(log.DefaultLevel)
+	return Runner{
+		ctx:           ctx,
+		repoClient:    githubrepo.CreateGithubRepoClient(ctx, logger),
+		ossFuzz:       ossfuzz.CreateOSSFuzzClient(ossfuzz.StatusURL),
+		cii:           clients.DefaultCIIBestPracticesClient(),
+		vuln:          clients.DefaultVulnerabilitiesClient(),
+		enabledChecks: checks.GetAll(),
+	}
+}
+
+//nolint:wrapcheck
+func (r *Runner) Run(repoURI string) (pkg.ScorecardResult, error) {
+	fmt.Fprintf(os.Stdout, "running for repo: %v\n", repoURI)
+	// TODO (gitlab?)
+	repo, err := githubrepo.MakeGithubRepo(repoURI)
+	if err != nil {
+		return pkg.ScorecardResult{}, err
+	}
+	return pkg.RunScorecard(r.ctx, repo, commit, commitDepth, r.enabledChecks, r.repoClient, r.ossFuzz, r.cii, r.vuln)
+}

--- a/cmd/internal/scdiff/app/runner/runner.go
+++ b/cmd/internal/scdiff/app/runner/runner.go
@@ -67,7 +67,7 @@ func (r *Runner) Run(repoURI string) (pkg.ScorecardResult, error) {
 	return pkg.RunScorecard(r.ctx, repo, commit, commitDepth, r.enabledChecks, r.repoClient, r.ossFuzz, r.cii, r.vuln)
 }
 
-// logs only if logger is set
+// logs only if logger is set.
 func (r *Runner) log(msg string) {
 	if r.logger != nil {
 		r.logger.Info(msg)

--- a/cmd/internal/scdiff/app/runner/runner.go
+++ b/cmd/internal/scdiff/app/runner/runner.go
@@ -1,3 +1,17 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package runner
 
 import (

--- a/cmd/internal/scdiff/app/runner/runner_test.go
+++ b/cmd/internal/scdiff/app/runner/runner_test.go
@@ -1,0 +1,54 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runner
+
+import (
+	"testing"
+
+	"github.com/golang/mock/gomock"
+
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/clients"
+	mockrepo "github.com/ossf/scorecard/v4/clients/mockclients"
+)
+
+func TestNew(t *testing.T) {
+	r := New()
+	if len(r.enabledChecks) == 0 {
+		t.Errorf("runner has no checks to run: %v", r.enabledChecks)
+	}
+}
+
+func TestRunner_Run(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	mockRepo := mockrepo.NewMockRepoClient(ctrl)
+	commit := []clients.Commit{{SHA: "foo"}}
+	mockRepo.EXPECT().ListCommits().Return(commit, nil)
+	mockRepo.EXPECT().InitRepo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
+	mockRepo.EXPECT().GetDefaultBranchName().Return("main", nil)
+	mockRepo.EXPECT().Close().Return(nil)
+	r := Runner{
+		enabledChecks: checker.CheckNameToFnMap{},
+		repoClient:    mockRepo,
+	}
+	const repo = "github.com/foo/bar"
+	result, err := r.Run(repo)
+	if err != nil {
+		t.Errorf("unexpected test error: %v", err)
+	}
+	if result.Repo.Name != repo {
+		t.Errorf("got: %v, wanted: %v", result.Repo.Name, repo)
+	}
+}

--- a/cmd/internal/scdiff/main.go
+++ b/cmd/internal/scdiff/main.go
@@ -1,0 +1,21 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import "github.com/ossf/scorecard/v4/cmd/internal/scdiff/app"
+
+func main() {
+	app.Execute()
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

feature

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**
This adds the cobra boilerplate for the binary (`scdiff`), and the subcommand `generate`.

Right now the code expects a newline-delimited list of repos in a file:
```
github.com/ossf/scorecard
github.com/ossf/scorecard-action

```

The command will run Scorecard against all repos in the file
```
go run cmd/internal/scdiff/main.go generate --repos repos.txt
```

Currently this just prints to stdout, but I'll write to a file format in a later PR.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Related to #2462, but this is the first of many PRs
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
All of this is in an `internal` folder, so I'll be able to make breaking changes to it later as I iterate.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
