### PR TITLE
:seedling: Add map to Finding

### DIFF
--- a/finding/finding.go
+++ b/finding/finding.go
@@ -100,6 +100,7 @@ type Finding struct {
 	Message     string             `json:"message"`
 	Location    *Location          `json:"location,omitempty"`
 	Remediation *probe.Remediation `json:"remediation,omitempty"`
+	Values      map[string]int     `json:”values,omitempty”`
 }
 
 // AnonymousFinding is a finding without a corerpsonding probe ID.


### PR DESCRIPTION
- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the new behavior (if this is a feature change)?**

Adds a numeric map to the Finding type as discussed in https://github.com/ossf/scorecard/issues/2928.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

https://github.com/ossf/scorecard/issues/2928

#### Does this PR introduce a user-facing change?
NONE

```release-note

```
