### PR TITLE
:bug: Dependency-Pinning Scoring

### DIFF
--- a/attestor/policy/attestation_policy_test.go
+++ b/attestor/policy/attestation_policy_test.go
@@ -651,7 +651,7 @@ func TestAttestationPolicy_EvaluateResults(t *testing.T) {
 				raw: &checker.RawResults{
 					PinningDependenciesResults: checker.PinningDependenciesData{
 						Dependencies: []checker.Dependency{
-							{Name: asPointer("foo"), PinnedAt: asPointer("abcdef")},
+							{Name: asStringPointer("foo"), PinnedAt: asStringPointer("abcdef")},
 						},
 					},
 				},

--- a/attestor/policy/attestation_policy_test.go
+++ b/attestor/policy/attestation_policy_test.go
@@ -379,7 +379,7 @@ func TestCheckCodeReviewed(t *testing.T) {
 	}
 }
 
-func asPointer(s string) *string {
+func asStringPointer(s string) *string {
 	return &s
 }
 
@@ -399,7 +399,7 @@ func TestNoUnpinnedDependencies(t *testing.T) {
 			raw: &checker.RawResults{
 				PinningDependenciesResults: checker.PinningDependenciesData{
 					Dependencies: []checker.Dependency{
-						{Name: asPointer("foo"), PinnedAt: asPointer("abcdef")},
+						{Name: asStringPointer("foo"), PinnedAt: asStringPointer("abcdef")},
 					},
 				},
 			},
@@ -413,7 +413,7 @@ func TestNoUnpinnedDependencies(t *testing.T) {
 			raw: &checker.RawResults{
 				PinningDependenciesResults: checker.PinningDependenciesData{
 					Dependencies: []checker.Dependency{
-						{Name: asPointer("foo"), PinnedAt: nil},
+						{Name: asStringPointer("foo"), PinnedAt: nil},
 					},
 				},
 			},
@@ -427,7 +427,7 @@ func TestNoUnpinnedDependencies(t *testing.T) {
 			raw: &checker.RawResults{
 				PinningDependenciesResults: checker.PinningDependenciesData{
 					Dependencies: []checker.Dependency{
-						{Name: asPointer("foo"), PinnedAt: nil},
+						{Name: asStringPointer("foo"), PinnedAt: nil},
 					},
 				},
 			},
@@ -439,7 +439,7 @@ func TestNoUnpinnedDependencies(t *testing.T) {
 			raw: &checker.RawResults{
 				PinningDependenciesResults: checker.PinningDependenciesData{
 					Dependencies: []checker.Dependency{
-						{Name: asPointer("second-pkg"), Location: &checker.File{Path: "bar"}, PinnedAt: nil},
+						{Name: asStringPointer("second-pkg"), Location: &checker.File{Path: "bar"}, PinnedAt: nil},
 					},
 				},
 			},

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -122,6 +122,7 @@ type Dependency struct {
 	Location *File
 	Msg      *string // Only for debug messages.
 	Type     DependencyUseType
+	Pinned   bool
 }
 
 // MaintainedData contains the raw results

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -122,7 +122,7 @@ type Dependency struct {
 	Location *File
 	Msg      *string // Only for debug messages.
 	Type     DependencyUseType
-	Pinned   bool
+	Pinned   *bool
 }
 
 // MaintainedData contains the raw results

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -121,8 +121,8 @@ type Dependency struct {
 	PinnedAt *string
 	Location *File
 	Msg      *string // Only for debug messages.
-	Type     DependencyUseType
 	Pinned   *bool
+	Type     DependencyUseType
 }
 
 // MaintainedData contains the raw results

--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -337,20 +337,24 @@ func createReturnValuesForGitHubActionsWorkflowPinned(r worklowPinningResult, ma
 
 	if r.gitHubOwned.total == r.gitHubOwned.pinned {
 		score += 2
-		dl.Info(&checker.LogMessage{
-			Type:   finding.FileTypeSource,
-			Offset: checker.OffsetDefault,
-			Text:   fmt.Sprintf("%s %s", "GitHub-owned", maxResultMsg),
-		})
+		if r.gitHubOwned.total != 0 {
+			dl.Info(&checker.LogMessage{
+				Type:   finding.FileTypeSource,
+				Offset: checker.OffsetDefault,
+				Text:   fmt.Sprintf("%s %s", "GitHub-owned", maxResultMsg),
+			})
+		}
 	}
 
 	if r.thirdParties.total == r.thirdParties.pinned {
 		score += 8
-		dl.Info(&checker.LogMessage{
-			Type:   finding.FileTypeSource,
-			Offset: checker.OffsetDefault,
-			Text:   fmt.Sprintf("%s %s", "Third-party", maxResultMsg),
-		})
+		if r.thirdParties.total != 0 {
+			dl.Info(&checker.LogMessage{
+				Type:   finding.FileTypeSource,
+				Offset: checker.OffsetDefault,
+				Text:   fmt.Sprintf("%s %s", "Third-party", maxResultMsg),
+			})
+		}
 	}
 
 	return score, nil

--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -181,7 +181,7 @@ func updatePinningResults(rr *checker.Dependency,
 	}
 
 	// Update other result types.
-	var p pinnedResult = pr[rr.Type]
+	p := pr[rr.Type]
 	addPinnedResult(rr, &p)
 	pr[rr.Type] = p
 }
@@ -290,17 +290,18 @@ func createReturnValues(pr map[checker.DependencyUseType]pinnedResult,
 	//nolint
 	r := pr[t]
 
-	if r.total == 0 {
+	switch r.total {
+	case 0:
 		dl.Info(&checker.LogMessage{
 			Text: inconclusiveResultMsg,
 		})
 		return checker.InconclusiveResultScore, nil
-	} else if r.total == r.pinned {
+	case r.pinned:
 		dl.Info(&checker.LogMessage{
 			Text: maxResultMsg,
 		})
 		return checker.MaxResultScore, nil
-	} else {
+	default:
 		return checker.MinResultScore, nil
 	}
 }

--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -144,6 +144,10 @@ func PinningDependencies(name string, c *checker.CheckRequest,
 		}
 	}
 
+	if len(conclusiveScores) == 0 {
+		return checker.CreateInconclusiveResult(name, "no dependencies found")
+	}
+
 	score := checker.AggregateScores(conclusiveScores...)
 
 	if score == checker.MaxResultScore {

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+
 	"github.com/ossf/scorecard/v4/checker"
 	scut "github.com/ossf/scorecard/v4/utests"
 )
@@ -30,8 +31,8 @@ func Test_createReturnForIsGitHubActionsWorkflowPinned(t *testing.T) {
 		dl *scut.TestDetailLogger
 	}
 	type want struct {
-		score int
 		logs  []string
+		score int
 	}
 	//nolint
 	tests := []struct {
@@ -679,7 +680,8 @@ func Test_createReturnValues(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := createReturnValues(tt.args.pr, tt.args.t, "all dependencies are pinned", "no dependencies found", tt.args.dl)
+			got, err := createReturnValues(tt.args.pr, tt.args.t, "all dependencies are pinned",
+				"no dependencies found", tt.args.dl)
 			if err != nil {
 				t.Errorf("error during createReturnValues: %v", err)
 			}
@@ -837,12 +839,14 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 			t.Parallel()
 			addWorkflowPinnedResult(tt.args.dependency, tt.args.w, tt.args.isGitHub)
 			if tt.want.thirdParties != tt.args.w.thirdParties {
-				t.Errorf("addWorkflowPinnedResult Third-party GitHub actions mismatch (-want +got):\nThird-party pinned: %s\nThird-party total: %s",
+				t.Errorf("addWorkflowPinnedResult Third-party GitHub actions mismatch (-want +got):"+
+					"\nThird-party pinned: %s\nThird-party total: %s",
 					cmp.Diff(tt.want.thirdParties.pinned, tt.args.w.thirdParties.pinned),
 					cmp.Diff(tt.want.thirdParties.total, tt.args.w.thirdParties.total))
 			}
 			if tt.want.gitHubOwned != tt.args.w.gitHubOwned {
-				t.Errorf("addWorkflowPinnedResult GitHub-owned GitHub actions mismatch (-want +got):\nGitHub-owned pinned: %s\nGitHub-owned total: %s",
+				t.Errorf("addWorkflowPinnedResult GitHub-owned GitHub actions mismatch (-want +got):"+
+					"\nGitHub-owned pinned: %s\nGitHub-owned total: %s",
 					cmp.Diff(tt.want.gitHubOwned.pinned, tt.args.w.gitHubOwned.pinned),
 					cmp.Diff(tt.want.gitHubOwned.total, tt.args.w.gitHubOwned.total))
 			}
@@ -1059,12 +1063,14 @@ func TestUpdatePinningResults(t *testing.T) {
 			t.Parallel()
 			updatePinningResults(tc.args.dependency, tc.args.w, tc.args.pr)
 			if tc.want.w.thirdParties != tc.args.w.thirdParties {
-				t.Errorf("updatePinningResults Third-party GitHub actions mismatch (-want +got):\nThird-party pinned: %s\nThird-party total: %s",
+				t.Errorf("updatePinningResults Third-party GitHub actions mismatch (-want +got):"+
+					"\nThird-party pinned: %s\nThird-party total: %s",
 					cmp.Diff(tc.want.w.thirdParties.pinned, tc.args.w.thirdParties.pinned),
 					cmp.Diff(tc.want.w.thirdParties.total, tc.args.w.thirdParties.total))
 			}
 			if tc.want.w.gitHubOwned != tc.args.w.gitHubOwned {
-				t.Errorf("updatePinningResults GitHub-owned GitHub actions mismatch (-want +got):\nGitHub-owned pinned: %s\nGitHub-owned total: %s",
+				t.Errorf("updatePinningResults GitHub-owned GitHub actions mismatch (-want +got):"+
+					"\nGitHub-owned pinned: %s\nGitHub-owned total: %s",
 					cmp.Diff(tc.want.w.gitHubOwned.pinned, tc.args.w.gitHubOwned.pinned),
 					cmp.Diff(tc.want.w.gitHubOwned.total, tc.args.w.gitHubOwned.total))
 			}

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -1012,6 +1012,46 @@ func TestUpdatePinningResults(t *testing.T) {
 				pr: make(map[checker.DependencyUseType]pinnedResult),
 			},
 		},
+		{
+			name: "add pinned pip install",
+			args: args{
+				dependency: &checker.Dependency{
+					Type:   checker.DependencyUseTypePipCommand,
+					Pinned: asBoolPointer(true),
+				},
+				w:  &worklowPinningResult{},
+				pr: make(map[checker.DependencyUseType]pinnedResult),
+			},
+			want: want{
+				w: &worklowPinningResult{},
+				pr: map[checker.DependencyUseType]pinnedResult{
+					checker.DependencyUseTypePipCommand: {
+						pinned: 1,
+						total:  1,
+					},
+				},
+			},
+		},
+		{
+			name: "add unpinned pip install",
+			args: args{
+				dependency: &checker.Dependency{
+					Type:   checker.DependencyUseTypePipCommand,
+					Pinned: asBoolPointer(false),
+				},
+				w:  &worklowPinningResult{},
+				pr: make(map[checker.DependencyUseType]pinnedResult),
+			},
+			want: want{
+				w: &worklowPinningResult{},
+				pr: map[checker.DependencyUseType]pinnedResult{
+					checker.DependencyUseTypePipCommand: {
+						pinned: 0,
+						total:  1,
+					},
+				},
+			},
+		},
 	}
 	for _, tc := range tests {
 		tc := tc
@@ -1027,6 +1067,14 @@ func TestUpdatePinningResults(t *testing.T) {
 				t.Errorf("updatePinningResults GitHub-owned GitHub actions mismatch (-want +got):\nGitHub-owned pinned: %s\nGitHub-owned total: %s",
 					cmp.Diff(tc.want.w.gitHubOwned.pinned, tc.args.w.gitHubOwned.pinned),
 					cmp.Diff(tc.want.w.gitHubOwned.total, tc.args.w.gitHubOwned.total))
+			}
+			for dependencyUseType := range tc.want.pr {
+				if tc.want.pr[dependencyUseType] != tc.args.pr[dependencyUseType] {
+					t.Errorf("updatePinningResults %s mismatch (-want +got):\npinned: %s\ntotal: %s",
+						dependencyUseType,
+						cmp.Diff(tc.want.pr[dependencyUseType].pinned, tc.args.pr[dependencyUseType].pinned),
+						cmp.Diff(tc.want.pr[dependencyUseType].total, tc.args.pr[dependencyUseType].total))
+				}
 			}
 		})
 	}

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -186,7 +186,7 @@ func Test_PinningDependencies(t *testing.T) {
 				{
 					Location: &checker.File{},
 					Type:     checker.DependencyUseTypePipCommand,
-					Msg:      asPointer("debug message"),
+					Msg:      asStringPointer("debug message"),
 				},
 			},
 			expected: scut.TestReturn{
@@ -224,7 +224,7 @@ func Test_PinningDependencies(t *testing.T) {
 				},
 				{
 					Location: &checker.File{},
-					Msg:      asPointer("debug message"),
+					Msg:      asStringPointer("debug message"),
 				},
 			},
 			expected: scut.TestReturn{

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -86,7 +86,7 @@ func Test_createReturnValuesForGitHubActionsWorkflowPinned(t *testing.T) {
 	}
 }
 
-func asPointer(s string) *string {
+func asStringPointer(s string) *string {
 	return &s
 }
 
@@ -103,7 +103,7 @@ func Test_PinningDependencies(t *testing.T) {
 			dependencies: []checker.Dependency{
 				{
 					Location: &checker.File{},
-					Msg:      asPointer("some message"),
+					Msg:      asStringPointer("some message"),
 					Type:     checker.DependencyUseTypeDownloadThenRun,
 				},
 			},
@@ -120,7 +120,7 @@ func Test_PinningDependencies(t *testing.T) {
 			dependencies: []checker.Dependency{
 				{
 					Location: &checker.File{},
-					Msg:      asPointer("some message"),
+					Msg:      asStringPointer("some message"),
 					Type:     checker.DependencyUseTypeDownloadThenRun,
 				},
 				{
@@ -153,7 +153,7 @@ func Test_PinningDependencies(t *testing.T) {
 				},
 				{
 					Location: &checker.File{},
-					Msg:      asPointer("debug message"),
+					Msg:      asStringPointer("debug message"),
 				},
 			},
 			expected: scut.TestReturn{

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -710,53 +710,6 @@ func Test_createReturnValues(t *testing.T) {
 	}
 }
 
-func Test_maxScore(t *testing.T) {
-	t.Parallel()
-	type args struct {
-		s1 int
-		s2 int
-	}
-	tests := []struct {
-		name string
-		args args
-		want int
-	}{
-		{
-			name: "returns s1 if s1 is greater than s2",
-			args: args{
-				s1: 10,
-				s2: 5,
-			},
-			want: 10,
-		},
-		{
-			name: "returns s2 if s2 is greater than s1",
-			args: args{
-				s1: 5,
-				s2: 10,
-			},
-			want: 10,
-		},
-		{
-			name: "returns s1 if s1 is equal to s2",
-			args: args{
-				s1: 10,
-				s2: 10,
-			},
-			want: 10,
-		},
-	}
-	for _, tt := range tests {
-		tt := tt
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-			if got := maxScore(tt.args.s1, tt.args.s2); got != tt.want {
-				t.Errorf("maxScore() = %v, want %v", got, tt.want)
-			}
-		})
-	}
-}
-
 func Test_generateOwnerToDisplay(t *testing.T) {
 	t.Parallel()
 	tests := []struct { //nolint:govet

--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -49,8 +49,8 @@ func DependencyUpdateTool(c clients.RepoClient) (checker.DependencyUpdateToolDat
 		if commits[i].Committer.ID == dependabotID {
 			tools = append(tools, checker.Tool{
 				Name:  "Dependabot",
-				URL:   asPointer("https://github.com/dependabot"),
-				Desc:  asPointer("Automated dependency updates built into GitHub"),
+				URL:   asStringPointer("https://github.com/dependabot"),
+				Desc:  asStringPointer("Automated dependency updates built into GitHub"),
 				Files: []checker.File{{}},
 			})
 			break
@@ -74,8 +74,8 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 	case ".github/dependabot.yml", ".github/dependabot.yaml":
 		*ptools = append(*ptools, checker.Tool{
 			Name: "Dependabot",
-			URL:  asPointer("https://github.com/dependabot"),
-			Desc: asPointer("Automated dependency updates built into GitHub"),
+			URL:  asStringPointer("https://github.com/dependabot"),
+			Desc: asStringPointer("Automated dependency updates built into GitHub"),
 			Files: []checker.File{
 				{
 					Path:   name,
@@ -90,8 +90,8 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 		"renovate.json5", ".renovaterc":
 		*ptools = append(*ptools, checker.Tool{
 			Name: "RenovateBot",
-			URL:  asPointer("https://github.com/renovatebot/renovate"),
-			Desc: asPointer("Automated dependency updates. Multi-platform and multi-language."),
+			URL:  asStringPointer("https://github.com/renovatebot/renovate"),
+			Desc: asStringPointer("Automated dependency updates. Multi-platform and multi-language."),
 			Files: []checker.File{
 				{
 					Path:   name,
@@ -103,8 +103,8 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 	case ".pyup.yml":
 		*ptools = append(*ptools, checker.Tool{
 			Name: "PyUp",
-			URL:  asPointer("https://pyup.io/"),
-			Desc: asPointer("Automated dependency updates for Python."),
+			URL:  asStringPointer("https://pyup.io/"),
+			Desc: asStringPointer("Automated dependency updates for Python."),
 			Files: []checker.File{
 				{
 					Path:   name,
@@ -116,8 +116,8 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 	case ".lift.toml", ".lift/config.toml":
 		*ptools = append(*ptools, checker.Tool{
 			Name: "Sonatype Lift",
-			URL:  asPointer("https://lift.sonatype.com"),
-			Desc: asPointer("Automated dependency updates. Multi-platform and multi-language."),
+			URL:  asStringPointer("https://lift.sonatype.com"),
+			Desc: asStringPointer("Automated dependency updates. Multi-platform and multi-language."),
 			Files: []checker.File{
 				{
 					Path:   name,
@@ -133,6 +133,6 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 	return true, nil
 }
 
-func asPointer(s string) *string {
+func asStringPointer(s string) *string {
 	return &s
 }

--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -136,3 +136,7 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 func asStringPointer(s string) *string {
 	return &s
 }
+
+func asBoolPointer(b bool) *bool {
+	return &b
+}

--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -62,8 +62,8 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		filePattern: "*_test.go",
 		funcPattern: `func\s+Fuzz\w+\s*\(\w+\s+\*testing.F\)`,
 		Name:        fuzzerBuiltInGo,
-		URL:         asPointer("https://go.dev/doc/fuzz/"),
-		Desc: asPointer(
+		URL:         asStringPointer("https://go.dev/doc/fuzz/"),
+		Desc: asStringPointer(
 			"Go fuzzing intelligently walks through the source code to report failures and find vulnerabilities."),
 	},
 	// Fuzz patterns for Haskell based on property-based testing.
@@ -127,8 +127,8 @@ func Fuzzing(c *checker.CheckRequest) (checker.FuzzingData, error) {
 		fuzzers = append(fuzzers,
 			checker.Tool{
 				Name: fuzzerClusterFuzzLite,
-				URL:  asPointer("https://github.com/google/clusterfuzzlite"),
-				Desc: asPointer("continuous fuzzing solution that runs as part of Continuous Integration (CI) workflows"),
+				URL:  asStringPointer("https://github.com/google/clusterfuzzlite"),
+				Desc: asStringPointer("continuous fuzzing solution that runs as part of Continuous Integration (CI) workflows"),
 				// TODO: File.
 			},
 		)
@@ -142,8 +142,8 @@ func Fuzzing(c *checker.CheckRequest) (checker.FuzzingData, error) {
 		fuzzers = append(fuzzers,
 			checker.Tool{
 				Name: oneFuzz,
-				URL:  asPointer("https://github.com/microsoft/onefuzz"),
-				Desc: asPointer("Enables continuous developer-driven fuzzing to proactively harden software prior to release."),
+				URL:  asStringPointer("https://github.com/microsoft/onefuzz"),
+				Desc: asStringPointer("Enables continuous developer-driven fuzzing to proactively harden software prior to release."),
 				// TODO: File.
 			},
 		)
@@ -157,8 +157,8 @@ func Fuzzing(c *checker.CheckRequest) (checker.FuzzingData, error) {
 		fuzzers = append(fuzzers,
 			checker.Tool{
 				Name: fuzzerOSSFuzz,
-				URL:  asPointer("https://github.com/google/oss-fuzz"),
-				Desc: asPointer("Continuous Fuzzing for Open Source Software"),
+				URL:  asStringPointer("https://github.com/google/oss-fuzz"),
+				Desc: asStringPointer("Continuous Fuzzing for Open Source Software"),
 				// TODO: File.
 			},
 		)

--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -143,7 +143,9 @@ func Fuzzing(c *checker.CheckRequest) (checker.FuzzingData, error) {
 			checker.Tool{
 				Name: oneFuzz,
 				URL:  asStringPointer("https://github.com/microsoft/onefuzz"),
-				Desc: asStringPointer("Enables continuous developer-driven fuzzing to proactively harden software prior to release."),
+				Desc: asStringPointer(
+					"Enables continuous developer-driven fuzzing to proactively harden software prior to release.",
+				),
 				// TODO: File.
 			},
 		)

--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -85,7 +85,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		// or their indirect imports through the higher-level Hspec or Tasty testing frameworks.
 		funcPattern: `import\s+(qualified\s+)?Test\.((Hspec|Tasty)\.)?(QuickCheck|Hedgehog|Validity|SmallCheck)`,
 		Name:        fuzzerPropertyBasedHaskell,
-		Desc: asPointer(
+		Desc: asStringPointer(
 			"Property-based testing in Haskell generates test instances randomly or exhaustively " +
 				"and test that specific properties are satisfied."),
 	},
@@ -100,7 +100,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		// Look for direct imports of fast-check.
 		funcPattern: `(from\s+['"]fast-check['"]|require\(\s*['"]fast-check['"]\s*\))`,
 		Name:        fuzzerPropertyBasedJavaScript,
-		Desc: asPointer(
+		Desc: asStringPointer(
 			"Property-based testing in JavaScript generates test instances randomly or exhaustively " +
 				"and test that specific properties are satisfied."),
 	},
@@ -109,7 +109,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		// Look for direct imports of fast-check.
 		funcPattern: `(from\s+['"]fast-check['"]|require\(\s*['"]fast-check['"]\s*\))`,
 		Name:        fuzzerPropertyBasedTypeScript,
-		Desc: asPointer(
+		Desc: asStringPointer(
 			"Property-based testing in TypeScript generates test instances randomly or exhaustively " +
 				"and test that specific properties are satisfied."),
 	},

--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -272,8 +272,8 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 						EndOffset: uint(child.EndLine),
 						Snippet:   child.Original,
 					},
-					Name:     asPointer(name),
-					PinnedAt: asPointer(asName),
+					Name:     asStringPointer(name),
+					PinnedAt: asStringPointer(asName),
 					Pinned:   pinned || regex.MatchString(name),
 					Type:     checker.DependencyUseTypeDockerfileContainerImage,
 				},
@@ -297,9 +297,9 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 			}
 			parts := strings.SplitN(name, ":", 2)
 			if len(parts) > 0 {
-				dep.Name = asPointer(parts[0])
+				dep.Name = asStringPointer(parts[0])
 				if len(parts) > 1 {
-					dep.PinnedAt = asPointer(parts[1])
+					dep.PinnedAt = asStringPointer(parts[1])
 				}
 			}
 			pdata.Dependencies = append(pdata.Dependencies, dep)
@@ -394,7 +394,7 @@ var validateGitHubWorkflowIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFile
 			if err := validateShellFile(pathfn, uint(execRun.Run.Pos.Line), uint(execRun.Run.Pos.Line),
 				script, taintedFiles, pdata); err != nil {
 				pdata.Dependencies = append(pdata.Dependencies, checker.Dependency{
-					Msg: asPointer(err.Error()),
+					Msg: asStringPointer(err.Error()),
 				})
 			}
 		}
@@ -482,9 +482,9 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 			}
 			parts := strings.SplitN(execAction.Uses.Value, "@", 2)
 			if len(parts) > 0 {
-				dep.Name = asPointer(parts[0])
+				dep.Name = asStringPointer(parts[0])
 				if len(parts) > 1 {
-					dep.PinnedAt = asPointer(parts[1])
+					dep.PinnedAt = asStringPointer(parts[1])
 				}
 			}
 			pdata.Dependencies = append(pdata.Dependencies, dep)

--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -274,7 +274,7 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 					},
 					Name:     asStringPointer(name),
 					PinnedAt: asStringPointer(asName),
-					Pinned:   pinned || regex.MatchString(name),
+					Pinned:   asBoolPointer(pinned || regex.MatchString(name)),
 					Type:     checker.DependencyUseTypeDockerfileContainerImage,
 				},
 			)
@@ -292,7 +292,7 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 					EndOffset: uint(child.EndLine),
 					Snippet:   child.Original,
 				},
-				Pinned: pinned || regex.MatchString(name),
+				Pinned: asBoolPointer(pinned || regex.MatchString(name)),
 				Type:   checker.DependencyUseTypeDockerfileContainerImage,
 			}
 			parts := strings.SplitN(name, ":", 2)
@@ -477,7 +477,7 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 					EndOffset: uint(execAction.Uses.Pos.Line), // `Uses` always span a single line.
 					Snippet:   execAction.Uses.Value,
 				},
-				Pinned: isActionDependencyPinned(execAction.Uses.Value),
+				Pinned: asBoolPointer(isActionDependencyPinned(execAction.Uses.Value)),
 				Type:   checker.DependencyUseTypeGHAction,
 			}
 			parts := strings.SplitN(execAction.Uses.Value, "@", 2)

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -92,8 +92,10 @@ func TestGithubWorkflowPinning(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -241,8 +243,10 @@ func TestNonGithubWorkflowPinning(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -288,8 +292,10 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -365,8 +371,10 @@ func TestDockerfilePinning(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -919,8 +927,10 @@ func TestDockerfilePinningWihoutHash(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -1022,8 +1032,10 @@ func TestDockerfileScriptDownload(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -1064,8 +1076,10 @@ func TestDockerfileScriptDownloadInfo(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -1140,12 +1154,14 @@ func TestShellScriptDownload(t *testing.T) {
 				return
 			}
 
+			unpinned := countUnpinned(r.Dependencies)
+
 			// Note: this works because all our examples
 			// either have warns or debugs.
-			ws := (tt.warns == len(r.Dependencies)) && (tt.debugs == 0)
-			ds := (tt.debugs == len(r.Dependencies)) && (tt.warns == 0)
+			ws := (tt.warns == unpinned) && (tt.debugs == 0)
+			ds := (tt.debugs == unpinned) && (tt.warns == 0)
 			if !ws && !ds {
-				t.Errorf("expected %v or %v. Got %v", tt.warns, tt.debugs, len(r.Dependencies))
+				t.Errorf("expected %v or %v. Got %v", tt.warns, tt.debugs, unpinned)
 			}
 		})
 	}
@@ -1192,8 +1208,10 @@ func TestShellScriptDownloadPinned(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -1251,8 +1269,10 @@ func TestGitHubWorflowRunDownload(t *testing.T) {
 				return
 			}
 
-			if tt.warns != len(r.Dependencies) {
-				t.Errorf("expected %v. Got %v", tt.warns, len(r.Dependencies))
+			unpinned := countUnpinned(r.Dependencies)
+
+			if tt.warns != unpinned {
+				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
 	}
@@ -1408,4 +1428,16 @@ func TestGitHubWorkInsecureDownloadsLineNumber(t *testing.T) {
 			}
 		})
 	}
+}
+
+func countUnpinned(r []checker.Dependency) int {
+	var unpinned int
+
+	for _, dependency := range r {
+		if *dependency.Pinned == false {
+			unpinned += 1
+		}
+	}
+
+	return unpinned
 }

--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -725,7 +725,9 @@ func isDotNetCliInstall(cmd []string) bool {
 	}
 	// Search for dotnet add <PROJECT> package <PACKAGE_NAME>
 	// where package command can be either the second or the third word
-	return (isBinaryName("dotnet", cmd[0]) || isBinaryName("dotnet.exe", cmd[0])) && strings.EqualFold(cmd[1], "add") && (strings.EqualFold(cmd[2], "package") || strings.EqualFold(cmd[3], "package"))
+	return (isBinaryName("dotnet", cmd[0]) || isBinaryName("dotnet.exe", cmd[0])) &&
+		strings.EqualFold(cmd[1], "add") &&
+		(strings.EqualFold(cmd[2], "package") || strings.EqualFold(cmd[3], "package"))
 }
 
 func isUnpinnedDotNetCliInstall(cmd []string) bool {
@@ -864,7 +866,7 @@ func collectUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.N
 					Snippet:   cmd,
 				},
 				Pinned: asBoolPointer(!isNugetUnpinnedDownload(c)),
-				Type: checker.DependencyUseTypeNugetCommand,
+				Type:   checker.DependencyUseTypeNugetCommand,
 			},
 		)
 

--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -337,7 +337,7 @@ func collectFetchPipeExecute(startLine, endLine uint, node syntax.Node, cmd, pat
 				EndOffset: endLine,
 				Snippet:   cmd,
 			},
-			Pinned: false,
+			Pinned: asBoolPointer(false),
 			Type:   checker.DependencyUseTypeDownloadThenRun,
 		},
 	)
@@ -389,7 +389,7 @@ func collectExecuteFiles(startLine, endLine uint, node syntax.Node, cmd, pathfn 
 						EndOffset: endLine,
 						Snippet:   cmd,
 					},
-					Pinned: false,
+					Pinned: asBoolPointer(false),
 					Type:   checker.DependencyUseTypeDownloadThenRun,
 				},
 			)
@@ -797,7 +797,7 @@ func collectUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.N
 					EndOffset: endLine,
 					Snippet:   cmd,
 				},
-				Pinned: !isGoUnpinnedDownload(c),
+				Pinned: asBoolPointer(!isGoUnpinnedDownload(c)),
 				Type:   checker.DependencyUseTypeGoCommand,
 			},
 		)
@@ -816,7 +816,7 @@ func collectUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.N
 					EndOffset: endLine,
 					Snippet:   cmd,
 				},
-				Pinned: !isPipUnpinnedDownload(c),
+				Pinned: asBoolPointer(!isPipUnpinnedDownload(c)),
 				Type:   checker.DependencyUseTypePipCommand,
 			},
 		)
@@ -835,7 +835,7 @@ func collectUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.N
 					EndOffset: endLine,
 					Snippet:   cmd,
 				},
-				Pinned: false,
+				Pinned: asBoolPointer(false),
 				Type:   checker.DependencyUseTypeNpmCommand,
 			},
 		)
@@ -854,7 +854,7 @@ func collectUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.N
 					EndOffset: endLine,
 					Snippet:   cmd,
 				},
-				Pinned: !isChocoUnpinnedDownload(c),
+				Pinned: asBoolPointer(!isChocoUnpinnedDownload(c)),
 				Type:   checker.DependencyUseTypeChocoCommand,
 			},
 		)
@@ -968,7 +968,7 @@ func collectFetchProcSubsExecute(startLine, endLine uint, node syntax.Node, cmd,
 				EndOffset: endLine,
 				Snippet:   cmd,
 			},
-			Pinned: false,
+			Pinned: asBoolPointer(false),
 			Type:   checker.DependencyUseTypeDownloadThenRun,
 		},
 	)

--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -680,22 +680,17 @@ func isChocoUnpinnedDownload(cmd []string) bool {
 	return true
 }
 
-func isUnpinnedNugetCliInstall(cmd []string) bool {
+func isNugetCliInstall(cmd []string) bool {
 	// looking for command of type nuget install ...
 	if len(cmd) < 2 {
 		return false
 	}
 
-	// Search for nuget commands.
-	if !isBinaryName("nuget", cmd[0]) && !isBinaryName("nuget.exe", cmd[0]) {
-		return false
-	}
+	// Search for nuget install commands.
+	return (isBinaryName("nuget", cmd[0]) || isBinaryName("nuget.exe", cmd[0])) && strings.EqualFold(cmd[1], "install")
+}
 
-	// Search for install commands.
-	if !strings.EqualFold(cmd[1], "install") {
-		return false
-	}
-
+func isUnpinnedNugetCliInstall(cmd []string) bool {
 	// Assume installing a project with PackageReference (with versions)
 	// or packages.config at the root of command
 	if len(cmd) == 2 {
@@ -723,26 +718,17 @@ func isUnpinnedNugetCliInstall(cmd []string) bool {
 	return unpinnedDependency
 }
 
-func isUnpinnedDotNetCliInstall(cmd []string) bool {
+func isDotNetCliInstall(cmd []string) bool {
 	// Search for command of type dotnet add <PROJECT> package <PACKAGE_NAME>
 	if len(cmd) < 4 {
 		return false
 	}
-	// Search for dotnet commands.
-	if !isBinaryName("dotnet", cmd[0]) && !isBinaryName("dotnet.exe", cmd[0]) {
-		return false
-	}
+	// Search for dotnet add <PROJECT> package <PACKAGE_NAME>
+	// where package command can be either the second or the third word
+	return (isBinaryName("dotnet", cmd[0]) || isBinaryName("dotnet.exe", cmd[0])) && strings.EqualFold(cmd[1], "add") && (strings.EqualFold(cmd[2], "package") || strings.EqualFold(cmd[3], "package"))
+}
 
-	// Search for add commands.
-	if !strings.EqualFold(cmd[1], "add") {
-		return false
-	}
-
-	// Search for package commands (can be either the second or the third word)
-	if !(strings.EqualFold(cmd[2], "package") || strings.EqualFold(cmd[3], "package")) {
-		return false
-	}
-
+func isUnpinnedDotNetCliInstall(cmd []string) bool {
 	unpinnedDependency := true
 	for i := 3; i < len(cmd); i++ {
 		// look for version flag
@@ -755,12 +741,16 @@ func isUnpinnedDotNetCliInstall(cmd []string) bool {
 	return unpinnedDependency
 }
 
+func isNugetDownload(cmd []string) bool {
+	return isDotNetCliInstall(cmd) || isNugetCliInstall(cmd)
+}
+
 func isNugetUnpinnedDownload(cmd []string) bool {
-	if isUnpinnedDotNetCliInstall(cmd) {
+	if isDotNetCliInstall(cmd) && isUnpinnedDotNetCliInstall(cmd) {
 		return true
 	}
 
-	if isUnpinnedNugetCliInstall(cmd) {
+	if isNugetCliInstall(cmd) && isUnpinnedNugetCliInstall(cmd) {
 		return true
 	}
 
@@ -863,7 +853,7 @@ func collectUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.N
 	}
 
 	// Nuget install.
-	if isNugetUnpinnedDownload(c) {
+	if isNugetDownload(c) {
 		r.Dependencies = append(r.Dependencies,
 			checker.Dependency{
 				Location: &checker.File{
@@ -873,6 +863,7 @@ func collectUnpinnedPakageManagerDownload(startLine, endLine uint, node syntax.N
 					EndOffset: endLine,
 					Snippet:   cmd,
 				},
+				Pinned: asBoolPointer(!isNugetUnpinnedDownload(c)),
 				Type: checker.DependencyUseTypeNugetCommand,
 			},
 		)

--- a/cron/worker/worker_test.go
+++ b/cron/worker/worker_test.go
@@ -23,7 +23,7 @@ import (
 	"github.com/ossf/scorecard/v4/cron/data"
 )
 
-func asPointer(i int32) *int32 {
+func asIntPointer(i int32) *int32 {
 	return &i
 }
 
@@ -38,7 +38,7 @@ func TestResultFilename(t *testing.T) {
 			name: "Basic",
 			req: &data.ScorecardBatchRequest{
 				JobTime:  timestamppb.New(time.Date(1979, time.October, 12, 1, 2, 3, 0, time.UTC)),
-				ShardNum: asPointer(42),
+				ShardNum: asIntPointer(42),
 			},
 			want: "1979.10.12/010203/shard-0000042",
 		},

--- a/dependencydiff/dependencydiff_test.go
+++ b/dependencydiff/dependencydiff_test.go
@@ -126,11 +126,11 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 			deps: []dependency{
 				{
 					Name:      "dependency_1",
-					Ecosystem: asPointer("not_supported"),
+					Ecosystem: asStringPointer("not_supported"),
 				},
 				{
 					Name:      "dependency_2",
-					Ecosystem: asPointer("gomod"),
+					Ecosystem: asStringPointer("gomod"),
 				},
 			},
 			errWanted: errInvalid,
@@ -140,7 +140,7 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 			deps: []dependency{
 				{
 					Name:      "dependency_3",
-					Ecosystem: asPointer("foobar"),
+					Ecosystem: asStringPointer("foobar"),
 				},
 			},
 			errWanted: errMappingNotFound,
@@ -150,19 +150,19 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 			deps: []dependency{
 				{
 					Name:      "dependency_4",
-					Ecosystem: asPointer("gomod"),
+					Ecosystem: asStringPointer("gomod"),
 				},
 				{
 					Name:      "dependency_5",
-					Ecosystem: asPointer("pip"),
+					Ecosystem: asStringPointer("pip"),
 				},
 				{
 					Name:      "dependency_6",
-					Ecosystem: asPointer("cargo"),
+					Ecosystem: asStringPointer("cargo"),
 				},
 				{
 					Name:      "dependency_7",
-					Ecosystem: asPointer("actions"),
+					Ecosystem: asStringPointer("actions"),
 				},
 			},
 		},

--- a/dependencydiff/mapping.go
+++ b/dependencydiff/mapping.go
@@ -22,7 +22,7 @@ import (
 type ecosystem string
 
 // OSV ecosystem naming data source: https://ossf.github.io/osv-schema/#affectedpackage-field
-//nolint
+// nolint
 const (
 	// The Go ecosystem.
 	ecosystemGo ecosystem = "Go"
@@ -101,7 +101,7 @@ func mapDependencyEcosystemNaming(deps []dependency) error {
 			// Iff. the ecosystem is not empty and the mapping entry is not found, we will return an error.
 			return fmt.Errorf("error mapping dependency ecosystem: %w", err)
 		}
-		deps[i].Ecosystem = asPointer(string(mappedEcosys))
+		deps[i].Ecosystem = asStringPointer(string(mappedEcosys))
 	}
 	return nil
 }
@@ -116,6 +116,6 @@ func toEcosystem(e string) (ecosystem, error) {
 	return "", fmt.Errorf("%w for github entry %s", errMappingNotFound, e)
 }
 
-func asPointer(s string) *string {
+func asStringPointer(s string) *string {
 	return &s
 }

--- a/e2e/pinned_dependencies_test.go
+++ b/e2e/pinned_dependencies_test.go
@@ -49,7 +49,7 @@ var _ = Describe("E2E TEST:"+checks.CheckPinnedDependencies, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         4,
+				Score:         3,
 				NumberOfWarn:  139,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
@@ -74,7 +74,7 @@ var _ = Describe("E2E TEST:"+checks.CheckPinnedDependencies, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         4,
+				Score:         3,
 				NumberOfWarn:  139,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,
@@ -110,7 +110,7 @@ var _ = Describe("E2E TEST:"+checks.CheckPinnedDependencies, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         4,
+				Score:         3,
 				NumberOfWarn:  139,
 				NumberOfInfo:  3,
 				NumberOfDebug: 0,

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -292,7 +292,7 @@ type jsonRawResults struct {
 	DependencyPinning jsonPinningDependenciesData `json:"dependencyPinning"`
 }
 
-func asPointer(s string) *string {
+func asStringPointer(s string) *string {
 	return &s
 }
 
@@ -312,7 +312,7 @@ func (r *jsonScorecardRawResult) addTokenPermissionsRawResults(tp *checker.Token
 		}
 
 		p := jsonTokenPermission{
-			LocationType: asPointer(string(*t.LocationType)),
+			LocationType: asStringPointer(string(*t.LocationType)),
 			Name:         t.Name,
 			Value:        t.Value,
 			Type:         string(t.Type),

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -331,7 +331,7 @@ func (r *jsonScorecardRawResult) addTokenPermissionsRawResults(tp *checker.Token
 				Offset: t.File.Offset,
 			}
 			if t.File.Snippet != "" {
-				p.File.Snippet = asPointer(t.File.Snippet)
+				p.File.Snippet = asStringPointer(t.File.Snippet)
 			}
 		}
 
@@ -361,7 +361,7 @@ func (r *jsonScorecardRawResult) addPackagingRawResults(pk *checker.PackagingDat
 		}
 
 		if p.File.Snippet != "" {
-			jpk.File.Snippet = asPointer(p.File.Snippet)
+			jpk.File.Snippet = asStringPointer(p.File.Snippet)
 		}
 
 		for _, run := range p.Runs {
@@ -419,7 +419,7 @@ func (r *jsonScorecardRawResult) addDangerousWorkflowRawResults(df *checker.Dang
 			Type: string(e.Type),
 		}
 		if e.File.Snippet != "" {
-			v.File.Snippet = asPointer(e.File.Snippet)
+			v.File.Snippet = asStringPointer(e.File.Snippet)
 		}
 		if e.Job != nil {
 			v.Job = &jsonWorkflowJob{

--- a/pkg/json_raw_results_test.go
+++ b/pkg/json_raw_results_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/ossf/scorecard/v4/clients"
 )
 
-func TestAsPointer(t *testing.T) {
+func TestAsStringPointer(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct { //nolint:govet
@@ -37,17 +37,17 @@ func TestAsPointer(t *testing.T) {
 		{
 			name:     "test_empty_string",
 			input:    "",
-			expected: asPointer(""),
+			expected: asStringPointer(""),
 		},
 		{
 			name:     "test_non_empty_string",
 			input:    "test",
-			expected: asPointer("test"),
+			expected: asStringPointer("test"),
 		},
 		{
 			name:     "test_number_string",
 			input:    "123",
-			expected: asPointer("123"),
+			expected: asStringPointer("123"),
 		},
 	}
 
@@ -55,9 +55,9 @@ func TestAsPointer(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			result := asPointer(tt.input)
+			result := asStringPointer(tt.input)
 			if *result != *tt.expected {
-				t.Errorf("asPointer() = %v, want %v", result, tt.expected)
+				t.Errorf("asStringPointer() = %v, want %v", result, tt.expected)
 			}
 		})
 	}
@@ -110,7 +110,7 @@ func TestJsonScorecardRawResult_AddPackagingRawResults(t *testing.T) {
 			input: &checker.PackagingData{
 				Packages: []checker.Package{
 					{
-						Msg: asPointer("testMsg"),
+						Msg: asStringPointer("testMsg"),
 					},
 				},
 			},
@@ -193,8 +193,8 @@ func TestJsonScorecardRawResult_AddTokenPermissionsRawResults(t *testing.T) {
 						LocationType: &loc,
 						Type:         checker.PermissionLevelUndeclared,
 						Job: &checker.WorkflowJob{
-							Name: asPointer("testJobName"),
-							ID:   asPointer("testJobID"),
+							Name: asStringPointer("testJobName"),
+							ID:   asStringPointer("testJobID"),
 						},
 						File: &checker.File{
 							Path:    "testPath",
@@ -250,8 +250,8 @@ func TestJsonScorecardRawResult_AddDependencyPinningRawResults(t *testing.T) {
 							EndOffset: 5,
 							Snippet:   "testSnippet",
 						},
-						Name:     asPointer("testDependency"),
-						PinnedAt: asPointer("testPinnedAt"),
+						Name:     asStringPointer("testDependency"),
+						PinnedAt: asStringPointer("testPinnedAt"),
 						Type:     checker.DependencyUseTypeGHAction,
 					},
 				},
@@ -264,8 +264,8 @@ func TestJsonScorecardRawResult_AddDependencyPinningRawResults(t *testing.T) {
 				Dependencies: []checker.Dependency{
 					{
 						Location: nil,
-						Name:     asPointer("testDependency"),
-						PinnedAt: asPointer("testPinnedAt"),
+						Name:     asStringPointer("testDependency"),
+						PinnedAt: asStringPointer("testPinnedAt"),
 						Type:     checker.DependencyUseTypeGHAction,
 					},
 				},
@@ -309,8 +309,8 @@ func TestJsonScorecardRawResult_AddDangerousWorkflowRawResults(t *testing.T) {
 						},
 						Type: checker.DangerousWorkflowScriptInjection,
 						Job: &checker.WorkflowJob{
-							Name: asPointer("testJob"),
-							ID:   asPointer("testID"),
+							Name: asStringPointer("testJob"),
+							ID:   asStringPointer("testID"),
 						},
 					},
 				},
@@ -437,7 +437,7 @@ func TestJsonScorecardRawResult_AddMaintainedRawResults(t *testing.T) {
 				CreatedAt: time.Now(),
 				Issues: []clients.Issue{
 					{
-						URI: asPointer("testUrl"),
+						URI: asStringPointer("testUrl"),
 						Author: &clients.User{
 							Login: "testLogin",
 						},
@@ -960,8 +960,8 @@ func TestAddFuzzingRawResults(t *testing.T) {
 		Fuzzers: []checker.Tool{
 			{
 				Name: "fuzzer1",
-				URL:  asPointer("https://example.com/fuzzer1"),
-				Desc: asPointer("Fuzzer 1 description"),
+				URL:  asStringPointer("https://example.com/fuzzer1"),
+				Desc: asStringPointer("Fuzzer 1 description"),
 				Files: []checker.File{
 					{
 						Path: "path/to/fuzzer1/file1",
@@ -973,8 +973,8 @@ func TestAddFuzzingRawResults(t *testing.T) {
 			},
 			{
 				Name: "fuzzer2",
-				URL:  asPointer("https://example.com/fuzzer2"),
-				Desc: asPointer("Fuzzer 2 description"),
+				URL:  asStringPointer("https://example.com/fuzzer2"),
+				Desc: asStringPointer("Fuzzer 2 description"),
 				Files: []checker.File{
 					{
 						Path: "path/to/fuzzer2/file1",
@@ -992,8 +992,8 @@ func TestAddFuzzingRawResults(t *testing.T) {
 	expectedFuzzers := []jsonTool{
 		{
 			Name: "fuzzer1",
-			URL:  asPointer("https://example.com/fuzzer1"),
-			Desc: asPointer("Fuzzer 1 description"),
+			URL:  asStringPointer("https://example.com/fuzzer1"),
+			Desc: asStringPointer("Fuzzer 1 description"),
 			Files: []jsonFile{
 				{
 					Path: "path/to/fuzzer1/file1",
@@ -1005,8 +1005,8 @@ func TestAddFuzzingRawResults(t *testing.T) {
 		},
 		{
 			Name: "fuzzer2",
-			URL:  asPointer("https://example.com/fuzzer2"),
-			Desc: asPointer("Fuzzer 2 description"),
+			URL:  asStringPointer("https://example.com/fuzzer2"),
+			Desc: asStringPointer("Fuzzer 2 description"),
 			Files: []jsonFile{
 				{
 					Path: "path/to/fuzzer2/file1",
@@ -1080,8 +1080,8 @@ func TestJsonScorecardRawResult(t *testing.T) {
 		Fuzzers: []checker.Tool{
 			{
 				Name: "fuzzer1",
-				URL:  asPointer("https://example.com/fuzzer1"),
-				Desc: asPointer("fuzzer1 description"),
+				URL:  asStringPointer("https://example.com/fuzzer1"),
+				Desc: asStringPointer("fuzzer1 description"),
 				Files: []checker.File{
 					{Path: "fuzzers/fuzzer1/foo"},
 					{Path: "fuzzers/fuzzer1/bar"},
@@ -1089,8 +1089,8 @@ func TestJsonScorecardRawResult(t *testing.T) {
 			},
 			{
 				Name: "fuzzer2",
-				URL:  asPointer("https://example.com/fuzzer2"),
-				Desc: asPointer("fuzzer2 description"),
+				URL:  asStringPointer("https://example.com/fuzzer2"),
+				Desc: asStringPointer("fuzzer2 description"),
 				Files: []checker.File{
 					{Path: "fuzzers/fuzzer2/foo"},
 					{Path: "fuzzers/fuzzer2/bar"},
@@ -1184,8 +1184,8 @@ func TestJsonScorecardRawResult(t *testing.T) {
 	expectedFuzzers := []jsonTool{
 		{
 			Name: "fuzzer1",
-			URL:  asPointer("https://example.com/fuzzer1"),
-			Desc: asPointer("fuzzer1 description"),
+			URL:  asStringPointer("https://example.com/fuzzer1"),
+			Desc: asStringPointer("fuzzer1 description"),
 			Files: []jsonFile{
 				{Path: "fuzzers/fuzzer1/foo"},
 				{Path: "fuzzers/fuzzer1/bar"},
@@ -1193,8 +1193,8 @@ func TestJsonScorecardRawResult(t *testing.T) {
 		},
 		{
 			Name: "fuzzer2",
-			URL:  asPointer("https://example.com/fuzzer1"),
-			Desc: asPointer("fuzzer1 description"),
+			URL:  asStringPointer("https://example.com/fuzzer1"),
+			Desc: asStringPointer("fuzzer1 description"),
 			Files: []jsonFile{
 				{Path: "fuzzers/fuzzer2/foo"},
 				{Path: "fuzzers/fuzzer2/bar"},

--- a/remediation/remediations_test.go
+++ b/remediation/remediations_test.go
@@ -52,7 +52,7 @@ func TestRepeatedSetup(t *testing.T) {
 	}
 }
 
-func asPointer(s string) *string {
+func asStringPointer(s string) *string {
 	return &s
 }
 
@@ -89,7 +89,7 @@ func TestCreateDockerfilePinningRemediation(t *testing.T) {
 		{
 			name: "image name no tag",
 			dep: checker.Dependency{
-				Name: asPointer("foo"),
+				Name: asStringPointer("foo"),
 				Type: checker.DependencyUseTypeDockerfileContainerImage,
 			},
 			expected: &rule.Remediation{
@@ -101,8 +101,8 @@ func TestCreateDockerfilePinningRemediation(t *testing.T) {
 			// github.com/ossf/scorecard/issues/2581
 			name: "image name with tag",
 			dep: checker.Dependency{
-				Name:     asPointer("amazoncorretto"),
-				PinnedAt: asPointer("11"),
+				Name:     asStringPointer("amazoncorretto"),
+				PinnedAt: asStringPointer("11"),
 				Type:     checker.DependencyUseTypeDockerfileContainerImage,
 			},
 			expected: &rule.Remediation{
@@ -113,7 +113,7 @@ func TestCreateDockerfilePinningRemediation(t *testing.T) {
 		{
 			name: "unknown image",
 			dep: checker.Dependency{
-				Name: asPointer("not-found"),
+				Name: asStringPointer("not-found"),
 				Type: checker.DependencyUseTypeDockerfileContainerImage,
 			},
 			expected: nil,
@@ -121,8 +121,8 @@ func TestCreateDockerfilePinningRemediation(t *testing.T) {
 		{
 			name: "unknown tag",
 			dep: checker.Dependency{
-				Name:     asPointer("foo"),
-				PinnedAt: asPointer("not-found"),
+				Name:     asStringPointer("foo"),
+				PinnedAt: asStringPointer("not-found"),
 				Type:     checker.DependencyUseTypeDockerfileContainerImage,
 			},
 			expected: nil,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This is a bug fix. Pinned-Dependencies score used to score a 10 for ecossystems not used by the project. Now, it scores -1 when the ecossystem is not used, and this score is not included in the final score for Pinned-Dependencies.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

For example, if project A uses only Python and has only Python or pip dependencies, the project would score 10 for Dockerfiles, npm, go and other ecossystems dependencies it does not use.

#### What is the new behavior (if this is a feature change)?**

In this PR, if no dependencies are found for an ecossystem, this ecossystem score is not included in the final score.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes https://github.com/ossf/scorecard/issues/3254

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Pinned-Dependencies score includes only used ecossystems (npm, go, pip, etc.)
```
