### PR TITLE
🌱 e2e tests: revert

### DIFF
--- a/clients/gitlabrepo/issues_e2e_test.go
+++ b/clients/gitlabrepo/issues_e2e_test.go
@@ -33,9 +33,7 @@ var _ = Describe("E2E TEST: gitlabrepo.ListIssues", func() {
 			err = client.InitRepo(repo, "HEAD", 0)
 			Expect(err).Should(BeNil())
 			_, err = client.ListIssues()
-			// returns error as the code checks for ListAllProjectMembers which is not available
-			// TODO: this will be fixed when it is fixed in the code
-			Expect(err).ShouldNot(BeNil())
+			Expect(err).Should(BeNil())
 		})
 	})
 })


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Fix E2E test that expected `nil`. This was due to the GitLab service user ([user](https://gitlab.com/gossts)) not being set up correctly for the repo ([repo](https://gitlab.com/ossf-test/e2e-issues))., leading to E2E test failures ([link](https://github.com/ossf/scorecard/actions/runs/5788395634/job/15687305862)). 