### PR TITLE
:bug: fix struct tag issue and enable `structtag` linter.

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -76,6 +76,7 @@ linters-settings:
   govet:
     enable:
       - fieldalignment
+      - structtag
   godox:
     keywords:
       - BUG

--- a/finding/finding.go
+++ b/finding/finding.go
@@ -100,7 +100,7 @@ type Finding struct {
 	Message     string             `json:"message"`
 	Location    *Location          `json:"location,omitempty"`
 	Remediation *probe.Remediation `json:"remediation,omitempty"`
-	Values      map[string]int     `json:”values,omitempty”`
+	Values      map[string]int     `json:"values,omitempty"`
 }
 
 // AnonymousFinding is a finding without a corerpsonding probe ID.


### PR DESCRIPTION


#### What kind of change does this PR introduce?

bug fix from #3558 

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The quotes used in the struct tag are wrong.

#### What is the new behavior (if this is a feature change)?**
fixes the tag issue, explicitly tries to enable `structtag` (but I'm pretty sure it's on by default)
Unfortunately, we use `//nolint:govet` on a lot of structures, so this may not be the most effective linter.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
