### PR TITLE
:bug: Ignore missing tarballs for empty org .github repos

### DIFF
--- a/clients/githubrepo/tarball.go
+++ b/clients/githubrepo/tarball.go
@@ -35,8 +35,9 @@ import (
 )
 
 const (
-	repoDir      = "repo*"
-	repoFilename = "githubrepo*.tar.gz"
+	repoDir       = "repo*"
+	repoFilename  = "githubrepo*.tar.gz"
+	orgGithubRepo = ".github"
 )
 
 var (
@@ -94,6 +95,11 @@ func (handler *tarballHandler) setup() error {
 
 		// Setup temp dir/files and download repo tarball.
 		if err := handler.getTarball(); errors.Is(err, errTarballNotFound) {
+			// don't warn for "someorg/.github" repos
+			// https://github.com/ossf/scorecard/issues/3076
+			if handler.repo.GetName() == orgGithubRepo {
+				return
+			}
 			log.Printf("unable to get tarball %v. Skipping...", err)
 			return
 		} else if err != nil {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
> If the Security-Policy check is run for a repo owned by an org with an empty .github repo, it runs a warning.

#### What is the new behavior (if this is a feature change)?**
the error doesn't print if the repo being looked at is `.github`

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #3076
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
The Security-Policy check will no longer print to the log if the org's .github repo is empty.
```
