### PR TITLE
:bug: remove probe remediations from detail strings

### DIFF
--- a/pkg/common.go
+++ b/pkg/common.go
@@ -62,10 +62,8 @@ func structuredResultString(d *checker.CheckDetail) string {
 		}
 	}
 
-	// Effort to remediate.
-	if f.Remediation != nil {
-		sb.WriteString(fmt.Sprintf(": %s (%s effort)", f.Remediation.Text, f.Remediation.Effort.String()))
-	}
+	// TODO(#3349) revisit remediation details later
+
 	return sb.String()
 }
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

data quality issue?

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
For now, this is just producing very long detail strings. Probably negatively affecting cron results

#### What is the new behavior (if this is a feature change)?**
Remediation details from findings aren't included in the detail strings

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Related to #3349
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
