### PR TITLE
:seedling: Switch test import to remove gotest.tools dependency.

### DIFF
--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -20,8 +20,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/rhysd/actionlint"
-	"gotest.tools/assert/cmp"
 )
 
 func TestGitHubWorkflowShell(t *testing.T) {
@@ -142,7 +142,7 @@ func TestGitHubWorkflowShell(t *testing.T) {
 					actualShells = append(actualShells, shell)
 				}
 			}
-			if !cmp.DeepEqual(tt.expectedShells, actualShells)().Success() {
+			if !cmp.Equal(tt.expectedShells, actualShells) {
 				t.Errorf("%v: Got (%v) expected (%v)", tt.name, actualShells, tt.expectedShells)
 			}
 		})

--- a/go.mod
+++ b/go.mod
@@ -3,11 +3,6 @@ module github.com/ossf/scorecard/v4
 go 1.19
 
 require (
-	github.com/rhysd/actionlint v1.6.15
-	gotest.tools v2.2.0+incompatible
-)
-
-require (
 	cloud.google.com/go/bigquery v1.55.0
 	cloud.google.com/go/monitoring v1.15.1 // indirect
 	cloud.google.com/go/pubsub v1.33.0
@@ -26,6 +21,7 @@ require (
 	github.com/moby/buildkit v0.12.2
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/gomega v1.27.10
+	github.com/rhysd/actionlint v1.6.15
 	github.com/shurcooL/githubv4 v0.0.0-20201206200315-234843c633fa
 	github.com/shurcooL/graphql v0.0.0-20200928012149-18c5c3165e3a
 	github.com/sirupsen/logrus v1.9.3


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Fixing a likely typo in test code

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
We import `gotest.tools/assert/cmp` to compare two string slices. This library is only used in one place.

#### What is the new behavior (if this is a feature change)?**
The comparison now uses `cmp.Equal` from `github.com/google/go-cmp/cmp`, allowing us to eliminate the dependency.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
I moved `github.com/rhysd/actionlint` down to be with the other imports.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
