### PR TITLE
:sparkles: Update GitHub documentation links in report

### DIFF
--- a/checks/evaluation/permissions/gitHubWorkflowPermissionsTopNoWrite.yml
+++ b/checks/evaluation/permissions/gitHubWorkflowPermissionsTopNoWrite.yml
@@ -17,7 +17,7 @@ short: Checks that GitHub workflows do not have default write permissions
 motivation: >
   If no permissions are declared, a workflow's GitHub token's permissions default to write for all scopes.
   This include write permissions to push to the repository, to read encrypted secrets, etc.
-  For more information, see https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token. 
+  For more information, see https://docs.github.com/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token. 
 implementation: >
   The rule is implemented by checking whether the `permissions` keyword is defined at the top of the workflow,
   and that no write permissions are given.

--- a/probes/toolDependabotInstalled/def.yml
+++ b/probes/toolDependabotInstalled/def.yml
@@ -27,6 +27,6 @@ outcome:
 remediation:
   effort: Low
   text:
-    - Follow the instructions from https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates.
+    - Follow the instructions from https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates.
   markdown:
-    - Follow the instructions from [the official documentation](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically/configuration-options-for-dependency-updates).
+    - Follow the instructions from [the official documentation](https://docs.github.com/code-security/dependabot/dependabot-version-updates/about-dependabot-version-updates).


### PR DESCRIPTION
#### What kind of change does this PR introduce?

- Update Dependabot documentation links where they currently redirect.
- Remove language code from GitHub documentation URLs in scorecard report.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

English specific GitHub documentation links are shown to users in the scorecard report.

#### What is the new behavior (if this is a feature change)?

Language-agnostic GitHub documentation links are shown to users in the scorecard report. This then allows GitHub's documentation to redirect the user to a more appropriate language (Spanish, Japanese etc.) if relevant to the user viewing them.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

NONE

#### Does this PR introduce a user-facing change?

```release-note
Remove links to English-specific GitHub documentation so users' language preferences are respected where possible.
```
