### PR TITLE
:bug: Fix parsing OSSFuzz project repos with subfolders and capitalization.

### DIFF
--- a/clients/ossfuzz/client.go
+++ b/clients/ossfuzz/client.go
@@ -83,7 +83,8 @@ func (c *client) Search(request clients.SearchRequest) (clients.SearchResponse, 
 	if c.err != nil {
 		return sr, c.err
 	}
-	if c.projects[request.Query] {
+	projectURI := strings.ToLower(request.Query)
+	if c.projects[projectURI] {
 		sr.Hits = 1
 	}
 	return sr, nil
@@ -135,7 +136,7 @@ func fetchStatusFile(uri string) ([]byte, error) {
 }
 
 func normalize(rawURL string) (string, error) {
-	u, err := url.Parse(rawURL)
+	u, err := url.Parse(strings.ToLower(rawURL))
 	if err != nil {
 		return "", fmt.Errorf("url.Parse: %w", err)
 	}

--- a/clients/ossfuzz/client.go
+++ b/clients/ossfuzz/client.go
@@ -139,9 +139,10 @@ func normalize(rawURL string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("url.Parse: %w", err)
 	}
-	const splitLen = 2
+	const splitLen = 3 // corresponding to owner/repo/rest
+	const minLen = 2   // corresponds to owner/repo
 	split := strings.SplitN(strings.Trim(u.Path, "/"), "/", splitLen)
-	if len(split) != splitLen {
+	if len(split) < minLen {
 		return "", fmt.Errorf("%s: %w", rawURL, errMalformedURL)
 	}
 	org := split[0]

--- a/clients/ossfuzz/client_test.go
+++ b/clients/ossfuzz/client_test.go
@@ -57,6 +57,13 @@ func TestClient(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "project with main_repo link longer than owner/repo",
+			project:    "github.com/google/go-cmp",
+			statusFile: "status.json",
+			wantHit:    true,
+			wantErr:    false,
+		},
+		{
 			name:       "non existent status file",
 			project:    "github.com/ossf/scorecard",
 			statusFile: "not_here.json",

--- a/clients/ossfuzz/client_test.go
+++ b/clients/ossfuzz/client_test.go
@@ -64,6 +64,13 @@ func TestClient(t *testing.T) {
 			wantErr:    false,
 		},
 		{
+			name:       "project case insensitive",
+			project:    "github.com/FFTW/fftw3",
+			statusFile: "status.json",
+			wantHit:    true,
+			wantErr:    false,
+		},
+		{
 			name:       "non existent status file",
 			project:    "github.com/ossf/scorecard",
 			statusFile: "not_here.json",

--- a/clients/ossfuzz/testdata/status.json
+++ b/clients/ossfuzz/testdata/status.json
@@ -19,6 +19,10 @@
     {
       "name": "zydis",
       "main_repo": "https://github.com/zyantific/zydis.git"
+    },
+    {
+      "name": "go-cmp",
+      "main_repo": "https://github.com/google/go-cmp/cmp"
     }
   ]
 }

--- a/clients/ossfuzz/testdata/status.json
+++ b/clients/ossfuzz/testdata/status.json
@@ -23,6 +23,10 @@
     {
       "name": "go-cmp",
       "main_repo": "https://github.com/google/go-cmp/cmp"
+    },
+    {
+      "name": "fftw3",
+      "main_repo": "https://github.com/fftw/fftw3.git"
     }
   ]
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- parsing ossfuzz projects whose `main_repo` field points to a subfolders (eg. `github.com/google/go-cmp/cmp`), doesn't register when asked about `github.com/google/go-cmp`)
- parsing ossfuzz projects that have different capitalization from GitHub's view causes ossfuzz detection to fail
#### What is the new behavior (if this is a feature change)?**
- `main_repo` fields to subfolders are parsed correctly
- the internals of the oss-fuzz client use lowercase strings to standardize capitalization.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #3256
Fixes #3257 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
