### PR TITLE
:sparkles: scdiff: improve `compare` usability

### DIFF
--- a/cmd/internal/scdiff/app/compare.go
+++ b/cmd/internal/scdiff/app/compare.go
@@ -68,6 +68,8 @@ func compareReaders(x, y io.Reader, output io.Writer) error {
 	xs.Buffer(nil, maxResultSize)
 	ys := bufio.NewScanner(y)
 	ys.Buffer(nil, maxResultSize)
+
+	var differs bool
 	for {
 		if shouldContinue, err := advanceScanners(xs, ys); err != nil {
 			return err
@@ -82,8 +84,11 @@ func compareReaders(x, y io.Reader, output io.Writer) error {
 			// go-cmp says its not production ready. Is this a valid usage?
 			// it certainly helps with readability.
 			fmt.Fprintf(output, "%s\n", cmp.Diff(xResult, yResult))
-			return errResultsDiffer
+			differs = true
 		}
+	}
+	if differs {
+		return errResultsDiffer
 	}
 	return nil
 }

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -16,6 +16,7 @@ package pkg
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -185,7 +186,11 @@ func ExperimentalFromJSON2(r io.Reader) (result ScorecardResult, score float64, 
 		return ScorecardResult{}, 0, fmt.Errorf("decode json: %w", err)
 	}
 
+	var parseErr *time.ParseError
 	date, err := time.Parse(time.RFC3339, jsr.Date)
+	if errors.As(err, &parseErr) {
+		date, err = time.Parse("2006-01-02", jsr.Date)
+	}
 	if err != nil {
 		return ScorecardResult{}, 0, fmt.Errorf("parse scorecard analysis time: %w", err)
 	}

--- a/pkg/json_test.go
+++ b/pkg/json_test.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"strings"
 	"testing"
 	"time"
 
@@ -486,6 +487,46 @@ func TestJSONOutput(t *testing.T) {
 					s += fmt.Sprintf("- %s\n", desc)
 				}
 				t.Fatalf("%s: invalid format: %s", tt.name, s)
+			}
+		})
+	}
+}
+
+func TestExperimentalFromJSON2_time(t *testing.T) {
+	t.Parallel()
+	//nolint:lll,govet // result strings are long
+	tests := []struct {
+		name    string
+		result  string
+		want    time.Time
+		wantErr bool
+	}{
+		{
+			name:   "main RFC3339 format",
+			result: `{"date":"2006-01-02T15:04:05+00:00","repo":{"name":"github.com/foo/bar","commit":"HEAD"},"score":-1.0,"metadata":null}`,
+			want:   time.Date(2006, time.January, 2, 15, 4, 5, 0, time.UTC),
+		},
+		{
+			name:   "backup 2006-01-02 format",
+			result: `{"date":"2023-09-26","repo":{"name":"github.com/foo/bar","commit":"HEAD"},"score":-1.0,"metadata":null}`,
+			want:   time.Date(2023, time.September, 26, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name:    "not RFC3339 or 2006-01-02 format",
+			result:  `{"date":"January 1, 2023","repo":{"name":"github.com/foo/bar","commit":"HEAD"},"score":-1.0,"metadata":null}`,
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, _, err := ExperimentalFromJSON2(strings.NewReader(tt.result))
+			if tt.wantErr != (err != nil) {
+				t.Fatalf("got: %v, wantedErr: %v", err, tt.wantErr)
+			}
+			if !got.Date.Equal(tt.want) {
+				t.Errorf("got: %v, wanted: %v", got.Date, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

scdiff enhancement

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- timestamps must be RFC3339, which works for data generated by `scdiff generate`. but the cron data uses the `2006-01-02` format.
- `compare` stops at the first error

#### What is the new behavior (if this is a feature change)?**

- Tries to parse again as `2006-01-02` format if parsing as `RFC3339` doesn't work.
- prints all differences, not just the first.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
