### PR TITLE
:seedling: Use a matrix for docker image building

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -64,8 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-    needs:
-      - docs_only_check
+    needs: docs_only_check
     if: (needs.docs_only_check.outputs.docs_only != 'true')
     steps:
      - name: Harden Runner

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -74,7 +74,7 @@ jobs:
          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
      - name: Clone the code
        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go # needed due to the Makefile Go binary expressions
+     - name: Setup Go # needed for some of the Makefile evaluations, even if building happens in Docker 
        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
        with:
          go-version-file: ${{ env.GO_VERSION_FILE }}

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,9 +23,7 @@ on:
   - main
 
 env:
-  PROTOC_VERSION: 3.17.3
   GO_VERSION_FILE: go.mod # no good way of getting a mutual version between go.mod and tools/go.mod
-  CACHE_DEPENDENCY_PATH: "**/go.sum" # include both go.sum and tools/go.sum
 
 jobs:
   docs_only_check:
@@ -50,8 +48,19 @@ jobs:
       name: Check for docs-only changes
       run: echo "docs_only=true" >> $GITHUB_OUTPUT
 
-  scorecard:
-    name: scorecard-docker
+  docker_matrix:
+    strategy:
+      matrix:
+        target:
+          - 'scorecard-docker'
+          - 'cron-controller-docker'
+          - 'cron-worker-docker'
+          - 'cron-cii-worker-docker'
+          - 'cron-bq-transfer-docker'
+          - 'cron-webhook-docker'
+          - 'cron-github-server-docker'
+          - 'build-attestor-docker'
+    name: ${{ matrix.target }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -63,227 +72,13 @@ jobs:
        uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
        with:
          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
      - name: Clone the code
        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
+     - name: Setup Go # needed due to the Makefile Go binary expressions
        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
        with:
          go-version-file: ${{ env.GO_VERSION_FILE }}
          check-latest: true
-         cache: true
-         cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
+         cache: false # the building happens in Docker, so saving this cache would negatively impact other builds
      - name: docker build
-       run: make scorecard-docker
-  cron-controller:
-    name: cron-controller-docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs:
-      - docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
-    steps:
-     - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-       with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
-         check-latest: true
-         cache: true
-         cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
-     - name: docker build
-       run: make cron-controller-docker
-  cron-worker:
-    name: cron-worker-docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs:
-      - docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
-    steps:
-     - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-       with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
-         check-latest: true
-         cache: true
-         cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
-     - name: docker build
-       run: make cron-worker-docker
-  cron-cii-worker:
-    name: cron-cii--worker-docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs:
-      - docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
-    steps:
-     - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-       with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
-         check-latest: true
-         cache: true
-         cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
-     - name: docker build
-       run: make cron-cii-worker-docker
-  cron-bq-transfer:
-    name: cron-bq-transfer-docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs:
-      - docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
-    steps:
-     - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-       with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
-         check-latest: true
-         cache: true
-         cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
-     - name: docker build
-       run: make cron-bq-transfer-docker
-  cron-webhook:
-    name: cron-webhook-docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs:
-      - docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
-    steps:
-     - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-       with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
-         check-latest: true
-         cache: true
-         cache-dependency-path: ${{ env.CACHE_DEPENDENCY_PATH }}
-     - name: docker build
-       run: make cron-webhook-docker
-  cron-github-server:
-    name: cron-github-server-docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs:
-      - docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
-    steps:
-     - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-       with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
-         check-latest: true
-         cache: true
-     - name: docker build
-       run: make cron-github-server-docker
-  attestor:
-    name: attestor-docker
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs:
-      - docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
-    steps:
-     - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
-       with:
-         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
-     - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
-       with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
-         check-latest: true
-         cache: true
-     - name: docker build
-       run: make build-attestor-docker
+       run: make ${{ matrix.target }}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

ci logic deduplication

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The docker images all get built with the same logic and setup. 
When adding a new image (like #3285), this involves a lot of unnecessary copy/pasting which is more of a burden to maintain. 

#### What is the new behavior (if this is a feature change)?**
- workflow uses a single-dimension matrix.
- no longer installs protoc, the docker images build without it.
- disabled caching for `actions/setup-go`, the Go tooling is only needed for a few Makefile expressions, all of the `go build` happens in the docker images. I think this is saving empty caches, and resulting in cache hits in other workflows that should be "misses".
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
This includes renaming one of the required checks. I can mark the new one as required once approved.
`cron-cii--worker-docker` -> `cron-cii-worker-docker`

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
