### PR TITLE
:seedling: Improve `gitlabrepo.ListProgrammingLanguages` e2e tests

### DIFF
--- a/clients/gitlabrepo/languages_e2e_test.go
+++ b/clients/gitlabrepo/languages_e2e_test.go
@@ -16,6 +16,8 @@ package gitlabrepo
 
 import (
 	"context"
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 )
@@ -34,6 +36,16 @@ var _ = Describe("E2E TEST: gitlabrepo.ListProgrammingLanguages", func() {
 			programmingLang, err := client.ListProgrammingLanguages()
 			Expect(err).Should(BeNil())
 			Expect(programmingLang).ShouldNot(BeNil())
+			// Check for the presence of some languages
+			isPythonPresent := false
+			for _, lang := range programmingLang {
+				// compare case insensitive
+				if strings.EqualFold(string(lang.Name), "Python") {
+					isPythonPresent = true
+					break
+				}
+			}
+			Expect(isPythonPresent).Should(BeTrue())
 		})
 		It("Should return no programming languages repo with no code", func() {
 			repo, err := MakeGitlabRepo("https://gitlab.com/ossf-test/scorecard-test-branches")

--- a/clients/gitlabrepo/languages_e2e_test.go
+++ b/clients/gitlabrepo/languages_e2e_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlabrepo
+
+import (
+	"context"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("E2E TEST: gitlabrepo.ListProgrammingLanguages", func() {
+	Context("Test list programming languages - GitLab", func() {
+		It("returns branches for the repo", func() {
+			repo, err := MakeGitlabRepo("https://gitlab.com/baserow/baserow")
+			Expect(err).Should(BeNil())
+
+			client, err := CreateGitlabClient(context.Background(), repo.Host())
+			Expect(err).Should(BeNil())
+
+			err = client.InitRepo(repo, "HEAD", 0)
+			Expect(err).Should(BeNil())
+			programmingLang, err := client.ListProgrammingLanguages()
+			Expect(err).Should(BeNil())
+			Expect(programmingLang).ShouldNot(BeNil())
+		})
+		It("Should return no programming languages repo with no code", func() {
+			repo, err := MakeGitlabRepo("https://gitlab.com/ossf-test/scorecard-test-branches")
+			Expect(err).Should(BeNil())
+
+			client, err := CreateGitlabClient(context.Background(), repo.Host())
+			Expect(err).Should(BeNil())
+
+			err = client.InitRepo(repo, "HEAD", 0)
+			Expect(err).Should(BeNil())
+			programmingLang, err := client.ListProgrammingLanguages()
+			Expect(err).Should(BeNil())
+			Expect(programmingLang).Should(BeNil())
+		})
+	})
+})


### PR DESCRIPTION
- Add an end-to-end test for the `gitlabrepo.ListProgrammingLanguages` function
- Include a test for repos without code to check that no programming languages are returned

[clients/gitlabrepo/languages_e2e_test.go]
- Add an e2e test for the `gitlabrepo.ListProgrammingLanguages` function
- Add a test for repos without code to check that no programming languages are returned

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
