### PR TITLE
🐛 Licenses: Get License SPDXId from GitLab API

### DIFF
--- a/clients/gitlabrepo/client.go
+++ b/clients/gitlabrepo/client.go
@@ -81,7 +81,8 @@ func (client *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitD
 
 	// Sanity check.
 	proj := fmt.Sprintf("%s/%s", glRepo.owner, glRepo.project)
-	repo, _, err := client.glClient.Projects.GetProject(proj, &gitlab.GetProjectOptions{})
+	license := true // Get project license information. Used for licenses client.
+	repo, _, err := client.glClient.Projects.GetProject(proj, &gitlab.GetProjectOptions{License: &license})
 	if err != nil {
 		return sce.WithMessage(sce.ErrRepoUnreachable, proj+"\t"+err.Error())
 	}
@@ -107,7 +108,7 @@ func (client *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitD
 	}
 
 	if repo.Owner != nil {
-		client.repourl.owner = repo.Owner.Name
+		client.repourl.owner = repo.Owner.Username
 	}
 
 	// Init contributorsHandler

--- a/clients/gitlabrepo/licenses.go
+++ b/clients/gitlabrepo/licenses.go
@@ -44,33 +44,27 @@ var errLicenseURLParse = errors.New("couldn't parse gitlab repo license url")
 
 func (handler *licensesHandler) setup() error {
 	handler.once.Do(func() {
-		licenseMap := []clients.License{}
-		if len(licenseMap) == 0 {
-			// TODO: handler.errSetup = fmt.Errorf("request for repo licenses failed with %w", err)
-			handler.errSetup = fmt.Errorf("%w: ListLicenses not yet supported for gitlab", clients.ErrUnsupportedFeature)
-			return
-		}
-
 		l := handler.glProject.License
 
-		ptn, err := regexp.Compile(fmt.Sprintf("%s/~/blob/master/(.*)", handler.repourl.URI()))
+		ptn, err := regexp.Compile(fmt.Sprintf("%s/-/blob/(\\w+)/(.*)", handler.repourl.URI()))
 		if err != nil {
-			handler.errSetup = fmt.Errorf("couldn't parse License URL: %w", err)
+			handler.errSetup = fmt.Errorf("couldn't parse license url: %w", err)
 			return
 		}
 
 		m := ptn.FindStringSubmatch(handler.glProject.LicenseURL)
-		if len(m) < 2 {
+		if len(m) < 3 {
 			handler.errSetup = fmt.Errorf("%w: %s", errLicenseURLParse, handler.glProject.LicenseURL)
 			return
 		}
-		path := m[1]
+		path := m[2]
 
 		handler.licenses = append(handler.licenses,
 			clients.License{
-				Key:  l.Key,
-				Name: l.Name,
-				Path: path,
+				Key:    l.Key,
+				Name:   l.Name,
+				Path:   path,
+				SPDXId: l.Key,
 			},
 		)
 

--- a/clients/gitlabrepo/licenses.go
+++ b/clients/gitlabrepo/licenses.go
@@ -46,18 +46,18 @@ func (handler *licensesHandler) setup() error {
 	handler.once.Do(func() {
 		l := handler.glProject.License
 
-		ptn, err := regexp.Compile(fmt.Sprintf("%s/-/blob/(\\w+)/(.*)", handler.repourl.URI()))
+		ptn, err := regexp.Compile(fmt.Sprintf("%s/-/blob/(?:\\w+)/(.*)", handler.repourl.URI()))
 		if err != nil {
 			handler.errSetup = fmt.Errorf("couldn't parse license url: %w", err)
 			return
 		}
 
 		m := ptn.FindStringSubmatch(handler.glProject.LicenseURL)
-		if len(m) < 3 {
+		if len(m) < 2 {
 			handler.errSetup = fmt.Errorf("%w: %s", errLicenseURLParse, handler.glProject.LicenseURL)
 			return
 		}
-		path := m[2]
+		path := m[1]
 
 		handler.licenses = append(handler.licenses,
 			clients.License{

--- a/e2e/license_test.go
+++ b/e2e/license_test.go
@@ -136,18 +136,16 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 				Dlogger:    &dl,
 			}
 			expected := scut.TestReturn{
-				Error:         nil,
-				Score:         10,
-				NumberOfWarn:  0,
-				NumberOfInfo:  2,
-				NumberOfDebug: 0,
+				Error:        nil,
+				Score:        10,
+				NumberOfInfo: 2,
 			}
 			result := checks.License(&req)
 
 			Expect(scut.ValidateTestReturn(nil, "license found", &expected, &result,
 				&dl)).Should(BeTrue())
 		})
-		It("Should return license check works - GitLab", func() {
+		It("Should return license check works for unrecognized license type - GitLab", func() {
 			skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
 
 			dl := scut.TestDetailLogger{}
@@ -166,8 +164,8 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         9,
-				NumberOfWarn:  0,
-				NumberOfInfo:  2,
+				NumberOfWarn:  1,
+				NumberOfInfo:  1,
 				NumberOfDebug: 0,
 			}
 			result := checks.License(&req)
@@ -192,11 +190,9 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 				Dlogger:    &dl,
 			}
 			expected := scut.TestReturn{
-				Error:         nil,
-				Score:         10,
-				NumberOfWarn:  1,
-				NumberOfInfo:  1,
-				NumberOfDebug: 0,
+				Error:        nil,
+				Score:        10,
+				NumberOfInfo: 2,
 			}
 			result := checks.License(&req)
 

--- a/e2e/license_test.go
+++ b/e2e/license_test.go
@@ -147,6 +147,34 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			Expect(scut.ValidateTestReturn(nil, "license found", &expected, &result,
 				&dl)).Should(BeTrue())
 		})
+		It("Should return license check works - GitLab", func() {
+			skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
+
+			dl := scut.TestDetailLogger{}
+			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/ossf-test/scorecard-check-license-e2e-unrecognized-license-type")
+			Expect(err).Should(BeNil())
+			repoClient, err := gitlabrepo.CreateGitlabClient(context.Background(), repo.Host())
+			Expect(err).Should(BeNil())
+			err = repoClient.InitRepo(repo, clients.HeadSHA, 0)
+			Expect(err).Should(BeNil())
+			req := checker.CheckRequest{
+				Ctx:        context.Background(),
+				RepoClient: repoClient,
+				Repo:       repo,
+				Dlogger:    &dl,
+			}
+			expected := scut.TestReturn{
+				Error:         nil,
+				Score:         9,
+				NumberOfWarn:  0,
+				NumberOfInfo:  2,
+				NumberOfDebug: 0,
+			}
+			result := checks.License(&req)
+
+			Expect(scut.ValidateTestReturn(nil, "license found", &expected, &result,
+				&dl)).Should(BeTrue())
+		})
 		It("Should return license check works at commitSHA - GitLab", func() {
 			skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
 
@@ -166,8 +194,8 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         10,
-				NumberOfWarn:  0,
-				NumberOfInfo:  2,
+				NumberOfWarn:  1,
+				NumberOfInfo:  1,
 				NumberOfDebug: 0,
 			}
 			result := checks.License(&req)

--- a/e2e/license_test.go
+++ b/e2e/license_test.go
@@ -123,7 +123,7 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
 
 			dl := scut.TestDetailLogger{}
-			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/N8BWert/scorecard-check-license-e2e")
+			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/ossf-test/scorecard-check-license-e2e")
 			Expect(err).Should(BeNil())
 			repoClient, err := gitlabrepo.CreateGitlabClient(context.Background(), repo.Host())
 			Expect(err).Should(BeNil())
@@ -137,9 +137,9 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         9,
-				NumberOfWarn:  1,
-				NumberOfInfo:  1,
+				Score:         10,
+				NumberOfWarn:  0,
+				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			}
 			result := checks.License(&req)
@@ -151,7 +151,7 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
 
 			dl := scut.TestDetailLogger{}
-			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/N8BWert/scorecard-check-license-e2e")
+			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/ossf-test/scorecard-check-license-e2e")
 			Expect(err).Should(BeNil())
 			repoClient, err := gitlabrepo.CreateGitlabClient(context.Background(), repo.Host())
 			Expect(err).Should(BeNil())
@@ -165,9 +165,9 @@ var _ = Describe("E2E TEST:"+checks.CheckLicense, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         9,
-				NumberOfWarn:  1,
-				NumberOfInfo:  1,
+				Score:         10,
+				NumberOfWarn:  0,
+				NumberOfInfo:  2,
 				NumberOfDebug: 0,
 			}
 			result := checks.License(&req)


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Updates the GitLab client so that we can get SPDXId from the GitLab API. A software license's SPDXId allows us to determine whether a GitLab repo's License is FSF/OSI-recognized, and get the last 1/10 points on the License check, which was previously impossible for GitLab repos.

Fixes #3333.