### PR TITLE
:seedling: Add probe test utility

### DIFF
--- a/probes/internal/utils/test/test.go
+++ b/probes/internal/utils/test/test.go
@@ -1,0 +1,44 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package test
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/ossf/scorecard/v4/finding"
+)
+
+// AssertCorrect is a suitable for all probes to compare raw
+// results against expected outcomes.
+func AssertCorrect(t *testing.T, probeExpect, probeGot string,
+	findings []finding.Finding, expectedOutcomes []finding.Outcome,
+) {
+	t.Helper()
+	if diff := cmp.Diff(probeExpect, probeGot); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+	if diff := cmp.Diff(len(expectedOutcomes), len(findings)); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
+	}
+	for i := range expectedOutcomes {
+		outcome := &expectedOutcomes[i]
+		f := &findings[i]
+		if diff := cmp.Diff(*outcome, f.Outcome); diff != "" {
+			t.Errorf("mismatch (-want +got):\n%s", diff)
+		}
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Adds a test helper suitable to check the output from probes in tests.

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
https://github.com/ossf/scorecard/issues/3472

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
NONE

```release-note

```
