### PR TITLE
:seedling: Increase test coverage for GitLab repository associations

### DIFF
--- a/clients/gitlabrepo/issues_test.go
+++ b/clients/gitlabrepo/issues_test.go
@@ -1,0 +1,49 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package gitlabrepo
+
+import (
+	"testing"
+
+	"github.com/xanzy/go-gitlab"
+
+	"github.com/ossf/scorecard/v4/clients"
+)
+
+func TestAccessLevelToRepoAssociation(t *testing.T) {
+	t.Parallel()
+	testCases := []struct {
+		level    gitlab.AccessLevelValue
+		expected clients.RepoAssociation
+	}{
+		{0, clients.RepoAssociationNone},
+		{5, clients.RepoAssociationFirstTimeContributor},
+		{10, clients.RepoAssociationCollaborator},
+		{20, clients.RepoAssociationCollaborator},
+		{30, clients.RepoAssociationMember},
+		{40, clients.RepoAssociationMaintainer},
+		{50, clients.RepoAssociationOwner},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run("", func(t *testing.T) {
+			t.Parallel()
+			actual := accessLevelToRepoAssociation(tc.level)
+			if actual != tc.expected {
+				t.Errorf("Expected %v but got %v for level %d", tc.expected, actual, tc.level)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add test to map GitLab access levels to Scorecard repository associations

[clients/gitlabrepo/issues_test.go]
- Add test for mapping GitLab access levels to Scorecard repository associations

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
