### PR TITLE
:book: CODEOWNERS: Support distribution of code reviews via team assignments

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,12 +4,8 @@
 # the repo. Unless a later match takes precedence,
 # the following users/teams will be requested for
 # review when someone opens a pull request.
-# TODO(owners): For ease of management, this should eventually shift to a
-#               defined GitHub team instead of individual usernames
-* @azeemshaikh38 @justaugustus @laurentsimon @naveensrinivasan @spencerschrock @raghavkaul
+* @ossf/scorecard-maintainers
 
 # Docs
-# TODO(owners): For ease of management, this should eventually shift to a
-#               defined GitHub team instead of individual usernames
-*.md @olivekl
-/docs/ @olivekl
+*.md @ossf/scorecard-doc-maintainers
+/docs/ @ossf/scorecard-doc-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,21 @@
+# Maintainers
+
+## `scorecard-maintainers`
+
+- Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Cisco
+- Raghav Kaul ([@raghavkaul](https://github.com/raghavkaul)), Google
+- Spencer Schrock ([@spencerschrock](https://github.com/spencerschrock)), Google
+- Azeem Shaikh [@azeemshaikh38](https://github.com/azeemshaikh38), Google
+- Laurent Simon ([@laurentsimon](https://github.com/laurentsimon)), Google
+- Naveen Srinivasan ([@naveensrinivasan](https://github.com/naveensrinivasan)), Independent
+
+## `scorecard-doc-maintainers`
+
+- Kara Olive ([@olivekl](https://github.com/olivekl)), Google
+
+## Emeritus
+
+Former maintainers are listed here.
+Thanks for your contributions to Scorecard!
+
+- 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Docs update

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- (N/A) Tests for the changes have been added (for bug fixes/features)

Individual maintainer assignments within CODEOWNERS mean that we cannot take advantage of GitHub code review distribution schemes for team review assignments.

In this commit, we switch to team assignments within CODEOWNERS.

A common complaint with this approach is that unless you are a part of the GitHub organization, you will not be able to view a team's membership/understand who the maintainers of a project are.

To provide visibility into the maintainer list, we've added a MAINTAINERS.md here as well.

Resolves the TODO comments left in https://github.com/ossf/scorecard/pull/1530.

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
