### PR TITLE
:seedling: Fix linter issues caught by new linters in golangci-lint v1.55.0

### DIFF
--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -91,9 +91,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		// or their indirect imports through the higher-level Hspec or Tasty testing frameworks.
 		funcPattern: `import\s+(qualified\s+)?Test\.((Hspec|Tasty)\.)?(QuickCheck|Hedgehog|Validity|SmallCheck)`,
 		Name:        fuzzerPropertyBasedHaskell,
-		Desc: asPointer(
-			"Property-based testing in Haskell generates test instances randomly or exhaustively " +
-				"and test that specific properties are satisfied."),
+		Desc:        propertyBasedDescription("Haskell"),
 	},
 	// Fuzz patterns for JavaScript and TypeScript based on property-based testing.
 	//
@@ -110,9 +108,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		funcPattern: `(from\s+['"](fast-check|@fast-check/(ava|jest|vitest))['"]|` +
 			`require\(\s*['"](fast-check|@fast-check/(ava|jest|vitest))['"]\s*\))`,
 		Name: fuzzerPropertyBasedJavaScript,
-		Desc: asPointer(
-			"Property-based testing in JavaScript generates test instances randomly or exhaustively " +
-				"and test that specific properties are satisfied."),
+		Desc: propertyBasedDescription("JavaScript"),
 	},
 	clients.TypeScript: {
 		filePatterns: []string{"*.ts"},
@@ -120,9 +116,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		funcPattern: `(from\s+['"](fast-check|@fast-check/(ava|jest|vitest))['"]|` +
 			`require\(\s*['"](fast-check|@fast-check/(ava|jest|vitest))['"]\s*\))`,
 		Name: fuzzerPropertyBasedTypeScript,
-		Desc: asPointer(
-			"Property-based testing in TypeScript generates test instances randomly or exhaustively " +
-				"and test that specific properties are satisfied."),
+		Desc: propertyBasedDescription("TypeScript"),
 	},
 	clients.Python: {
 		filePatterns: []string{"*.py"},
@@ -386,4 +380,10 @@ func getProminentLanguages(langs []clients.Language) []clients.LanguageName {
 		}
 	}
 	return ret
+}
+
+func propertyBasedDescription(language string) *string {
+	s := fmt.Sprintf("Property-based testing in %s generates test instances randomly or exhaustively "+
+		"and test that specific properties are satisfied.", language)
+	return &s
 }

--- a/cron/internal/controller/main.go
+++ b/cron/internal/controller/main.go
@@ -103,6 +103,7 @@ func localFiles(filenames []string) (data.Iterator, error) {
 	return iter, nil
 }
 
+//nolint:protogetter // this is a false positive https://github.com/ghostiam/protogetter/issues/4
 func main() {
 	ctx := context.Background()
 	t := time.Now().UTC()

--- a/cron/internal/pubsub/subscriber_gcs.go
+++ b/cron/internal/pubsub/subscriber_gcs.go
@@ -93,7 +93,7 @@ func (subscriber *gcsSubscriber) SynchronousPull() (*data.ScorecardBatchRequest,
 			log.Printf("error during Recieive: %v", err)
 			return nil, nil
 		}
-		numReceivedMessages = len(result.ReceivedMessages)
+		numReceivedMessages = len(result.GetReceivedMessages())
 		if numReceivedMessages > 0 {
 			msgToProcess = result.GetReceivedMessages()[0]
 		} else {
@@ -107,7 +107,7 @@ func (subscriber *gcsSubscriber) SynchronousPull() (*data.ScorecardBatchRequest,
 		log.Fatalf("expected to receive max %d messages, got %d", maxMessagesToPull, numReceivedMessages)
 	}
 
-	subscriber.recvdAckID = msgToProcess.AckId
+	subscriber.recvdAckID = msgToProcess.GetAckId()
 	// Continuously notify the server that processing is still happening on this message.
 	go subscriber.extendAckDeadline()
 

--- a/cron/internal/worker/main.go
+++ b/cron/internal/worker/main.go
@@ -174,25 +174,25 @@ func processRequest(ctx context.Context,
 	var rawBuffer bytes.Buffer
 	// TODO: run Scorecard for each repo in a separate thread.
 	for _, repoReq := range batchRequest.GetRepos() {
-		logger.Info(fmt.Sprintf("Running Scorecard for repo: %s", *repoReq.Url))
+		logger.Info(fmt.Sprintf("Running Scorecard for repo: %s", repoReq.GetUrl()))
 		var repo clients.Repo
 		var err error
 		repoClient := githubClient
 		disabledChecks := blacklistedChecks
-		if repo, err = gitlabrepo.MakeGitlabRepo(*repoReq.Url); err == nil { // repo is a gitlab url
+		if repo, err = gitlabrepo.MakeGitlabRepo(repoReq.GetUrl()); err == nil { // repo is a gitlab url
 			repoClient = gitlabClient
 			disabledChecks = gitlabDisabledChecks
-		} else if repo, err = githubrepo.MakeGithubRepo(*repoReq.Url); err != nil {
+		} else if repo, err = githubrepo.MakeGithubRepo(repoReq.GetUrl()); err != nil {
 			// TODO(log): Previously Warn. Consider logging an error here.
 			logger.Info(fmt.Sprintf("URL was neither valid GitLab nor GitHub: %v", err))
 			continue
 		}
-		repo.AppendMetadata(repoReq.Metadata...)
+		repo.AppendMetadata(repoReq.GetMetadata()...)
 
 		commitSHA := clients.HeadSHA
 		requiredRequestType := []checker.RequestType{}
-		if repoReq.Commit != nil && *repoReq.Commit != clients.HeadSHA {
-			commitSHA = *repoReq.Commit
+		if repoReq.GetCommit() != clients.HeadSHA {
+			commitSHA = repoReq.GetCommit()
 			requiredRequestType = append(requiredRequestType, checker.CommitBased)
 		}
 		checksToRun, err := policy.GetEnabled(nil /*policy*/, nil /*checks*/, requiredRequestType)

--- a/policy/policy.go
+++ b/policy/policy.go
@@ -200,7 +200,7 @@ func GetEnabled(
 
 func checksHavePolicies(sp *ScorecardPolicy, enabledChecks checker.CheckNameToFnMap) bool {
 	for checkName := range enabledChecks {
-		_, exists := sp.Policies[checkName]
+		_, exists := sp.GetPolicies()[checkName]
 		if !exists {
 			log.Printf("check %s has no policy declared", checkName)
 			return false

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -160,7 +160,7 @@ func TestChecksHavePolicies(t *testing.T) {
 		t.Error("Expected checks to have policies")
 	}
 
-	delete(sp.Policies, "Binary-Artifacts")
+	delete(sp.GetPolicies(), "Binary-Artifacts")
 	// Call the function being tested
 	result = checksHavePolicies(sp, check)
 
@@ -246,8 +246,8 @@ func TestParseFromFile(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %v", err)
 	}
-	if len(sp.Policies) != 3 {
-		t.Errorf("Unexpected number of policies: got %v, want %v", len(sp.Policies), 3)
+	if len(sp.GetPolicies()) != 3 {
+		t.Errorf("Unexpected number of policies: got %v, want %v", len(sp.GetPolicies()), 3)
 	}
 	invalidPolicy := "testdata/policy-invalid-score-0.yaml"
 	_, err = ParseFromFile(invalidPolicy)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

lint fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
There are linter errors

#### What is the new behavior (if this is a feature change)?**

Errors are either addressed or ignored if false positives.


- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

This is the second time this has happened, so I opened #3602 to get to the root cause.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
