### PR TITLE
:seedling: Ensure check markdown is kept in sync with source yaml.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -143,39 +143,19 @@ jobs:
       contents: read
     steps:
      - name: Harden Runner
-       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v1
+       uses: step-security/harden-runner@55d479fb1c5bcad5a4f9099a5d9f37c8857b2845 # v2.4.1
        with:
          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-     - name: Install Protoc
-       uses: arduino/setup-protoc@149f6c87b92550901b26acd1632e11c3662e381f # v1.3.0
-       with:
-        version: ${{ env.PROTOC_VERSION }}
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
-     - name: Cache builds
-       # https://github.com/mvdan/github-actions-golang#how-do-i-set-up-caching-between-builds
-       uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
-       with:
-         path: |
-           ~/go/pkg/mod
-           ~/.cache/go-build
-           ~/Library/Caches/go-build
-           %LocalAppData%\go-build
-         key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-         restore-keys: |
-           ${{ runner.os }}-go-
      - name: Clone the code
-       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v2.3.4
-       with:
-          fetch-depth: 0
+       uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
      - name: Setup Go
-       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v2.2.0
+       uses: actions/setup-go@fac708d6674e30b6ba41289acaab6d4b75aa0753 # v4.0.1
        with:
          go-version: ${{ env.GO_VERSION }}
          check-latest: true
          cache: true
      - name: generate docs
-       uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd
+       uses: nick-invision/retry@943e742917ac94714d2f408a0e8320f2d1fcafcd # v2.8.3
        with:
           max_attempts: 3
           retry_on: error
@@ -183,6 +163,8 @@ jobs:
           command: |
             go env -w GOFLAGS=-mod=mod
             make generate-docs
+     - name: ensure checks.yaml and checks.md match
+       run: git diff --exit-code
   build-proto:
     name: build-proto
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -161,8 +161,7 @@ cmd/internal/nuget/nuget_mockclient.go: cmd/internal/nuget/client.go | $(MOCKGEN
 	$(MOCKGEN) -source=cmd/internal/nuget/client.go -destination=cmd/internal/nuget/nuget_mockclient.go -package=nuget -copyright_file=clients/mockclients/license.txt
 
 generate-docs: ## Generates docs
-generate-docs: validate-docs docs/checks.md
-docs/checks.md: docs/checks/internal/checks.yaml docs/checks/internal/*.go docs/checks/internal/generate/*.go
+generate-docs: validate-docs docs/checks.md docs/checks/internal/checks.yaml docs/checks/internal/*.go docs/checks/internal/generate/*.go
 	# Generating checks.md
 	go run ./docs/checks/internal/generate/main.go docs/checks.md
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

ci change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
PR authors/maintainers need to remember to check if `docs/checks/internal/checks.yaml` and `docs/checks.md` are kept in sync. Sometimes this doesn't happen (e.g #2772)

#### What is the new behavior (if this is a feature change)?**
The CI job now calls `git diff --exit-code` to ensure the two are in sync.

- If someone commits to `docs/checks.md` directly, then the changes will be overwritten when `make generate-docs` is ran, and `git diff` will fail the job. 
- If someone commits to `checks.yaml` directly, then `make generate-docs` will modify `checks.md`. Which `git diff` will detect and fail.


I also included some cleanup in the action:
-  version comments are accurate
- we dont need protoc for this job
-  we dont need full commit history
- caching is handled through setup-go

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
None
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
