### PR TITLE
:seedling: Fix race condition in output file test.

### DIFF
--- a/pkg/scorecard_result_test.go
+++ b/pkg/scorecard_result_test.go
@@ -99,7 +99,6 @@ func Test_formatResults_outputToFile(t *testing.T) {
 			args: args{
 				opts: &options.Options{
 					Format:      options.FormatJSON,
-					ResultsFile: "result.json",
 					ShowDetails: true,
 					LogLevel:    log.DebugLevel.String(),
 				},
@@ -116,7 +115,6 @@ func Test_formatResults_outputToFile(t *testing.T) {
 			args: args{
 				opts: &options.Options{
 					Format:      options.FormatDefault,
-					ResultsFile: "result.log",
 					ShowDetails: true,
 					LogLevel:    log.DebugLevel.String(),
 				},
@@ -133,6 +131,14 @@ func Test_formatResults_outputToFile(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
+
+			// generate a unique result file in a temp directory for every test run to avoid race conditions in the test.
+			// This can happen when ginkgo runs unit tests in parallel (with -p flag)
+			resultFile, err := os.CreateTemp("", "result-file")
+			if err != nil {
+				t.Fatalf("create temp result file: %v", err)
+			}
+			tt.args.opts.ResultsFile = resultFile.Name()
 
 			// Format results.
 			formatErr := FormatResults(tt.args.opts, tt.args.results, tt.args.doc, tt.args.policy)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

test fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Because the unit test uses a hard coded file, and the test deletes this file, a race condition exists when multiple versions of the test are run in parallel. This happens with our e2e tests as we call `ginkgo -p`.

#### What is the new behavior (if this is a feature change)?**
The test doesn't hardcode an output file name, and instead uses a random name provided by [os.CreateTemp](https://pkg.go.dev/os#CreateTemp):

e.g.`/tmp/result-file2178365783`
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
The error message from ginkgo was very vague. It used to present more information

https://github.com/ossf/scorecard/actions/runs/6398651796/job/17369225051
```console
Running Suite: Pkg Suite - /home/runner/work/scorecard/scorecard/pkg
====================================================================
Random Seed: 1696369398

Will run 0 of 1 specs
Running in parallel across 2 processes
------------------------------
S [SKIPPED]
E2E TEST: RunScorecard with re-used repoClient
/home/runner/work/scorecard/scorecard/pkg/scorecard_e2e_test.go:100
  E2E TEST: Validate results are identical regardless of order
  /home/runner/work/scorecard/scorecard/pkg/scorecard_e2e_test.go:101
    A then B results should be produce the same distribution of details as the isolated B results
    /home/runner/work/scorecard/scorecard/pkg/scorecard_e2e_test.go:132
------------------------------

Ran 0 of 1 Specs in 0.010 seconds
SUCCESS! -- 0 Passed | 0 Failed | 0 Pending | 1 Skipped


Ginkgo ran 57 suites in 3m42.083751187s

There were failures detected in the following suites:
  pkg ./pkg

Test Suite Failed
```


When running on an older version:

```console
--- FAIL: Test_formatResults_outputToFile (0.00s)
    scorecard_result_test.go:89: date: 2023-03-02 10:30:43 -0600 -0600
    --- FAIL: Test_formatResults_outputToFile/output_file_with_format_default (0.00s)
        scorecard_result_test.go:148: cannot read file: open result.log: no such file or directory
FAIL


Ginkgo ran 1 suite in 2.97872532s

Test Suite Failed
```
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
