### PR TITLE
:bug: Set repo commit SHA in results after fetching successfully.

### DIFF
--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -127,6 +127,7 @@ func RunScorecard(ctx context.Context,
 	} else if err != nil {
 		return ScorecardResult{}, err
 	}
+	ret.Repo.CommitSHA = commitSHA
 
 	defaultBranch, err := repoClient.GetDefaultBranchName()
 	if err != nil {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The results at head currently always list the commit as `HEAD`. Introduced in #3426 
```console
go run main.go --repo ossf/scorecard --checks License --format json | jq
{
  "date": "2023-09-25T08:39:59-07:00",
  "repo": {
    "name": "github.com/ossf/scorecard",
    "commit": "HEAD"
  },
```

#### What is the new behavior (if this is a feature change)?**
if successfully fetched, the commit SHA is set in the results.
```console
go run main.go --repo ossf/scorecard --checks License --format json | jq
{
  "date": "2023-09-25T08:44:16-07:00",
  "repo": {
    "name": "github.com/ossf/scorecard",
    "commit": "fd12f6a4e2f1d5c9b0afb3c41c67a943f13dea39"
  },
```
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
