### PR TITLE
:sparkles: Check for static archives in Binary Artifacts

### DIFF
--- a/checks/raw/binary_artifact.go
+++ b/checks/raw/binary_artifact.go
@@ -117,6 +117,7 @@ var checkBinaryFileContent fileparser.DoWhileTrueOnFileContent = func(path strin
 		"dey":    true,
 		"elf":    true,
 		"o":      true,
+		"a":      true,
 		"so":     true,
 		"macho":  true,
 		"iso":    true,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Static archives do not lead to score reduction in Binary Artifacts, although `.o` files do and `.a` correspond to a group of `.o` files.

#### What is the new behavior (if this is a feature change)?**

Static archives lead to score reduction.

- [ ] Tests for the changes have been added (for bug fixes/features)

Did not add a test because only a few binary checks have these. It may also be in the interest of size for the repository not to have `.a` files stored?

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

None

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Add static archives as binary artifacts
```
