### PR TITLE
🌱 workflows/stale: Update workflow to increase operations-per-run to process more issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -43,5 +43,5 @@ jobs:
         days-before-pr-stale: '10'
         days-before-pr-close: '20'
         days-before-issue-stale: '60'
-        days-before-issue-close: '67'
-        operations-per-run: '400'
+        days-before-issue-close: '7'
+        operations-per-run: '100'

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -44,3 +44,4 @@ jobs:
         days-before-pr-close: '20'
         days-before-issue-stale: '60'
         days-before-issue-close: '67'
+        operations-per-run: '400'


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Increases operations-per-run from default of 30 to 100 to test whether older issues will be marked as inactive

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Issues are only marked as inactive as they reach the 60 day trigger, but are not being marked if they have been at 60+ days of inactivity
#### What is the new behavior (if this is a feature change)?**
Older issues will be marked as inactive as well
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
No
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```NONE

```
