### PR TITLE
:seedling: workflows/stale: Update exempt labels

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -37,7 +37,7 @@ jobs:
         stale-issue-message: 'Stale issue message'
         stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
-        exempt-issue-labels: 'wishlist,slsa,priority,bug,core feature,enhancement,good first issue,help wanted,needs discussion'
+        exempt-issue-labels: 'priority,bug,good first issue'
         stale-pr-label: 'no-pr-activity'
         exempt-pr-labels: 'awaiting-approval,work-in-progress'
         days-before-pr-stale: '10'


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)
This is a workflow update to reduce the number of label types being exempted from the stale workflow.

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Most issues are not being addressed with this stale workflow.

#### What is the new behavior (if this is a feature change)?**
More issues will be processed by stale workflow.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
n/a

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Please let me know if other labels need to remain exempt.

#### Does this PR introduce a user-facing change? 
No used facing change

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
