### PR TITLE
:seedling: Run fieldalignment on ./checker, ./checks and ./finding

### DIFF
--- a/checker/check_result.go
+++ b/checker/check_result.go
@@ -59,14 +59,13 @@ var errSuccessTotal = errors.New("unexpected number of success is higher than to
 //
 //nolint:govet
 type CheckResult struct {
-	Name    string
-	Version int
 	Error   error
-	Score   int
+	Name    string
 	Reason  string
 	Details []CheckDetail
-	// Structured results.
-	Rules []string // TODO(X): add support.
+	Rules   []string
+	Version int
+	Score   int
 }
 
 // CheckDetail contains information for each detail.
@@ -80,17 +79,14 @@ type CheckDetail struct {
 //
 //nolint:govet
 type LogMessage struct {
-	// Structured results.
-	Finding *finding.Finding
-
-	// Non-structured results.
-	Text        string            // A short string explaining why the detail was recorded/logged.
-	Path        string            // Fullpath to the file.
-	Type        finding.FileType  // Type of file.
-	Offset      uint              // Offset in the file of Path (line for source/text files).
-	EndOffset   uint              // End of offset in the file, e.g. if the command spans multiple lines.
-	Snippet     string            // Snippet of code
-	Remediation *rule.Remediation // Remediation information, if any.
+	Finding     *finding.Finding
+	Remediation *rule.Remediation
+	Text        string
+	Path        string
+	Snippet     string
+	Type        finding.FileType
+	Offset      uint
+	EndOffset   uint
 }
 
 // ProportionalScoreWeighted is a structure that contains

--- a/checker/check_result_test.go
+++ b/checker/check_result_test.go
@@ -62,9 +62,9 @@ func TestAggregateScoresWithWeight(t *testing.T) {
 	type args struct {
 		scores map[int]int
 	}
-	tests := []struct { //nolint:govet
-		name string
+	tests := []struct {
 		args args
+		name string
 		want int
 	}{
 		{
@@ -412,10 +412,10 @@ func TestNormalizeReason(t *testing.T) {
 		reason string
 		score  int
 	}
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name string
-		args args
 		want string
+		args args
 	}{
 		{
 			name: "empty",
@@ -505,7 +505,7 @@ func TestCreateProportionalScoreResult(t *testing.T) {
 		b      int
 		t      int
 	}
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name string
 		args args
 		want CheckResult
@@ -701,9 +701,9 @@ func TestCreateInconclusiveResult(t *testing.T) {
 
 func TestCreateRuntimeErrorResult(t *testing.T) {
 	t.Parallel()
-	type args struct { //nolint:govet
-		name string
+	type args struct {
 		e    error
+		name string
 	}
 	tests := []struct {
 		name string

--- a/checker/client_test.go
+++ b/checker/client_test.go
@@ -23,15 +23,15 @@ import (
 // nolint:paralleltest
 // because we are using t.Setenv.
 func TestGetClients(t *testing.T) { //nolint:gocognit
-	type args struct { //nolint:govet
+	type args struct {
 		ctx      context.Context
+		logger   *log.Logger
 		repoURI  string
 		localURI string
-		logger   *log.Logger
 	}
-	tests := []struct { //nolint:govet
-		name                  string
+	tests := []struct {
 		args                  args
+		name                  string
 		shouldOSSFuzzBeNil    bool
 		shouldRepoClientBeNil bool
 		shouldVulnClientBeNil bool

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -25,25 +25,25 @@ import (
 // is applied.
 // nolint
 type RawResults struct {
-	BinaryArtifactResults       BinaryArtifactData
+	Metadata                    MetadataData
 	BranchProtectionResults     BranchProtectionsData
-	CIIBestPracticesResults     CIIBestPracticesData
-	CITestResults               CITestData
+	FuzzingResults              FuzzingData
+	SignedReleasesResults       SignedReleasesData
 	CodeReviewResults           CodeReviewData
 	ContributorsResults         ContributorsData
-	DangerousWorkflowResults    DangerousWorkflowData
+	WebhookResults              WebhooksData
 	DependencyUpdateToolResults DependencyUpdateToolData
-	FuzzingResults              FuzzingData
+	BinaryArtifactResults       BinaryArtifactData
 	LicenseResults              LicenseData
-	MaintainedResults           MaintainedData
-	Metadata                    MetadataData
+	VulnerabilitiesResults      VulnerabilitiesData
+	CITestResults               CITestData
 	PackagingResults            PackagingData
 	PinningDependenciesResults  PinningDependenciesData
 	SecurityPolicyResults       SecurityPolicyData
-	SignedReleasesResults       SignedReleasesData
+	MaintainedResults           MaintainedData
 	TokenPermissionsResults     TokenPermissionsData
-	VulnerabilitiesResults      VulnerabilitiesData
-	WebhookResults              WebhooksData
+	DangerousWorkflowResults    DangerousWorkflowData
+	CIIBestPracticesResults     CIIBestPracticesData
 }
 
 type MetadataData struct {

--- a/checks/all_checks_test.go
+++ b/checks/all_checks_test.go
@@ -25,13 +25,13 @@ func Test_registerCheck(t *testing.T) {
 	t.Parallel()
 	//nolint
 	type args struct {
-		name string
 		fn   checker.CheckFn
+		name string
 	}
 	//nolint
 	tests := []struct {
-		name    string
 		args    args
+		name    string
 		wanterr bool
 	}{
 		{

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -68,12 +68,12 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name          string
-		expected      scut.TestReturn
-		branches      []*clients.BranchRef
 		defaultBranch string
+		branches      []*clients.BranchRef
 		releases      []string
-		nonadmin      bool
 		repoFiles     []string
+		expected      scut.TestReturn
+		nonadmin      bool
 	}{
 		{
 			name: "Nil release and main branch names",

--- a/checks/dependency_update_tool_test.go
+++ b/checks/dependency_update_tool_test.go
@@ -35,12 +35,12 @@ func TestDependencyUpdateTool(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name              string
-		wantErr           bool
-		SearchCommits     []clients.Commit
-		CallSearchCommits int
-		files             []string
 		want              checker.CheckResult
+		SearchCommits     []clients.Commit
+		files             []string
 		expected          scut.TestReturn
+		CallSearchCommits int
+		wantErr           bool
 	}{
 		{
 			name:    "dependency yml",

--- a/checks/evaluation/binary_artifacts_test.go
+++ b/checks/evaluation/binary_artifacts_test.go
@@ -26,9 +26,9 @@ func TestBinaryArtifacts(t *testing.T) {
 	t.Parallel()
 	//nolint
 	type args struct {
-		name string
 		dl   checker.DetailLogger
 		r    *checker.BinaryArtifactData
+		name string
 	}
 	tests := []struct {
 		name    string

--- a/checks/evaluation/ci_tests_test.go
+++ b/checks/evaluation/ci_tests_test.go
@@ -204,11 +204,11 @@ func Test_prHasSuccessfulCheck(t *testing.T) {
 
 func Test_prHasSuccessStatus(t *testing.T) {
 	t.Parallel()
-	type args struct { //nolint:govet
-		r  checker.RevisionCIInfo
+	type args struct {
 		dl checker.DetailLogger
+		r  checker.RevisionCIInfo
 	}
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name    string
 		args    args
 		want    bool
@@ -277,11 +277,11 @@ func Test_prHasSuccessStatus(t *testing.T) {
 
 func Test_prHasSuccessfulCheckAdditional(t *testing.T) {
 	t.Parallel()
-	type args struct { //nolint:govet
-		r  checker.RevisionCIInfo
+	type args struct {
 		dl checker.DetailLogger
+		r  checker.RevisionCIInfo
 	}
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name    string
 		args    args
 		want    bool
@@ -369,14 +369,14 @@ func Test_prHasSuccessfulCheckAdditional(t *testing.T) {
 
 func TestCITests(t *testing.T) {
 	t.Parallel()
-	type args struct { //nolint:govet
-		in0 string
-		c   *checker.CITestData
+	type args struct {
 		dl  checker.DetailLogger
+		c   *checker.CITestData
+		in0 string
 	}
-	tests := []struct { //nolint:govet
-		name string
+	tests := []struct {
 		args args
+		name string
 		want int
 	}{
 		{

--- a/checks/evaluation/code_review_test.go
+++ b/checks/evaluation/code_review_test.go
@@ -28,9 +28,9 @@ func TestCodeReview(t *testing.T) {
 
 	//nolint:govet // ignore since this is a test.
 	tests := []struct {
+		rawData  *checker.CodeReviewData
 		name     string
 		expected scut.TestReturn
-		rawData  *checker.CodeReviewData
 	}{
 		{
 			name: "NullRawData",

--- a/checks/evaluation/dangerous_workflow_test.go
+++ b/checks/evaluation/dangerous_workflow_test.go
@@ -25,10 +25,10 @@ import (
 
 func TestDangerousWorkflow(t *testing.T) {
 	t.Parallel()
-	type args struct { //nolint:govet
-		name string
+	type args struct {
 		dl   checker.DetailLogger
 		r    *checker.DangerousWorkflowData
+		name string
 	}
 	tests := []struct {
 		name string

--- a/checks/evaluation/license_test.go
+++ b/checks/evaluation/license_test.go
@@ -29,9 +29,9 @@ func Test_scoreLicenseCriteria(t *testing.T) {
 		f  *checker.LicenseFile
 		dl checker.DetailLogger
 	}
-	tests := []struct { //nolint:govet
-		name string
+	tests := []struct {
 		args args
+		name string
 		want int
 	}{
 		{
@@ -97,10 +97,10 @@ func Test_scoreLicenseCriteria(t *testing.T) {
 
 func TestLicense(t *testing.T) {
 	t.Parallel()
-	type args struct { //nolint:govet
-		name string
+	type args struct {
 		dl   checker.DetailLogger
 		r    *checker.LicenseData
+		name string
 	}
 	tests := []struct {
 		name string

--- a/checks/evaluation/maintained_test.go
+++ b/checks/evaluation/maintained_test.go
@@ -33,9 +33,9 @@ func Test_hasActivityByCollaboratorOrHigher(t *testing.T) {
 		issue     *clients.Issue
 		threshold time.Time
 	}
-	tests := []struct { //nolint:govet
-		name string
+	tests := []struct {
 		args args
+		name string
 		want bool
 	}{
 		{
@@ -98,10 +98,10 @@ func TestMaintained(t *testing.T) {
 	twentyDaysAgo := time.Now().AddDate(0 /*years*/, 0 /*months*/, -20 /*days*/)
 	collab := clients.RepoAssociationCollaborator
 	t.Parallel()
-	type args struct { //nolint:govet
-		name string
+	type args struct {
 		dl   checker.DetailLogger
 		r    *checker.MaintainedData
+		name string
 	}
 	tests := []struct {
 		name string

--- a/checks/evaluation/packaging_test.go
+++ b/checks/evaluation/packaging_test.go
@@ -26,7 +26,7 @@ import (
 func Test_createLogMessage(t *testing.T) {
 	msg := "msg"
 	t.Parallel()
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name    string
 		args    checker.Package
 		want    checker.LogMessage
@@ -103,10 +103,10 @@ func Test_createLogMessage(t *testing.T) {
 
 func TestPackaging(t *testing.T) {
 	t.Parallel()
-	type args struct { //nolint:govet
-		name string
+	type args struct {
 		dl   checker.DetailLogger
 		r    *checker.PackagingData
+		name string
 	}
 	tests := []struct {
 		name string

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -29,8 +29,8 @@ func Test_createScoreForGitHubActionsWorkflow(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name   string
-		r      worklowPinningResult
 		scores []checker.ProportionalScoreWeighted
+		r      worklowPinningResult
 	}{
 		{
 			name: "GitHub-owned and Third-Party actions pinned",
@@ -819,10 +819,10 @@ func Test_PinningDependencies(t *testing.T) {
 
 func Test_generateOwnerToDisplay(t *testing.T) {
 	t.Parallel()
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name        string
-		gitHubOwned bool
 		want        string
+		gitHubOwned bool
 	}{
 		{
 			name:        "returns GitHub if gitHubOwned is true",
@@ -1009,10 +1009,10 @@ func TestUpdatePinningResults(t *testing.T) {
 		w  *worklowPinningResult
 		pr map[checker.DependencyUseType]pinnedResult
 	}
-	tests := []struct { //nolint:govet
-		name string
+	tests := []struct {
 		args args
 		want want
+		name string
 	}{
 		{
 			name: "add pinned GitHub-owned action",

--- a/checks/evaluation/vulnerabilities_test.go
+++ b/checks/evaluation/vulnerabilities_test.go
@@ -27,16 +27,14 @@ func TestVulnerabilities(t *testing.T) {
 	t.Parallel()
 	//nolint
 	type args struct {
-		name string
 		r    *checker.VulnerabilitiesData
+		name string
 	}
 	tests := []struct {
-		name     string
 		args     args
+		name     string
+		expected []struct{ lineNumber uint }
 		want     checker.CheckResult
-		expected []struct {
-			lineNumber uint
-		}
 	}{
 		{
 			name: "no vulnerabilities",

--- a/checks/evaluation/webhooks_test.go
+++ b/checks/evaluation/webhooks_test.go
@@ -27,9 +27,9 @@ func TestWebhooks(t *testing.T) {
 	t.Parallel()
 	//nolint
 	type args struct {
-		name string
 		dl   checker.DetailLogger
 		r    *checker.WebhooksData
+		name string
 	}
 	tests := []struct {
 		name    string

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -403,8 +403,8 @@ func TestGetLineNumber(t *testing.T) {
 	}
 	//nolint
 	tests := []struct {
-		name string
 		args args
+		name string
 		want uint
 	}{
 		{
@@ -490,9 +490,9 @@ func TestGetUses(t *testing.T) {
 	}
 	//nolint
 	tests := []struct {
-		name string
 		args args
 		want *actionlint.String
+		name string
 	}{
 		{
 			name: "uses",
@@ -564,9 +564,9 @@ func Test_getWith(t *testing.T) {
 	}
 	//nolint
 	tests := []struct {
-		name string
 		args args
 		want map[string]*actionlint.Input
+		name string
 	}{
 		{
 			name: "with",
@@ -650,9 +650,9 @@ func Test_getRun(t *testing.T) {
 	}
 	//nolint
 	tests := []struct {
-		name string
 		args args
 		want *actionlint.String
+		name string
 	}{
 		{
 			name: "run",
@@ -748,8 +748,8 @@ func Test_stepsMatch(t *testing.T) {
 	}
 	//nolint
 	tests := []struct {
-		name string
 		args args
+		name string
 		want bool
 	}{
 		{

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -137,8 +137,8 @@ func TestCheckFileContainsCommands(t *testing.T) {
 	t.Parallel()
 	//nolint
 	type args struct {
-		content []byte
 		comment string
+		content []byte
 	}
 	tests := []struct {
 		name string
@@ -400,12 +400,12 @@ func TestOnMatchingFileContent(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name                   string
-		wantErr                bool
 		shellPattern           string
+		files                  []string
+		wantErr                bool
 		caseSensitive          bool
 		shouldFuncFail         bool
 		shouldGetPredicateFail bool
-		files                  []string
 	}{
 		{
 			name:          "no files",
@@ -586,13 +586,13 @@ func TestOnAllFilesDo(t *testing.T) {
 	}
 	//nolint
 	tests := []struct {
-		name         string
-		onFile       DoWhileTrueOnFilename
-		onFileArgs   []interface{}
-		listFiles    []string
 		errListFiles error
 		err          error
+		onFile       DoWhileTrueOnFilename
 		testArgs     testArgsFn
+		name         string
+		onFileArgs   []interface{}
+		listFiles    []string
 	}{
 		{
 			name:         "error during ListFiles",

--- a/checks/fuzzing_test.go
+++ b/checks/fuzzing_test.go
@@ -33,13 +33,13 @@ func TestFuzzing(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name        string
+		fileContent string
 		langs       []clients.Language
+		fileName    []string
 		response    clients.SearchResponse
+		expected    scut.TestReturn
 		wantErr     bool
 		wantFuzzErr bool
-		fileName    []string
-		fileContent string
-		expected    scut.TestReturn
 	}{
 		{
 			name:     "empty response",

--- a/checks/maintained_test.go
+++ b/checks/maintained_test.go
@@ -29,7 +29,7 @@ import (
 
 // ignoring the linter for cyclomatic complexity because it is a test func
 // TestMaintained tests the maintained check.
-//nolint
+// nolint
 func Test_Maintained(t *testing.T) {
 	t.Parallel()
 	threeHundredDaysAgo := time.Now().AddDate(0, 0, -300)
@@ -47,16 +47,16 @@ func Test_Maintained(t *testing.T) {
 	}
 	//nolint
 	tests := []struct {
-		err        error
-		name       string
-		isarchived bool
-		archiveerr error
-		commits    []clients.Commit
-		commiterr  error
-		issues     []clients.Issue
-		issueerr   error
 		createdat  time.Time
+		err        error
+		archiveerr error
+		commiterr  error
+		issueerr   error
+		name       string
+		commits    []clients.Commit
+		issues     []clients.Issue
 		expected   checker.CheckResult
+		isarchived bool
 	}{
 		{
 			name:       "archived",

--- a/checks/raw/branch_protection_test.go
+++ b/checks/raw/branch_protection_test.go
@@ -36,8 +36,8 @@ var (
 // nolint: govet
 type branchArg struct {
 	err           error
-	name          string
 	branchRef     *clients.BranchRef
+	name          string
 	defaultBranch bool
 }
 
@@ -65,13 +65,13 @@ func TestBranchProtection(t *testing.T) {
 	t.Parallel()
 	//nolint: govet
 	tests := []struct {
+		releasesErr error
+		wantErr     error
 		name        string
+		want        checker.BranchProtectionsData
 		branches    branchesArg
 		repoFiles   []string
 		releases    []clients.Release
-		releasesErr error
-		want        checker.BranchProtectionsData
-		wantErr     error
 	}{
 		{
 			name: "default-branch-err",

--- a/checks/raw/contributors_test.go
+++ b/checks/raw/contributors_test.go
@@ -25,10 +25,10 @@ import (
 
 func TestCompanyContains(t *testing.T) {
 	t.Parallel()
-	testCases := []struct { //nolint:govet
+	testCases := []struct {
 		name     string
-		cs       []string
 		company  string
+		cs       []string
 		expected bool
 	}{
 		{
@@ -65,10 +65,10 @@ func TestCompanyContains(t *testing.T) {
 
 func TestOrgContains(t *testing.T) {
 	t.Parallel()
-	testCases := []struct { //nolint:govet
+	testCases := []struct {
 		name     string
-		os       []clients.User
 		login    string
+		os       []clients.User
 		expected bool
 	}{
 		{

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -133,11 +133,11 @@ func TestDependencyUpdateTool(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name              string
-		wantErr           bool
-		want              int
 		SearchCommits     []clients.Commit
-		CallSearchCommits int
 		files             []string
+		want              int
+		CallSearchCommits int
+		wantErr           bool
 	}{
 		{
 			name:              "dependency update tool",

--- a/checks/raw/fuzzing_test.go
+++ b/checks/raw/fuzzing_test.go
@@ -33,8 +33,8 @@ func Test_checkOSSFuzz(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name        string
-		want        bool
 		response    clients.SearchResponse
+		want        bool
 		wantErr     bool
 		wantFuzzErr bool
 	}{
@@ -109,9 +109,9 @@ func Test_checkOneFuzz(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name     string
+		fileName []string
 		want     bool
 		wantErr  bool
-		fileName []string
 	}{
 		{
 			name:     "Test_checkOneFuzz success",
@@ -168,10 +168,10 @@ func Test_checkCFLite(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name        string
+		fileContent string
+		fileName    []string
 		want        bool
 		wantErr     bool
-		fileName    []string
-		fileContent string
 	}{
 		{
 			name:        "Test_checkCFLite success",
@@ -222,11 +222,11 @@ func Test_fuzzFileAndFuncMatchPattern(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name              string
-		expectedFileMatch bool
-		expectedFuncMatch bool
 		lang              clients.LanguageName
 		fileName          string
 		fileContent       string
+		expectedFileMatch bool
+		expectedFuncMatch bool
 		wantErr           bool
 	}{
 		{
@@ -297,11 +297,11 @@ func Test_checkFuzzFunc(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name        string
-		want        bool
-		wantErr     bool
+		fileContent string
 		langs       []clients.Language
 		fileName    []string
-		fileContent string
+		want        bool
+		wantErr     bool
 	}{
 		{
 			name:    "Test_checkFuzzFunc failure",

--- a/checks/raw/gitlab/packaging_test.go
+++ b/checks/raw/gitlab/packaging_test.go
@@ -30,8 +30,8 @@ func TestGitlabPackagingYamlCheck(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name       string
-		lineNumber uint
 		filename   string
+		lineNumber uint
 		exists     bool
 	}{
 		{
@@ -103,8 +103,8 @@ func TestGitlabPackagingPackager(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name       string
-		lineNumber uint
 		filename   string
+		lineNumber uint
 		exists     bool
 	}{
 		{

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -31,10 +31,10 @@ func TestGithubWorkflowPinning(t *testing.T) {
 
 	//nolint
 	tests := []struct {
-		warns    int
 		err      error
 		name     string
 		filename string
+		warns    int
 	}{
 		{
 			name:     "empty file",
@@ -187,10 +187,10 @@ func TestNonGithubWorkflowPinning(t *testing.T) {
 
 	//nolint
 	tests := []struct {
-		warns    int
 		err      error
 		name     string
 		filename string
+		warns    int
 	}{
 		{
 			name:     "Pinned non-github workflow",
@@ -257,10 +257,10 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 
 	//nolint
 	tests := []struct {
-		warns    int
 		err      error
 		name     string
 		filename string
+		warns    int
 	}{
 		{
 			name:     "npm packages without verification",
@@ -306,10 +306,10 @@ func TestDockerfilePinning(t *testing.T) {
 
 	//nolint
 	tests := []struct {
-		warns    int
 		err      error
 		name     string
 		filename string
+		warns    int
 	}{
 		{
 			name:     "invalid dockerfile",
@@ -538,9 +538,9 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 		filename string
 		expected []struct {
 			snippet   string
+			t         checker.DependencyUseType
 			startLine uint
 			endLine   uint
-			t         checker.DependencyUseType
 		}
 	}{
 		{
@@ -549,9 +549,9 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 			//nolint
 			expected: []struct {
 				snippet   string
+				t         checker.DependencyUseType
 				startLine uint
 				endLine   uint
-				t         checker.DependencyUseType
 			}{
 				{
 					snippet:   "curl bla | bash",
@@ -633,9 +633,9 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 			//nolint
 			expected: []struct {
 				snippet   string
+				t         checker.DependencyUseType
 				startLine uint
 				endLine   uint
-				t         checker.DependencyUseType
 			}{
 				{
 					snippet:   "/tmp/file3",
@@ -704,9 +704,9 @@ func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 		filename string
 		expected []struct {
 			snippet   string
+			t         checker.DependencyUseType
 			startLine uint
 			endLine   uint
-			t         checker.DependencyUseType
 		}
 	}{
 		{
@@ -715,9 +715,9 @@ func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 			//nolint
 			expected: []struct {
 				snippet   string
+				t         checker.DependencyUseType
 				startLine uint
 				endLine   uint
-				t         checker.DependencyUseType
 			}{
 				{
 					snippet:   "bash /tmp/file",
@@ -885,10 +885,10 @@ func TestDockerfilePinningWihoutHash(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
-		warns    int
 		err      error
 		name     string
 		filename string
+		warns    int
 	}{
 		{
 			name:     "Pinned dockerfile as no hash",
@@ -940,10 +940,10 @@ func TestDockerfileScriptDownload(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
-		warns    int
 		err      error
 		name     string
 		filename string
+		warns    int
 	}{
 		{
 			name:     "curl | sh",
@@ -1045,10 +1045,10 @@ func TestDockerfileScriptDownloadInfo(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
+		err      error
 		name     string
 		filename string
 		warns    int
-		err      error
 	}{
 		{
 			name:     "curl | sh",
@@ -1089,11 +1089,11 @@ func TestShellScriptDownload(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
+		err      error
 		name     string
 		filename string
 		warns    int
 		debugs   int
-		err      error
 	}{
 		{
 			name:     "sh script",
@@ -1171,10 +1171,10 @@ func TestShellScriptDownloadPinned(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
+		err      error
 		name     string
 		filename string
 		warns    int
-		err      error
 	}{
 		{
 			name:     "sh script",
@@ -1221,10 +1221,10 @@ func TestGitHubWorflowRunDownload(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
+		err      error
 		name     string
 		filename string
 		warns    int
-		err      error
 	}{
 		{
 			name:     "workflow curl default",

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -66,11 +66,11 @@ func TestSecurityPolicy(t *testing.T) {
 	//nolint
 	tests := []struct {
 		name    string
-		files   []string
 		path    string
+		files   []string
 		result  checker.SecurityPolicyData
-		wantErr bool
 		want    scut.TestReturn
+		wantErr bool
 	}{
 		{
 			name: "security.md",

--- a/checks/raw/vulnerabilities_test.go
+++ b/checks/raw/vulnerabilities_test.go
@@ -31,13 +31,13 @@ func TestVulnerabilities(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
+		err             error
 		name            string
 		want            checker.VulnerabilitiesData
-		err             error
-		wantErr         bool
 		vulnsResponse   clients.VulnerabilitiesResponse
-		numberofCommits int
 		expected        scut.TestReturn
+		numberofCommits int
+		wantErr         bool
 		vulnsError      bool
 	}{
 		{

--- a/checks/raw/webhooks_test.go
+++ b/checks/raw/webhooks_test.go
@@ -31,13 +31,13 @@ func TestWebhooks(t *testing.T) {
 	t.Parallel()
 	//nolint
 	tests := []struct {
-		name                   string
 		err                    error
+		name                   string
 		uri                    string
-		wantErr                bool
-		expectedUsesAuthSecret int
-		expected               scut.TestReturn
 		webhookResponse        []clients.Webhook
+		expected               scut.TestReturn
+		expectedUsesAuthSecret int
+		wantErr                bool
 	}{
 		{
 			name:            "No Webhooks",

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -36,13 +36,13 @@ func Test_SAST(t *testing.T) {
 
 	//nolint: govet, goerr113
 	tests := []struct {
-		name          string
-		commits       []clients.Commit
 		err           error
-		searchresult  clients.SearchResponse
-		checkRuns     []clients.CheckRun
 		searchRequest clients.SearchRequest
+		name          string
 		path          string
+		commits       []clients.Commit
+		checkRuns     []clients.CheckRun
+		searchresult  clients.SearchResponse
 		expected      checker.CheckResult
 	}{
 		{
@@ -272,9 +272,9 @@ func Test_validateSonarConfig(t *testing.T) {
 	tests := []struct {
 		name      string
 		path      string
+		url       string
 		offset    uint
 		endOffset uint
-		url       string
 		score     int
 	}{
 		{

--- a/checks/security_policy_test.go
+++ b/checks/security_policy_test.go
@@ -33,8 +33,8 @@ func TestSecurityPolicy(t *testing.T) {
 		name    string
 		path    string
 		files   []string
-		wantErr bool
 		want    scut.TestReturn
+		wantErr bool
 	}{
 		{
 			name: "security.md",

--- a/checks/webhook_test.go
+++ b/checks/webhook_test.go
@@ -30,11 +30,11 @@ import (
 func TestWebhooks(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		expected checker.CheckResult
-		uri      string
 		err      error
+		uri      string
 		name     string
 		webhooks []clients.Webhook
+		expected checker.CheckResult
 	}{
 		{
 			name: "No Webhooks",

--- a/finding/finding.go
+++ b/finding/finding.go
@@ -45,11 +45,11 @@ const (
 // Location represents the location of a finding.
 // nolint: govet
 type Location struct {
-	Type      FileType `json:"type"`
-	Path      string   `json:"path"`
 	LineStart *uint    `json:"lineStart,omitempty"`
 	LineEnd   *uint    `json:"lineEnd,omitempty"`
 	Snippet   *string  `json:"snippet,omitempty"`
+	Path      string   `json:"path"`
+	Type      FileType `json:"type"`
 }
 
 // Outcome is the result of a finding.
@@ -95,20 +95,18 @@ const (
 // Finding represents a finding.
 // nolint: govet
 type Finding struct {
-	Probe       string             `json:"probe"`
-	Outcome     Outcome            `json:"outcome"`
-	Message     string             `json:"message"`
 	Location    *Location          `json:"location,omitempty"`
 	Remediation *probe.Remediation `json:"remediation,omitempty"`
 	Values      map[string]int     `json:"values,omitempty"`
+	Probe       string             `json:"probe"`
+	Message     string             `json:"message"`
+	Outcome     Outcome            `json:"outcome"`
 }
 
 // AnonymousFinding is a finding without a corerpsonding probe ID.
 type AnonymousFinding struct {
-	Finding
-	// Remove the probe ID from
-	// the structure until the probes are GA.
 	Probe string `json:"probe,omitempty"`
+	Finding
 }
 
 var errInvalid = errors.New("invalid")

--- a/finding/finding_test.go
+++ b/finding/finding_test.go
@@ -40,13 +40,13 @@ func Test_FromBytes(t *testing.T) {
 	t.Parallel()
 	// nolint:govet
 	tests := []struct {
+		err      error
+		outcome  *Outcome
+		metadata map[string]string
+		finding  *Finding
 		name     string
 		id       string
 		path     string
-		outcome  *Outcome
-		err      error
-		metadata map[string]string
-		finding  *Finding
 	}{
 		{
 			name:    "effort low",
@@ -205,10 +205,10 @@ func TestOutcome_UnmarshalYAML(t *testing.T) {
 	type args struct {
 		n *yaml.Node
 	}
-	tests := []struct { //nolint:govet
+	tests := []struct {
+		args        args
 		name        string
 		wantOutcome Outcome
-		args        args
 		wantErr     bool
 	}{
 		{

--- a/finding/probe/probe.go
+++ b/finding/probe/probe.go
@@ -69,11 +69,11 @@ type yamlProbe struct {
 
 // nolint: govet
 type Probe struct {
+	Remediation    *Remediation
 	ID             string
 	Short          string
 	Motivation     string
 	Implementation string
-	Remediation    *Remediation
 }
 
 // FromBytes creates a probe from a file.

--- a/finding/probe/probe_test.go
+++ b/finding/probe/probe_test.go
@@ -31,11 +31,11 @@ func Test_FromBytes(t *testing.T) {
 	t.Parallel()
 	// nolint: govet
 	tests := []struct {
+		err   error
+		probe *Probe
 		name  string
 		id    string
 		path  string
-		err   error
-		probe *Probe
 	}{
 		{
 			name: "all fields set",

--- a/pkg/common_test.go
+++ b/pkg/common_test.go
@@ -26,9 +26,9 @@ func TestDetailString(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name   string
-		detail checker.CheckDetail
 		log    log.Level
 		want   string
+		detail checker.CheckDetail
 	}{
 		{
 			name: "ignoreDebug",

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -49,11 +49,11 @@ type jsonCheckDocumentationV2 struct {
 
 // nolint: govet
 type jsonCheckResultV2 struct {
-	Details []string                 `json:"details"`
-	Score   int                      `json:"score"`
+	Doc     jsonCheckDocumentationV2 `json:"documentation"`
 	Reason  string                   `json:"reason"`
 	Name    string                   `json:"name"`
-	Doc     jsonCheckDocumentationV2 `json:"documentation"`
+	Details []string                 `json:"details"`
+	Score   int                      `json:"score"`
 }
 
 type jsonRepoV2 struct {
@@ -77,12 +77,12 @@ func (s jsonFloatScore) MarshalJSON() ([]byte, error) {
 //
 //nolint:govet
 type JSONScorecardResultV2 struct {
-	Date           string              `json:"date"`
 	Repo           jsonRepoV2          `json:"repo"`
 	Scorecard      jsonScorecardV2     `json:"scorecard"`
-	AggregateScore jsonFloatScore      `json:"score"`
+	Date           string              `json:"date"`
 	Checks         []jsonCheckResultV2 `json:"checks"`
 	Metadata       []string            `json:"metadata"`
+	AggregateScore jsonFloatScore      `json:"score"`
 }
 
 // AsJSON exports results as JSON for new detail format.

--- a/pkg/json_raw_results_test.go
+++ b/pkg/json_raw_results_test.go
@@ -29,10 +29,10 @@ import (
 func TestAsPointer(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
+	tests := []struct {
+		expected *string
 		name     string
 		input    string
-		expected *string
 	}{
 		{
 			name:     "test_empty_string",
@@ -66,9 +66,9 @@ func TestAsPointer(t *testing.T) {
 func TestJsonScorecardRawResult_AddPackagingRawResults(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.PackagingData
+		name      string
 		wantError bool
 	}{
 		{
@@ -145,9 +145,9 @@ func TestJsonScorecardRawResult_AddPackagingRawResults(t *testing.T) {
 func TestJsonScorecardRawResult_AddTokenPermissionsRawResults(t *testing.T) {
 	t.Parallel()
 	loc := checker.PermissionLocation("testLocationType")
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.TokenPermissionsData
+		name      string
 		wantError bool
 	}{
 		{
@@ -225,9 +225,9 @@ func TestJsonScorecardRawResult_AddTokenPermissionsRawResults(t *testing.T) {
 func TestJsonScorecardRawResult_AddDependencyPinningRawResults(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.PinningDependenciesData
+		name      string
 		wantError bool
 	}{
 		{
@@ -291,9 +291,9 @@ func TestJsonScorecardRawResult_AddDependencyPinningRawResults(t *testing.T) {
 func TestJsonScorecardRawResult_AddDangerousWorkflowRawResults(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.DangerousWorkflowData
+		name      string
 		wantError bool
 	}{
 		{
@@ -336,9 +336,9 @@ func TestJsonScorecardRawResult_AddDangerousWorkflowRawResults(t *testing.T) {
 func TestJsonScorecardRawResult_AddContributorsRawResults(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.ContributorsData
+		name      string
 		wantError bool
 	}{
 		{
@@ -376,9 +376,9 @@ func TestJsonScorecardRawResult_AddContributorsRawResults(t *testing.T) {
 func TestJsonScorecardRawResult_AddSignedReleasesRawResults(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.SignedReleasesData
+		name      string
 		wantError bool
 	}{
 		{
@@ -418,9 +418,9 @@ func TestJsonScorecardRawResult_AddSignedReleasesRawResults(t *testing.T) {
 func TestJsonScorecardRawResult_AddMaintainedRawResults(t *testing.T) {
 	t.Parallel()
 	c := clients.RepoAssociationNone
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.MaintainedData
+		name      string
 		wantError bool
 	}{
 		{
@@ -551,9 +551,9 @@ func TestSetDefaultCommitData(t *testing.T) {
 func TestJsonScorecardRawResult_AddOssfBestPracticesRawResults(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.CIIBestPracticesData
+		name      string
 		wantError bool
 	}{
 		{
@@ -592,9 +592,9 @@ func TestJsonScorecardRawResult_AddOssfBestPracticesRawResults(t *testing.T) {
 func TestJsonScorecardRawResult_AddCodeReviewRawResults(t *testing.T) {
 	t.Parallel()
 
-	tests := []struct { //nolint:govet
-		name      string
+	tests := []struct {
 		input     *checker.CodeReviewData
+		name      string
 		wantError bool
 	}{
 		{
@@ -1227,17 +1227,17 @@ func intPtr(i int32) *int32 {
 //nolint:lll
 func TestScorecardResult_AsRawJSON(t *testing.T) {
 	type fields struct {
-		Repo       RepoInfo
 		Date       time.Time
+		Repo       RepoInfo
 		Scorecard  ScorecardInfo
 		Checks     []checker.CheckResult
-		RawResults checker.RawResults
 		Metadata   []string
+		RawResults checker.RawResults
 	}
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name       string
-		fields     fields
 		wantWriter string
+		fields     fields
 		wantErr    bool
 	}{
 		{
@@ -1278,10 +1278,10 @@ func TestScorecardResult_AsRawJSON(t *testing.T) {
 
 func TestAddBranchProtectionRawResults(t *testing.T) {
 	t.Parallel()
-	testCases := []struct { //nolint:govet
-		name     string
+	testCases := []struct {
 		input    *checker.BranchProtectionsData
 		expected *jsonScorecardRawResult
+		name     string
 	}{
 		{
 			name: "no branch protections",

--- a/pkg/json_test.go
+++ b/pkg/json_test.go
@@ -84,9 +84,9 @@ func TestJSONOutput(t *testing.T) {
 	tests := []struct {
 		name        string
 		expected    string
-		showDetails bool
 		logLevel    log.Level
 		result      ScorecardResult
+		showDetails bool
 	}{
 		{
 			name:        "check-1",

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -46,13 +46,13 @@ type RepoInfo struct {
 // ScorecardResult struct is returned on a successful Scorecard run.
 // nolint
 type ScorecardResult struct {
-	Repo       RepoInfo
 	Date       time.Time
+	Repo       RepoInfo
 	Scorecard  ScorecardInfo
 	Checks     []checker.CheckResult
-	RawResults checker.RawResults
 	Findings   []finding.Finding
 	Metadata   []string
+	RawResults checker.RawResults
 }
 
 func scoreToString(s float64) string {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR runs fieldalignment on `./checker`, `./checks`, `./finding` and `./pkg`.

`fieldAlignment` complains in make `check-linter`, but running `fieldAlignment` also removes comments, so I am not quite sure about it.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### Which issue(s) this PR fixes
NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
