### PR TITLE
:sparkles: scdiff: normalize scorecard results

### DIFF
--- a/cmd/internal/scdiff/app/format/format.go
+++ b/cmd/internal/scdiff/app/format/format.go
@@ -15,20 +15,43 @@
 package format
 
 import (
-	"os"
+	"io"
+	"sort"
+	"time"
 
 	"github.com/ossf/scorecard/v4/docs/checks"
 	"github.com/ossf/scorecard/v4/log"
 	"github.com/ossf/scorecard/v4/pkg"
 )
 
+const logLevel = log.DefaultLevel
+
+func normalize(r *pkg.ScorecardResult) {
+	if r == nil {
+		return
+	}
+
+	// these fields will change run-to-run, and aren't indicative of behavior changes.
+	r.Repo.CommitSHA = ""
+	r.Scorecard = pkg.ScorecardInfo{}
+	r.Date = time.Time{}
+
+	for i := range r.Checks {
+		check := &r.Checks[i]
+		sort.Slice(check.Details, func(i, j int) bool {
+			return pkg.DetailToString(&check.Details[i], logLevel) < pkg.DetailToString(&check.Details[j], logLevel)
+		})
+	}
+}
+
 //nolint:wrapcheck
-func JSON(r *pkg.ScorecardResult) error {
+func JSON(r *pkg.ScorecardResult, w io.Writer) error {
 	const details = true
 	docs, err := checks.Read()
 	if err != nil {
 		return err
 	}
-	// TODO standardize the input, and output it to a file
-	return r.AsJSON2(details, log.DefaultLevel, docs, os.Stdout)
+	normalize(r)
+	// TODO output it to a file
+	return r.AsJSON2(details, logLevel, docs, w)
 }

--- a/cmd/internal/scdiff/app/format/format.go
+++ b/cmd/internal/scdiff/app/format/format.go
@@ -36,6 +36,10 @@ func normalize(r *pkg.ScorecardResult) {
 	r.Scorecard = pkg.ScorecardInfo{}
 	r.Date = time.Time{}
 
+	sort.Slice(r.Checks, func(i, j int) bool {
+		return r.Checks[i].Name < r.Checks[j].Name
+	})
+
 	for i := range r.Checks {
 		check := &r.Checks[i]
 		sort.Slice(check.Details, func(i, j int) bool {

--- a/cmd/internal/scdiff/app/format/format.go
+++ b/cmd/internal/scdiff/app/format/format.go
@@ -56,6 +56,5 @@ func JSON(r *pkg.ScorecardResult, w io.Writer) error {
 		return err
 	}
 	normalize(r)
-	// TODO output it to a file
 	return r.AsJSON2(details, logLevel, docs, w)
 }

--- a/cmd/internal/scdiff/app/format/format_test.go
+++ b/cmd/internal/scdiff/app/format/format_test.go
@@ -164,3 +164,12 @@ func TestJSON(t *testing.T) {
 		})
 	}
 }
+
+func Test_normalize_nil_safe(t *testing.T) {
+	var x, y *pkg.ScorecardResult
+	normalize(x)
+	normalize(y)
+	if !cmp.Equal(x, y) {
+		t.Errorf("normalized results differ: %v", cmp.Diff(x, y))
+	}
+}

--- a/cmd/internal/scdiff/app/format/format_test.go
+++ b/cmd/internal/scdiff/app/format/format_test.go
@@ -1,0 +1,164 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package format
+
+import (
+	"bytes"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/pkg"
+)
+
+func TestJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b pkg.ScorecardResult
+	}{
+		{
+			name: "repo commit SHA standardized",
+			a: pkg.ScorecardResult{
+				Repo: pkg.RepoInfo{
+					Name:      "github.com/foo/bar",
+					CommitSHA: "commit a",
+				},
+			},
+			b: pkg.ScorecardResult{
+				Repo: pkg.RepoInfo{
+					Name:      "github.com/foo/bar",
+					CommitSHA: "commit b",
+				},
+			},
+		},
+		{
+			name: "dates standardized",
+			a: pkg.ScorecardResult{
+				Date: time.Now(),
+			},
+			b: pkg.ScorecardResult{
+				Date: time.Now().AddDate(0, 0, -1),
+			},
+		},
+		{
+			name: "scorecard info standardized",
+			a: pkg.ScorecardResult{
+				Scorecard: pkg.ScorecardInfo{
+					Version:   "version a",
+					CommitSHA: "scorecard commit x",
+				},
+			},
+			b: pkg.ScorecardResult{
+				Scorecard: pkg.ScorecardInfo{
+					Version:   "version b",
+					CommitSHA: "scorecard commit y",
+				},
+			},
+		},
+		{
+			name: "check order standardized",
+			a: pkg.ScorecardResult{
+				Checks: []checker.CheckResult{
+					{
+						Name:  "Token-Permissions",
+						Score: 10,
+					},
+					{
+						Name:  "License",
+						Score: 10,
+					},
+				},
+			},
+			b: pkg.ScorecardResult{
+				Checks: []checker.CheckResult{
+					{
+						Name:  "License",
+						Score: 10,
+					},
+					{
+						Name:  "Token-Permissions",
+						Score: 10,
+					},
+				},
+			},
+		},
+		{
+			name: "detail order standardized",
+			a: pkg.ScorecardResult{
+				Checks: []checker.CheckResult{
+					{
+						Name:  "Token-Permissions",
+						Score: 10,
+						Details: []checker.CheckDetail{
+							{
+								Msg: checker.LogMessage{
+									Text: "foo",
+								},
+								Type: checker.DetailInfo,
+							},
+							{
+								Msg: checker.LogMessage{
+									Text: "bar",
+								},
+								Type: checker.DetailWarn,
+							},
+						},
+					},
+				},
+			},
+			b: pkg.ScorecardResult{
+				Checks: []checker.CheckResult{
+					{
+						Name:  "Token-Permissions",
+						Score: 10,
+						Details: []checker.CheckDetail{
+							{
+								Msg: checker.LogMessage{
+									Text: "bar",
+								},
+								Type: checker.DetailWarn,
+							},
+							{
+								Msg: checker.LogMessage{
+									Text: "foo",
+								},
+								Type: checker.DetailInfo,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			var bufA, bufB bytes.Buffer
+			err := JSON(&tt.a, &bufA)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			err = JSON(&tt.b, &bufB)
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if bufA.String() != bufB.String() {
+				t.Errorf("outputs not identical: %s", cmp.Diff(bufA.String(), bufB.String()))
+			}
+		})
+	}
+}

--- a/cmd/internal/scdiff/app/format/format_test.go
+++ b/cmd/internal/scdiff/app/format/format_test.go
@@ -26,6 +26,7 @@ import (
 )
 
 func TestJSON(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name string
 		a, b pkg.ScorecardResult
@@ -147,6 +148,7 @@ func TestJSON(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			var bufA, bufB bytes.Buffer
 			err := JSON(&tt.a, &bufA)
 			if err != nil {

--- a/cmd/internal/scdiff/app/generate.go
+++ b/cmd/internal/scdiff/app/generate.go
@@ -50,7 +50,7 @@ var (
 				if err != nil {
 					return fmt.Errorf("running scorecard on %s: %w", scanner.Text(), err)
 				}
-				err = format.JSON(&results)
+				err = format.JSON(&results, os.Stdout)
 				if err != nil {
 					return fmt.Errorf("formatting results: %w", err)
 				}

--- a/cmd/internal/scdiff/app/generate.go
+++ b/cmd/internal/scdiff/app/generate.go
@@ -50,7 +50,7 @@ var (
 				if err != nil {
 					return fmt.Errorf("running scorecard on %s: %w", scanner.Text(), err)
 				}
-				// TODO output it to a file
+				// TODO output it to a file, preferably in pretty printed json
 				err = format.JSON(&results, os.Stdout)
 				if err != nil {
 					return fmt.Errorf("formatting results: %w", err)

--- a/cmd/internal/scdiff/app/generate.go
+++ b/cmd/internal/scdiff/app/generate.go
@@ -50,6 +50,7 @@ var (
 				if err != nil {
 					return fmt.Errorf("running scorecard on %s: %w", scanner.Text(), err)
 				}
+				// TODO output it to a file
 				err = format.JSON(&results, os.Stdout)
 				if err != nil {
 					return fmt.Errorf("formatting results: %w", err)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

feature

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
scorecard results were printed verbatim by the scdiff tool

#### What is the new behavior (if this is a feature change)?**
certain fields, such as dates or commit shas, are stripped before printing.
these fields are informational, but don't provide value in detecting a change in scorecard behavior. instead they interfere with the comparison

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Related to https://github.com/ossf/scorecard/issues/2462, 2/n
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
