### PR TITLE
:seedling: Reduce confusion around codecov check status.

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -23,16 +23,15 @@ coverage:
   status:
     project:
       default:
-        enabled: true
-        # allowed to drop coverage and still result in a "success" commit status
-        threshold: null
+        informational: true
         if_not_found: success
         if_no_uploads: success
         if_ci_failed: error
     patch:
       default:
-        enabled: true
-        threshold: 90%
+        # patch coverage should be within 10% of existing coverage
+        target: auto
+        threshold: 10%
         if_not_found: success
         if_no_uploads: success
         if_ci_failed: error


### PR DESCRIPTION


#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- With our current coverage upload setup, it will always show a drop of 6-7% (see #3388). This is also confusing to contributors (https://github.com/ossf/scorecard/pull/3426#issuecomment-1724484499)
- The patch config is broken, so it essentially always passes: `50.00% of diff hit (within 90.00% threshold of 74.34%)`
  - The goal here was probably a target of 90%, not a threshold

#### What is the new behavior (if this is a feature change)?**
The project status is converted to [informational](https://docs.codecov.com/docs/commit-status#informational), so it will always pass. 
> Use Codecov in informational mode. Default is false. If true is specified the resulting status will pass no matter what the coverage is or what other settings are specified. Informational mode is great to use if you want to expose codecov information to other developers in your pull request without necessarily gating PRs on that information.

I still find the patch status helpful (especially the annotations while reviewing), so I'm leaving it as a check which can pass or fail. I've just fixed the threshold, it is now looking for patch coverage to be within 10% of the current code coverage level. Note: this is still a guideline and non-blocking since the check isn't marked as required.


- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
I've validated the file using their recommended approach.

```console
curl -X POST --data-binary @.codecov.yml https://codecov.io/validate
Valid!
```
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
