### PR TITLE
:sparkles: scdiff: add basic stats command to count scores by buckets

### DIFF
--- a/cmd/internal/scdiff/app/compare.go
+++ b/cmd/internal/scdiff/app/compare.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 var (
-	errMissingInputFiles = errors.New("must provide at least two files from scdiff generate")
+	errMissingInputFiles = errors.New("missing input file(s)")
 	errResultsDiffer     = errors.New("results differ")
 	errNumResults        = errors.New("number of results being compared differ")
 

--- a/cmd/internal/scdiff/app/compare.go
+++ b/cmd/internal/scdiff/app/compare.go
@@ -68,7 +68,9 @@ var (
 func compareReaders(x, y io.Reader, output io.Writer) error {
 	// results are currently newline delimited
 	xs := bufio.NewScanner(x)
+	xs.Buffer(nil, maxResultSize)
 	ys := bufio.NewScanner(y)
+	ys.Buffer(nil, maxResultSize)
 	for {
 		if shouldContinue, err := advanceScanners(xs, ys); err != nil {
 			return err

--- a/cmd/internal/scdiff/app/compare.go
+++ b/cmd/internal/scdiff/app/compare.go
@@ -90,11 +90,11 @@ func compareReaders(x, y io.Reader, output io.Writer) error {
 }
 
 func loadResults(x, y *bufio.Scanner) (pkg.ScorecardResult, pkg.ScorecardResult, error) {
-	xResult, err := pkg.ExperimentalFromJSON2(strings.NewReader(x.Text()))
+	xResult, _, err := pkg.ExperimentalFromJSON2(strings.NewReader(x.Text()))
 	if err != nil {
 		return pkg.ScorecardResult{}, pkg.ScorecardResult{}, fmt.Errorf("parsing first result: %w", err)
 	}
-	yResult, err := pkg.ExperimentalFromJSON2(strings.NewReader(y.Text()))
+	yResult, _, err := pkg.ExperimentalFromJSON2(strings.NewReader(y.Text()))
 	if err != nil {
 		return pkg.ScorecardResult{}, pkg.ScorecardResult{}, fmt.Errorf("parsing second result: %w", err)
 	}

--- a/cmd/internal/scdiff/app/stats.go
+++ b/cmd/internal/scdiff/app/stats.go
@@ -48,7 +48,7 @@ var (
 		Long:  `Summarize stats for a golden file`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errMissingInputFiles // TODO: generalize this?
+				return errMissingInputFiles
 			}
 			f1, err := os.Open(args[0])
 			if err != nil {

--- a/cmd/internal/scdiff/app/stats.go
+++ b/cmd/internal/scdiff/app/stats.go
@@ -1,0 +1,79 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/ossf/scorecard/v4/pkg"
+)
+
+//nolint:gochecknoinits // common for cobra apps
+func init() {
+	rootCmd.AddCommand(statsCmd)
+}
+
+var statsCmd = &cobra.Command{
+	Use:   "stats [flags] FILE",
+	Short: "Summarize stats for a golden file",
+	Long:  `Summarize stats for a golden file`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) < 1 {
+			return errMissingInputFiles // TODO: generalize this?
+		}
+		f1, err := os.Open(args[0])
+		if err != nil {
+			return fmt.Errorf("opening %q: %w", args[0], err)
+		}
+		defer f1.Close()
+		return calcStats(f1, os.Stdout)
+	},
+}
+
+func calcStats(input io.Reader, output io.Writer) error {
+	var counts [12]int // [-1, 10] inclusive
+	scanner := bufio.NewScanner(input)
+	for scanner.Scan() {
+		result, err := pkg.ExperimentalFromJSON2(strings.NewReader(scanner.Text()))
+		if err != nil {
+			return fmt.Errorf("parsing result: %w", err)
+		}
+		score, err := result.GetAggregateScore(nil) // todo, read from the file?
+		if score < -1 || score > 10 {
+			return fmt.Errorf("invalid score") // todo sentinel
+		}
+		bucket := int(score) + 1
+		counts[bucket]++
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("parsing golden file: %w", err)
+	}
+	summary(&counts, output)
+	return nil
+}
+
+func summary(counts *[12]int, output io.Writer) {
+	fmt.Fprintln(output, "Score Distribution:")
+	for i, c := range counts {
+		scoreBucket := i - 1
+		fmt.Fprintf(output, "%d: %d", scoreBucket, c)
+	}
+}

--- a/cmd/internal/scdiff/app/stats.go
+++ b/cmd/internal/scdiff/app/stats.go
@@ -16,6 +16,7 @@ package app
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -37,8 +38,7 @@ func init() {
 
 var (
 	statsCheck string
-
-	statsCmd = &cobra.Command{
+	statsCmd   = &cobra.Command{
 		Use:   "stats [flags] FILE",
 		Short: "Summarize stats for a golden file",
 		Long:  `Summarize stats for a golden file`,
@@ -54,6 +54,9 @@ var (
 			return calcStats(f1, os.Stdout)
 		},
 	}
+
+	errCheckNotPresent = errors.New("requested check not present")
+	errInvalidScore    = errors.New("invalid score")
 )
 
 func calcStats(input io.Reader, output io.Writer) error {
@@ -73,12 +76,12 @@ func calcStats(input io.Reader, output io.Writer) error {
 				return strings.EqualFold(c.Name, statsCheck)
 			})
 			if i == -1 {
-				return fmt.Errorf("requested check not present")
+				return errCheckNotPresent
 			}
 			score = result.Checks[i].Score
 		}
 		if score < -1 || score > 10 {
-			return fmt.Errorf("invalid score") // todo sentinel
+			return errInvalidScore
 		}
 		bucket := score + 1 // score of -1 is index 0, score of 0 is index 1, etc.
 		counts[bucket]++

--- a/cmd/internal/scdiff/app/stats.go
+++ b/cmd/internal/scdiff/app/stats.go
@@ -36,6 +36,10 @@ func init() {
 	statsCmd.PersistentFlags().StringVarP(&statsCheck, "check", "c", "", "Analyze breakdown of a single check")
 }
 
+// 1 MiB size limit for individual results. This currently works,
+// but bufio.Scanner always has a limit, may need to change approach in the future.
+const maxResultSize = 1024 * 1024
+
 var (
 	statsCheck string
 	statsCmd   = &cobra.Command{
@@ -65,7 +69,7 @@ func countScores(input io.Reader, check string) ([12]int, error) {
 	var counts [12]int // [-1, 10] inclusive
 	var score int
 	scanner := bufio.NewScanner(input)
-	scanner.Buffer(nil, 1024*1024) // TODO, how big is big enough?
+	scanner.Buffer(nil, maxResultSize)
 	for scanner.Scan() {
 		result, aggregateScore, err := pkg.ExperimentalFromJSON2(strings.NewReader(scanner.Text()))
 		if err != nil {

--- a/cmd/internal/scdiff/app/stats_test.go
+++ b/cmd/internal/scdiff/app/stats_test.go
@@ -15,6 +15,7 @@
 package app
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -82,5 +83,27 @@ func Test_countScores(t *testing.T) {
 				t.Errorf("counts differ: %v", cmp.Diff(got, tt.want))
 			}
 		})
+	}
+}
+
+func removeRepeatedSpaces(t *testing.T, s string) string {
+	t.Helper()
+	return strings.Join(strings.Fields(s), " ")
+}
+
+func Test_calcStats(t *testing.T) {
+	t.Parallel()
+	input := strings.NewReader(`{"date":"0001-01-01T00:00:00Z","repo":{"name":"repo1"},"score":10}`)
+	var output bytes.Buffer
+	if err := calcStats(input, &output); err != nil {
+		t.Fatalf("unexepected error: %v", err)
+	}
+	got := output.String()
+	// this is a bit of a simplification, but keeps the test simple
+	// without needing to update every minor formatting change.
+	got = removeRepeatedSpaces(t, got)
+	want := "10 1" // score 10 should have count 1
+	if !strings.Contains(got, want) {
+		t.Errorf("didn't contain expected count")
 	}
 }

--- a/cmd/internal/scdiff/app/stats_test.go
+++ b/cmd/internal/scdiff/app/stats_test.go
@@ -21,14 +21,11 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-//nolint:lll // results are long
 func Test_countScores(t *testing.T) {
 	t.Parallel()
 
-	validResults := `{"date":"0001-01-01T00:00:00Z","repo":{"name":"github.com/repo/one","commit":""},"scorecard":{"version":"","commit":""},"score":0,"checks":[{"details":null,"score":10,"reason":"no bars detected","name":"Foo"}],"metadata":null}
-	{"date":"0001-01-01T00:00:00Z","repo":{"name":"github.com/repo/two","commit":""},"scorecard":{"version":"","commit":""},"score":-1,"checks":[{"details":null,"score":9,"reason":"some bars detected","name":"Foo"}],"metadata":null}
-`
-	invalidScore := `{"date":"0001-01-01T00:00:00Z","repo":{"name":"github.com/repo/one","commit":""},"scorecard":{"version":"","commit":""},"score":-2,"metadata":null}
+	common := `{"date":"0001-01-01T00:00:00Z","repo":{"name":"repo1"},"score":0,"checks":[{"score":10,"name":"Foo"}]}
+{"date":"0001-01-01T00:00:00Z","repo":{"name":"repo2"},"score":-1,"checks":[{"score":9,"name":"Foo"}]}
 `
 	tests := []struct {
 		name    string
@@ -39,30 +36,30 @@ func Test_countScores(t *testing.T) {
 	}{
 		{
 			name:    "aggregate score used when no check specified",
-			results: validResults,
+			results: common,
 			want:    [12]int{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
 		},
 		{
 			name:    "check score used when check specified",
 			check:   "Foo",
-			results: validResults,
+			results: common,
 			want:    [12]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
 		},
 		{
 			name:    "check name case insensitive",
 			check:   "fOo",
-			results: validResults,
+			results: common,
 			want:    [12]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
 		},
 		{
 			name:    "non existent check",
 			check:   "not present",
-			results: validResults,
+			results: common,
 			wantErr: true,
 		},
 		{
 			name:    "score outside of [-1, 10] rejected",
-			results: invalidScore,
+			results: `{"date":"0001-01-01T00:00:00Z","repo":{"name":"repo1"},"score":12}`,
 			wantErr: true,
 		},
 	}
@@ -81,5 +78,4 @@ func Test_countScores(t *testing.T) {
 			}
 		})
 	}
-
 }

--- a/cmd/internal/scdiff/app/stats_test.go
+++ b/cmd/internal/scdiff/app/stats_test.go
@@ -1,0 +1,85 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+//nolint:lll // results are long
+func Test_countScores(t *testing.T) {
+	t.Parallel()
+
+	validResults := `{"date":"0001-01-01T00:00:00Z","repo":{"name":"github.com/repo/one","commit":""},"scorecard":{"version":"","commit":""},"score":0,"checks":[{"details":null,"score":10,"reason":"no bars detected","name":"Foo"}],"metadata":null}
+	{"date":"0001-01-01T00:00:00Z","repo":{"name":"github.com/repo/two","commit":""},"scorecard":{"version":"","commit":""},"score":-1,"checks":[{"details":null,"score":9,"reason":"some bars detected","name":"Foo"}],"metadata":null}
+`
+	invalidScore := `{"date":"0001-01-01T00:00:00Z","repo":{"name":"github.com/repo/one","commit":""},"scorecard":{"version":"","commit":""},"score":-2,"metadata":null}
+`
+	tests := []struct {
+		name    string
+		check   string
+		results string
+		want    [12]int
+		wantErr bool
+	}{
+		{
+			name:    "aggregate score used when no check specified",
+			results: validResults,
+			want:    [12]int{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:    "check score used when check specified",
+			check:   "Foo",
+			results: validResults,
+			want:    [12]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
+		},
+		{
+			name:    "check name case insensitive",
+			check:   "fOo",
+			results: validResults,
+			want:    [12]int{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
+		},
+		{
+			name:    "non existent check",
+			check:   "not present",
+			results: validResults,
+			wantErr: true,
+		},
+		{
+			name:    "score outside of [-1, 10] rejected",
+			results: invalidScore,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			input := strings.NewReader(tt.results)
+			got, err := countScores(input, tt.check)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("unexpected error: got %v, wantedErr: %t", err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("counts differ: %v", cmp.Diff(got, tt.want))
+			}
+		})
+	}
+
+}

--- a/cmd/internal/scdiff/app/stats_test.go
+++ b/cmd/internal/scdiff/app/stats_test.go
@@ -62,6 +62,11 @@ func Test_countScores(t *testing.T) {
 			results: `{"date":"0001-01-01T00:00:00Z","repo":{"name":"repo1"},"score":12}`,
 			wantErr: true,
 		},
+		{
+			name:    "result fails to parse",
+			results: `]}[{}`,
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -176,17 +176,18 @@ func (r *ScorecardResult) AsJSON2(showDetails bool,
 	return nil
 }
 
-// This function is experimental. Do not depend on it, it may be removed at any point.
-func ExperimentalFromJSON2(r io.Reader) (ScorecardResult, error) {
+// ExperimentalFromJSON2 is experimental. Do not depend on it, it may be removed at any point.
+// Also returns the aggregate score, as the ScorecardResult field does not contain it.
+func ExperimentalFromJSON2(r io.Reader) (result ScorecardResult, score float64, err error) {
 	var jsr JSONScorecardResultV2
 	decoder := json.NewDecoder(r)
 	if err := decoder.Decode(&jsr); err != nil {
-		return ScorecardResult{}, fmt.Errorf("decode json: %w", err)
+		return ScorecardResult{}, 0, fmt.Errorf("decode json: %w", err)
 	}
 
 	date, err := time.Parse(time.RFC3339, jsr.Date)
 	if err != nil {
-		return ScorecardResult{}, fmt.Errorf("parse scorecard analysis time: %w", err)
+		return ScorecardResult{}, 0, fmt.Errorf("parse scorecard analysis time: %w", err)
 	}
 
 	sr := ScorecardResult{
@@ -216,7 +217,7 @@ func ExperimentalFromJSON2(r io.Reader) (ScorecardResult, error) {
 		sr.Checks = append(sr.Checks, cr)
 	}
 
-	return sr, nil
+	return sr, float64(jsr.AggregateScore), nil
 }
 
 func (r *ScorecardResult) AsFJSON(showDetails bool,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

feature

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**
The `stats command:
```
Summarize stats for a golden file

Usage:
  scdiff stats [flags] FILE

Flags:
  -c, --check string   Analyze breakdown of a single check
  -h, --help           help for stats
```

Which currently produces a table:
```console
 Aggregate Score Count
              -1     0
               0     0
               1     0
               2     0
               3     0
               4     2
               5     1
               6     2
               7     4
               8     1
               9     0
              10     0
```
- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Related to #2462, 5/n
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Any thoughts on output format? I tried doing a simple tabwriter approach, but happy to go simpler (csv?) or more complicated if warranted.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
