### PR TITLE
:seedling: Fix hanging docker jobs for doc only changes.

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -65,19 +65,24 @@ jobs:
     permissions:
       contents: read
     needs: docs_only_check
-    if: (needs.docs_only_check.outputs.docs_only != 'true')
+    # ideally we put one "if" here, but due to how skipped matrix jobs work, we need one for each each step
+    # https://github.com/orgs/community/discussions/9141
     steps:
      - name: Harden Runner
+       if: (needs.docs_only_check.outputs.docs_only != 'true')
        uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
        with:
          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
      - name: Clone the code
+       if: (needs.docs_only_check.outputs.docs_only != 'true')
        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
      - name: Setup Go # needed for some of the Makefile evaluations, even if building happens in Docker 
+       if: (needs.docs_only_check.outputs.docs_only != 'true')
        uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
        with:
          go-version-file: ${{ env.GO_VERSION_FILE }}
          check-latest: true
          cache: false # the building happens in Docker, so saving this cache would negatively impact other builds
      - name: docker build
+       if: (needs.docs_only_check.outputs.docs_only != 'true')
        run: make ${{ matrix.target }}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

ci fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
After #3290, doc only changes cause the required docker jobs to hang. You can see this in #3246.
This is due to how skipped matrices work https://github.com/orgs/community/discussions/9141

#### What is the new behavior (if this is a feature change)?**
The if statement has been moved down to every step.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
