### PR TITLE
:bug: Fix SAST no longer working for CodeQL

### DIFF
--- a/checks/sast.go
+++ b/checks/sast.go
@@ -36,7 +36,12 @@ const CheckSAST = "SAST"
 
 var errInvalid = errors.New("invalid")
 
-var sastTools = map[string]bool{"github-advanced-security": true, "github-code-scanning": true, "lgtm-com": true, "sonarcloud": true}
+var sastTools = map[string]bool{
+	"github-advanced-security": true,
+	"github-code-scanning":     true,
+	"lgtm-com":                 true,
+	"sonarcloud":               true,
+}
 
 var allowedConclusions = map[string]bool{"success": true, "neutral": true}
 

--- a/checks/sast.go
+++ b/checks/sast.go
@@ -36,7 +36,7 @@ const CheckSAST = "SAST"
 
 var errInvalid = errors.New("invalid")
 
-var sastTools = map[string]bool{"github-code-scanning": true, "lgtm-com": true, "sonarcloud": true}
+var sastTools = map[string]bool{"github-advanced-security": true, "github-code-scanning": true, "lgtm-com": true, "sonarcloud": true}
 
 var allowedConclusions = map[string]bool{"success": true, "neutral": true}
 

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -60,7 +60,53 @@ func Test_SAST(t *testing.T) {
 			expected:     checker.CheckResult{Score: -1},
 		},
 		{
-			name: "Successful SAST checker should return success status",
+			name: "Successful SAST checker should return success status for github-advanced-security",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 1),
+					},
+				},
+			},
+			searchresult: clients.SearchResponse{},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "github-advanced-security",
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 10,
+			},
+		},
+		{
+			name: "Successful SAST checker should return success status for github-code-scanning",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 1),
+					},
+				},
+			},
+			searchresult: clients.SearchResponse{},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "github-code-scanning",
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 10,
+			},
+		},
+		{
+			name: "Successful SAST checker should return success status for lgtm",
 			commits: []clients.Commit{
 				{
 					AssociatedMergeRequest: clients.PullRequest{
@@ -75,6 +121,29 @@ func Test_SAST(t *testing.T) {
 					Conclusion: "success",
 					App: clients.CheckRunApp{
 						Slug: "lgtm-com",
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 10,
+			},
+		},
+		{
+			name: "Successful SAST checker should return success status for sonarcloud",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						MergedAt: time.Now().Add(time.Hour - 1),
+					},
+				},
+			},
+			searchresult: clients.SearchResponse{},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "sonarcloud",
 					},
 				},
 			},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

The app slug for CodeQL appears to have changed from `github-advanced-security` to `github-code-scanning`, causing the SAST rule to false-negative on commits.

This appears to have happened some time in the last week (the JSON below suggests from `2023-10-17T19:04:33Z` when the app was last updated). I looked into this today after noticing a lot of security warnings appearing in repos I maintain advising that a SAST tool isn't being used this week where it was previously working fine and with no changes to its infrastructure.

Here are some GitHub API responses showing the change to the app's slug in the check runs for commits tested in a pull request.

- [martincostello/lambda-test-server@448887974ed92795d8c5994300d29b4b9a99fb37](https://api.github.com/repos/martincostello/lambda-test-server/commits/448887974ed92795d8c5994300d29b4b9a99fb37/check-runs)
- [App-vNext/Polly@dd5d87c206b878ebde6133d7ea202d91007c5191](https://api.github.com/repos/App-vNext/Polly/commits/dd5d87c206b878ebde6133d7ea202d91007c5191/check-runs)

Here's a snippet of a relevant part:

```json
{
  "id": 17900833160,
  "name": "CodeQL",
  "head_sha": "dd5d87c206b878ebde6133d7ea202d91007c5191",
  "url": "https://api.github.com/repos/App-vNext/Polly/check-runs/17900833160",
  "html_url": "https://github.com/App-vNext/Polly/runs/17900833160",
  "details_url": "https://github.com/App-vNext/Polly/runs/17900833160",
  "status": "completed",
  "conclusion": "success",
  "started_at": "2023-10-20T13:37:12Z",
  "completed_at": "2023-10-20T13:37:15Z",
  "output": {
    "title": "No new alerts in code changed by this pull request",
    "summary": "[View all branch alerts](/App-vNext/Polly/security/code-scanning?query=pr%3A1714+tool%3ACodeQL+is%3Aopen).",
    "text": null,
    "annotations_count": 0,
    "annotations_url": "https://api.github.com/repos/App-vNext/Polly/check-runs/17900833160/annotations"
  },
  "check_suite": {
    "id": 17452500301
  },
  "app": {
    "id": 57789,
    "slug": "github-advanced-security",
    "node_id": "MDM6QXBwNTc3ODk=",
    "owner": {
      "login": "github"
    },
    "name": "GitHub Advanced Security",
    "description": "",
    "external_url": "https://github.com/features/security",
    "html_url": "https://github.com/apps/github-advanced-security",
    "created_at": "2020-03-17T21:25:09Z",
    "updated_at": "2023-10-17T19:04:33Z"
  }
}
```

This change adds `github-advanced-security` to the list of supported GitHub App slugs that signify use of a SAST tool.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Repositories previously scoring 10/10 for a SAST tool usage score 7/10 as its use is no longer detected on commits.

```
Reason

SAST tool detected but not run on all commits

Details

Warn: 0 commits out of 30 are checked with a SAST tool
Info: SAST tool detected: CodeQL
```

#### What is the new behavior (if this is a feature change)?**

Commits scanned with CodeQL are correctly identified again.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Fix usage of GitHub CodeQL not being detected correctly.
```
