### PR TITLE
:book: Fixed slack badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Go Reference](https://pkg.go.dev/badge/github.com/ossf/scorecard/v4.svg)](https://pkg.go.dev/github.com/ossf/scorecard/v4)
 [![Go Report Card](https://goreportcard.com/badge/github.com/ossf/scorecard/v4)](https://goreportcard.com/report/github.com/ossf/scorecard/v4)
 [![codecov](https://codecov.io/gh/ossf/scorecard/branch/main/graph/badge.svg?token=PMJ6NAN9J3)](https://codecov.io/gh/ossf/scorecard)
-[![Slack](https://slack.babeljs.io/badge.svg)](https://slack.openssf.org/#security_scorecards)
 [![SLSA 3](https://slsa.dev/images/gh-badge-level3.svg)](https://slsa.dev)
+[![Slack](https://img.shields.io/badge/slack-openssf/security_scorecards-white.svg?logo=slack)](https://slack.openssf.org/#security_scorecards)
 
 <img align="right" src="artwork/openssf_security_compressed.png" width="200" height="400">
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Fixes the slack badge that is currently broken

#### What is the current behavior?

<img width="871" alt="Screen Shot 2023-07-25 at 7 09 16 PM" src="https://github.com/ossf/scorecard/assets/21176439/3bc2eb82-2d8a-41e1-bf98-ce83591a609e">

#### What is the new behavior?

<img width="1006" alt="Screen Shot 2023-07-25 at 7 10 42 PM" src="https://github.com/ossf/scorecard/assets/21176439/85732b2f-1ff9-4334-983b-6fc5c337dfd4">

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

Let me know if style is an issue... these badges are highly customizable.

#### Does this PR introduce a user-facing change?

No

```release-note
NONE
```
