### PR TITLE
:bug: fallback to local file detection on empty GitHub license response.

### DIFF
--- a/checks/raw/license.go
+++ b/checks/raw/license.go
@@ -116,6 +116,11 @@ func License(c *checker.CheckRequest) (checker.LicenseData, error) {
 	// repo API for licenses is supported
 	// go the work and return from immediate (no searching repo).
 	case lerr == nil:
+		// licenses API may be supported, but platform might not detect license same way we do
+		// fallback to our local file logic
+		if len(licensesFound) == 0 {
+			break
+		}
 		for _, v := range licensesFound {
 			results.LicenseFiles = append(results.LicenseFiles,
 				checker.LicenseFile{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
If GitHub doesn't detect a license, the project gets a 0

#### What is the new behavior (if this is a feature change)?**
We use our existing local file detection if github doesn't detect a license

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #3279
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Fixed bug where the Licenses folder wasn't being detected.
```
