### PR TITLE
:seedling: Migrate to go 1.21

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ on:
   - main
 
 env:
-  GO_VERSION_FILE: go.mod # no good way of getting a mutual version between go.mod and tools/go.mod
+  GO_VERSION: 1.21
 
 jobs:
   docs_only_check:
@@ -80,7 +80,7 @@ jobs:
        if: (needs.docs_only_check.outputs.docs_only != 'true')
        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
        with:
-         go-version-file: ${{ env.GO_VERSION_FILE }}
+         go-version: ${{ env.GO_VERSION }}
          check-latest: true
          cache: false # the building happens in Docker, so saving this cache would negatively impact other builds
      - name: docker build

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -25,7 +25,7 @@ on:
       - main
 
 env:
-  GO_VERSION_FILE: go.mod # no good way of getting a mutual version between go.mod and tools/go.mod
+  GO_VERSION: 1.21
 
 jobs:
   gitlab-integration-trusted:
@@ -43,7 +43,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: ${{ env.GO_VERSION_FILE }}
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: false # we manually manage caches below
       - id: go-cache-paths

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -22,6 +22,9 @@ on:
 permissions:
   contents: read
 
+env:
+  GO_VERSION: 1.21
+
 jobs:
   goreleaser:
     outputs:
@@ -42,7 +45,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v2.2.0
         with:
-          go-version: 1.19
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
       - name: Configure ldflags
         id: ldflags

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION_FILE: go.mod # no good way of getting a mutual version between go.mod and tools/go.mod
+  GO_VERSION: 1.21
 
 jobs:
   approve:
@@ -54,7 +54,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: ${{ env.GO_VERSION_FILE }}
+          go-version: ${{ env.GO_VERSION }}
           check-latest: true
           cache: false # we manually manage caches below
       - id: go-cache-paths

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,9 @@ permissions:
   contents: read
   pull-requests: read # Use with `only-new-issues` option.
 
+env:
+  GO_VERSION: 1.21
+
 jobs:
   golangci:
     name: check-linter
@@ -22,7 +25,7 @@ jobs:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4.1.0
         with:
-          go-version-file: 'go.mod'
+          go-version: ${{ env.GO_VERSION }}
           cache: false # golangci-lint maintains its own cache
       - name: set golangci-lint version # keep in sync with tools/go.mod
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   PROTOC_VERSION: 3.17.3
-  GO_VERSION: 1.19
+  GO_VERSION: 1.21
 
 jobs:
   unit-test:

--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -21,6 +21,9 @@ on:
     branches:
       - main
 
+env:
+  GO_VERSION: 1.21
+
 jobs:
   publishimage:
     runs-on: ubuntu-latest
@@ -43,7 +46,7 @@ jobs:
      - name: Setup Go
        uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe
        with:
-         go-version-file: go.mod # use version from go.mod so it stays in sync
+         go-version: ${{ env.GO_VERSION }}
          check-latest: true
      - name: install ko
        uses: ko-build/setup-ko@ace48d793556083a76f1e3e6068850c1f4a369aa # v0.6

--- a/.github/workflows/slsa-goreleaser.yml
+++ b/.github/workflows/slsa-goreleaser.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: read-all
 
+env:
+  GO_VERSION: 1.21
+
 jobs:
   # Generate ldflags dynamically.
   args:
@@ -31,7 +34,7 @@ jobs:
     needs: args
     uses: slsa-framework/slsa-github-generator/.github/workflows/builder_go_slsa3.yml@v1.8.0 #7f4fdb871876c23e455853d694197440c5a91506
     with:
-      go-version: 1.19
+      go-version: ${{ env.GO_VERSION }}
       evaluated-envs: "VERSION_LDFLAGS:${{needs.args.outputs.ldflags}}"
 
   verification:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ You must install these tools:
 1.  [`git`](https://help.github.com/articles/set-up-git/): For source control
 
 1.  [`go`](https://golang.org/doc/install): You need go version
-    [v1.17](https://golang.org/dl/) or higher.
+    [v1.19](https://golang.org/dl/) or higher.
 
 1.  [`docker`](https://docs.docker.com/engine/install/): `v18.9` or higher.
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/attestor/Dockerfile
+++ b/attestor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src/scorecard
 COPY . ./
 

--- a/clients/githubrepo/roundtripper/tokens/server/Dockerfile
+++ b/clients/githubrepo/roundtripper/tokens/server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/bq/Dockerfile
+++ b/cron/internal/bq/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/cii/Dockerfile
+++ b/cron/internal/cii/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/controller/Dockerfile
+++ b/cron/internal/controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/webhook/Dockerfile
+++ b/cron/internal/webhook/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/worker/Dockerfile
+++ b/cron/internal/worker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.19@sha256:6b3fa4b908676231b50acbbc00e84d8cee9c6ce072b1175c0ff352c57d8a612f AS base
+FROM golang:1.21@sha256:ec457a2fcd235259273428a24e09900c496d0c52207266f96a330062a01e3622 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./


### PR DESCRIPTION
#### What kind of change does this PR introduce?

dependency update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- use go1.19, which is no longer supported

#### What is the new behavior (if this is a feature change)?**
- use go1.21 for our CI and builds/releases
- keep go1.19 in our go.mod as we don't currently use any 1.20 or 1.21 features. this is for our dependents.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
#3386 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Scorecard releases will now use go1.21
```
