### PR TITLE
:seedling: Improve gitlabrepo webhook handler tests

### DIFF
--- a/clients/gitlabrepo/testdata/valid-webhook
+++ b/clients/gitlabrepo/testdata/valid-webhook
@@ -1,0 +1,27 @@
+[
+  {
+  "id": 1,
+  "url": "http://example.com/hook",
+  "project_id": 3,
+  "push_events": true,
+  "push_events_branch_filter": "",
+  "issues_events": true,
+  "confidential_issues_events": true,
+  "merge_requests_events": true,
+  "tag_push_events": true,
+  "note_events": true,
+  "confidential_note_events": true,
+  "job_events": true,
+  "pipeline_events": true,
+  "wiki_page_events": true,
+  "deployment_events": true,
+  "releases_events": true,
+  "enable_ssl_verification": true,
+  "repository_update_events": false,
+  "alert_status": "executable",
+  "disabled_until": null,
+  "url_variables": [ ],
+  "created_at": "2012-10-12T17:04:47Z"
+}
+
+]

--- a/clients/gitlabrepo/webhook_test.go
+++ b/clients/gitlabrepo/webhook_test.go
@@ -1,0 +1,103 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlabrepo
+
+import (
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/xanzy/go-gitlab"
+
+	"github.com/ossf/scorecard/v4/clients"
+)
+
+type stubTripper struct {
+	responsePath string
+}
+
+func (s stubTripper) RoundTrip(_ *http.Request) (*http.Response, error) {
+	f, err := os.Open(s.responsePath)
+	if err != nil {
+		//nolint:wrapcheck
+		return nil, err
+	}
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: http.StatusOK,
+		Body:       f,
+	}, nil
+}
+
+func Test_listWebhooks(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name         string
+		responsePath string
+		want         []clients.Webhook
+		wantErr      bool
+	}{
+		{
+			name:         "valid webhook",
+			responsePath: "./testdata/valid-webhook",
+			want: []clients.Webhook{
+				{
+					ID:             1,
+					Path:           "http://example.com/hook",
+					UsesAuthSecret: true,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name:         "invalid webhook",
+			responsePath: "./testdata/invalid-webhook",
+			want:         nil,
+			wantErr:      true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			httpClient := &http.Client{
+				Transport: stubTripper{
+					responsePath: tt.responsePath,
+				},
+			}
+			client, err := gitlab.NewClient("", gitlab.WithHTTPClient(httpClient))
+			if err != nil {
+				t.Fatalf("gitlab.NewClient error: %v", err)
+			}
+			handler := &webhookHandler{
+				glClient: client,
+			}
+
+			repoURL := repoURL{
+				owner:     "ossf-tests",
+				commitSHA: clients.HeadSHA,
+			}
+			handler.init(&repoURL)
+			got, err := handler.listWebhooks()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("listWebhooks error: %v, wantedErr: %t", err, tt.wantErr)
+			}
+			if !cmp.Equal(got, tt.want) {
+				t.Errorf("listWebhooks() = %v, want %v", got, cmp.Diff(got, tt.want))
+			}
+		})
+	}
+}


### PR DESCRIPTION
- Add a test for the gitlabrepo webhook handler
- Add a stubTripper for testing the webhook handler
- Add two test cases for the webhook handler: one valid and one invalid

[clients/gitlabrepo/webhook_test.go]
- Add a test for the gitlabrepo webhook handler
- Add a stubTripper for testing the webhook handler
- Add two test cases for the webhook handler: one valid and one invalid

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
