### PR TITLE
:sparkles: Add support for fast-check test runners integrations

### DIFF
--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -98,23 +98,28 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 	// Fuzz patterns for JavaScript and TypeScript based on property-based testing.
 	//
 	// Based on the import of one of these packages:
-	// * https://fast-check.dev/
+	// * https://github.com/dubzzz/fast-check/tree/main/packages/fast-check#readme
+	// * https://github.com/dubzzz/fast-check/tree/main/packages/ava#readme
+	// * https://github.com/dubzzz/fast-check/tree/main/packages/jest#readme
+	// * https://github.com/dubzzz/fast-check/tree/main/packages/vitest#readme
 	//
 	// This is not an exhaustive list.
 	clients.JavaScript: {
 		filePatterns: []string{"*.js"},
-		// Look for direct imports of fast-check.
-		funcPattern: `(from\s+['"]fast-check['"]|require\(\s*['"]fast-check['"]\s*\))`,
-		Name:        fuzzerPropertyBasedJavaScript,
+		// Look for direct imports of fast-check and its test runners integrations.
+		funcPattern: `(from\s+['"](fast-check|@fast-check/(ava|jest|vitest))['"]|` +
+			`require\(\s*['"](fast-check|@fast-check/(ava|jest|vitest))['"]\s*\))`,
+		Name: fuzzerPropertyBasedJavaScript,
 		Desc: asPointer(
 			"Property-based testing in JavaScript generates test instances randomly or exhaustively " +
 				"and test that specific properties are satisfied."),
 	},
 	clients.TypeScript: {
 		filePatterns: []string{"*.ts"},
-		// Look for direct imports of fast-check.
-		funcPattern: `(from\s+['"]fast-check['"]|require\(\s*['"]fast-check['"]\s*\))`,
-		Name:        fuzzerPropertyBasedTypeScript,
+		// Look for direct imports of fast-check and its test runners integrations.
+		funcPattern: `(from\s+['"](fast-check|@fast-check/(ava|jest|vitest))['"]|` +
+			`require\(\s*['"](fast-check|@fast-check/(ava|jest|vitest))['"]\s*\))`,
+		Name: fuzzerPropertyBasedTypeScript,
 		Desc: asPointer(
 			"Property-based testing in TypeScript generates test instances randomly or exhaustively " +
 				"and test that specific properties are satisfied."),

--- a/checks/raw/fuzzing_test.go
+++ b/checks/raw/fuzzing_test.go
@@ -441,6 +441,30 @@ func Test_checkFuzzFunc(t *testing.T) {
 			fileContent: "import fc from \"fast-check\";",
 		},
 		{
+			name:     "JavaScript fast-check scoped via require",
+			want:     true,
+			fileName: []string{"main.spec.js"},
+			langs: []clients.Language{
+				{
+					Name:     clients.JavaScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const { fc, testProp } = require('@fast-check/ava');",
+		},
+		{
+			name:     "JavaScript fast-check scoped via import",
+			want:     true,
+			fileName: []string{"main.spec.js"},
+			langs: []clients.Language{
+				{
+					Name:     clients.JavaScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "import { fc, test } from \"@fast-check/jest\";",
+		},
+		{
 			name:     "JavaScript with no property-based testing",
 			want:     false,
 			fileName: []string{"main.spec.js"},
@@ -476,6 +500,30 @@ func Test_checkFuzzFunc(t *testing.T) {
 				},
 			},
 			fileContent: "import fc from \"fast-check\";",
+		},
+		{
+			name:     "TypeScript fast-check scoped via require",
+			want:     true,
+			fileName: []string{"main.spec.ts"},
+			langs: []clients.Language{
+				{
+					Name:     clients.TypeScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const { fc, testProp } = require('@fast-check/ava');",
+		},
+		{
+			name:     "TypeScript fast-check scoped via import",
+			want:     true,
+			fileName: []string{"main.spec.ts"},
+			langs: []clients.Language{
+				{
+					Name:     clients.TypeScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "import { fc, test } from \"@fast-check/vitest\";",
 		},
 		{
 			name:     "TypeScript with no property-based testing",


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR adds checks support for the `fast-check` (JS/TS) test runners interactions (`@fast-check/ava`, `@fast-check/jest` and `@fast-check/vitest`).

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`fast-check` (JS/TS) test runners interactions are not detected.

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #3567


#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Add support for `fast-check` test runners integrations
```
