### PR TITLE
:bug: Clear all possible token env vars for token accessor test.

### DIFF
--- a/clients/githubrepo/roundtripper/tokens/accessor_test.go
+++ b/clients/githubrepo/roundtripper/tokens/accessor_test.go
@@ -40,16 +40,17 @@ func TestMakeTokenAccessor(t *testing.T) {
 			useServer: true,
 		},
 	}
-	t.Setenv("GITHUB_AUTH_TOKEN", "")
-	t.Setenv("GITHUB_TOKEN", "")
+	// clear all env variables devs may have defined, or the test will fail locally
+	for _, envVar := range githubAuthTokenEnvVars {
+		t.Setenv(envVar, "")
+	}
+	t.Setenv(githubAuthServer, "")
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			switch {
 			case tt.useGitHubToken:
-				t.Helper()
 				testToken(t)
 			case tt.useServer:
-				t.Helper()
 				testServer(t)
 			default:
 				got := MakeTokenAccessor()


### PR DESCRIPTION
#### What kind of change does this PR introduce?

test bug fix

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
If a dev has any of the env vars set, the `TestMakeTokenAccessor` will fail locally for them.

#### What is the new behavior (if this is a feature change)?**
All possible env vars that the accessor reads from are cleared before this test

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
@laurentsimon can you confirm this fixes your issue?

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
