### PR TITLE
:seedling: Don't close stale issues explicitly

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/stale@1160a2240286f5da8ec72b1c0816ce2481aabf84 # v3.0.18
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
-        stale-issue-message: 'Stale issue message - this issue will be closed in 7 days'
+        stale-issue-message: 'This issue is stale because it has been open for 60 days with no activity.'
         stale-pr-message: 'Stale pull request message'
         stale-issue-label: 'no-issue-activity'
         exempt-issue-labels: 'priority,bug,good first issue'
@@ -43,4 +43,5 @@ jobs:
         days-before-pr-stale: '10'
         days-before-pr-close: '20'
         days-before-issue-stale: '60'
+        days-before-issue-close: -1
         operations-per-run: '100'


### PR DESCRIPTION
Issues are still getting closed after https://github.com/ossf/scorecard/pull/3493. I assume there's a default value being used somewhere.

#### What kind of change does this PR introduce?

ci fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Issues are still getting closed (like #2614), even though #3493 was merged.

#### What is the new behavior (if this is a feature change)?**
`days-before-issue-close` is explicitly marked `-1` to disable auto-close.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
