### PR TITLE
:seedling: Include attestor Dockerfile in CI and dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -74,3 +74,10 @@ updates:
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
+- package-ecosystem: docker
+  directory: "/attestor"
+  schedule:
+    interval: weekly
+  rebase-strategy: disabled
+  commit-message:
+      prefix: ":seedling:"

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -259,3 +259,31 @@ jobs:
          cache: true
      - name: docker build
        run: make cron-github-server-docker
+  attestor:
+    name: attestor-docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs:
+      - docs_only_check
+    if: (needs.docs_only_check.outputs.docs_only != 'true')
+    steps:
+     - name: Harden Runner
+       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
+       with:
+         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
+     - name: Install Protoc
+       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
+       with:
+        version: ${{ env.PROTOC_VERSION }}
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+     - name: Clone the code
+       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+     - name: Setup Go
+       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
+       with:
+         go-version-file: ${{ env.GO_VERSION_FILE }}
+         check-latest: true
+         cache: true
+     - name: docker build
+       run: make build-attestor-docker

--- a/attestor/Dockerfile
+++ b/attestor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang@sha256:ea3d912d500b1ae0a691b2e53eb8a6345b579d42d7e6a64acca83d274b949740 AS base
+FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
 WORKDIR /src/scorecard
 COPY . ./
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

CI and repo config

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The attestor dockerfile isnt being updated, so it's using an older version of golang. 
This caused [the build to break](https://github.com/ossf/scorecard/runs/15205406012) on the latest merged PR (#3284).

#### What is the new behavior (if this is a feature change)?**
- golang updated to the same version as all other dockerfiles
- the dockerfile has been added to dependabot
- a build step has been added to catch this sort of thing before merge.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
