### PR TITLE
:bug: scdiff: fix generate cmd when no `--checks` arg provided

### DIFF
--- a/cmd/internal/scdiff/app/generate.go
+++ b/cmd/internal/scdiff/app/generate.go
@@ -60,7 +60,10 @@ var (
 				defer outputF.Close()
 				output = outputF
 			}
-			checks := strings.Split(checksArg, ",")
+			var checks []string
+			if checksArg != "" {
+				checks = strings.Split(checksArg, ",")
+			}
 			r := runner.New(checks)
 			return generate(&r, input, output)
 		},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
When no `--checks` arg is provided, the `checksArg` string is the empty string. 
`strings.Split` of the empty string returns a slice containing the empty string, so the `parseChecks` helper func thought it was a requested check.

#### What is the new behavior (if this is a feature change)?**
If no arg is provided, `strings.Split` isn't called, so the intended "run all check instead" behavior is used.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Followup of #3535 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
I could alternatively return an error if a requested check doesn't match the available checks 

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
