### PR TITLE
:seedling: enable `nolintlint` linter and fix violations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -58,6 +58,7 @@ linters:
     - misspell
     - nakedret
     - nestif
+    - nolintlint
     - predeclared
     - staticcheck
     - stylecheck
@@ -152,6 +153,8 @@ linters-settings:
       - ptrToRefParam
       - typeUnparen
       - unnecessaryBlock
+  nolintlint:
+    require-specific: true
   wrapcheck:
     ignorePackageGlobs:
       - github.com/ossf/scorecard/v4/checks/fileparser

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -154,6 +154,8 @@ linters-settings:
       - typeUnparen
       - unnecessaryBlock
   nolintlint:
+    # `//nolint` should mention specific linter such as `//nolint:my-linter`
+    # Overly broad directives can hide unrelated issues
     require-specific: true
   wrapcheck:
     ignorePackageGlobs:

--- a/attestor/policy/attestation_policy_test.go
+++ b/attestor/policy/attestation_policy_test.go
@@ -170,7 +170,7 @@ func TestCheckPreventBinaryArtifacts(t *testing.T) {
 func TestCheckCodeReviewed(t *testing.T) {
 	t.Parallel()
 
-	// nolint
+	//nolint
 	tests := []struct {
 		err      error
 		raw      *checker.RawResults
@@ -385,7 +385,7 @@ func asPointer(s string) *string {
 func TestNoUnpinnedDependencies(t *testing.T) {
 	t.Parallel()
 
-	// nolint
+	//nolint
 	tests := []struct {
 		err      error
 		raw      *checker.RawResults

--- a/attestor/policy/attestation_policy_test.go
+++ b/attestor/policy/attestation_policy_test.go
@@ -170,7 +170,7 @@ func TestCheckPreventBinaryArtifacts(t *testing.T) {
 func TestCheckCodeReviewed(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		err      error
 		raw      *checker.RawResults
@@ -385,7 +385,7 @@ func asPointer(s string) *string {
 func TestNoUnpinnedDependencies(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		err      error
 		raw      *checker.RawResults

--- a/checker/check_result_test.go
+++ b/checker/check_result_test.go
@@ -50,7 +50,7 @@ func TestAggregateScores(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := AggregateScores(tt.args.scores...); got != tt.want { //nolint:govet
+			if got := AggregateScores(tt.args.scores...); got != tt.want {
 				t.Errorf("AggregateScores() = %v, want %v", got, tt.want)
 			}
 		})
@@ -86,7 +86,7 @@ func TestAggregateScoresWithWeight(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := AggregateScoresWithWeight(tt.args.scores); got != tt.want { //nolint:govet
+			if got := AggregateScoresWithWeight(tt.args.scores); got != tt.want {
 				t.Errorf("AggregateScoresWithWeight() = %v, want %v", got, tt.want)
 			}
 		})
@@ -132,8 +132,8 @@ func TestCreateProportionalScore(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := CreateProportionalScore(tt.args.success, tt.args.total); got != tt.want { //nolint:govet
-				t.Errorf("CreateProportionalScore() = %v, want %v", got, tt.want) //nolint:govet
+			if got := CreateProportionalScore(tt.args.success, tt.args.total); got != tt.want {
+				t.Errorf("CreateProportionalScore() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -438,8 +438,8 @@ func TestNormalizeReason(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := NormalizeReason(tt.args.reason, tt.args.score); got != tt.want { //nolint:govet
-				t.Errorf("NormalizeReason() = %v, want %v", got, tt.want) //nolint:govet
+			if got := NormalizeReason(tt.args.reason, tt.args.score); got != tt.want {
+				t.Errorf("NormalizeReason() = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -490,8 +490,8 @@ func TestCreateResultWithScore(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := CreateResultWithScore(tt.args.name, tt.args.reason, tt.args.score); !cmp.Equal(got, tt.want) { //nolint:lll,govet
-				t.Errorf("CreateResultWithScore() = %v, want %v", got, cmp.Diff(got, tt.want)) //nolint:govet
+			if got := CreateResultWithScore(tt.args.name, tt.args.reason, tt.args.score); !cmp.Equal(got, tt.want) {
+				t.Errorf("CreateResultWithScore() = %v, want %v", got, cmp.Diff(got, tt.want))
 			}
 		})
 	}
@@ -545,8 +545,8 @@ func TestCreateProportionalScoreResult(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := CreateProportionalScoreResult(tt.args.name, tt.args.reason, tt.args.b, tt.args.t); !cmp.Equal(got, tt.want) { //nolint:govet,lll
-				t.Errorf("CreateProportionalScoreResult() = %v, want %v", got, cmp.Diff(got, tt.want)) //nolint:govet
+			if got := CreateProportionalScoreResult(tt.args.name, tt.args.reason, tt.args.b, tt.args.t); !cmp.Equal(got, tt.want) { //nolint:lll
+				t.Errorf("CreateProportionalScoreResult() = %v, want %v", got, cmp.Diff(got, tt.want))
 			}
 		})
 	}
@@ -594,7 +594,7 @@ func TestCreateMaxScoreResult(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := CreateMaxScoreResult(tt.args.name, tt.args.reason); !cmp.Equal(got, tt.want) { //nolint:govet
+			if got := CreateMaxScoreResult(tt.args.name, tt.args.reason); !cmp.Equal(got, tt.want) {
 				t.Errorf("CreateMaxScoreResult() = %v, want %v", got, cmp.Diff(got, tt.want))
 			}
 		})
@@ -643,7 +643,7 @@ func TestCreateMinScoreResult(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := CreateMinScoreResult(tt.args.name, tt.args.reason); !cmp.Equal(got, tt.want) { //nolint:govet
+			if got := CreateMinScoreResult(tt.args.name, tt.args.reason); !cmp.Equal(got, tt.want) {
 				t.Errorf("CreateMinScoreResult() = %v, want %v", got, cmp.Diff(got, tt.want))
 			}
 		})

--- a/checker/client_test.go
+++ b/checker/client_test.go
@@ -20,9 +20,8 @@ import (
 	"github.com/ossf/scorecard/v4/log"
 )
 
-// nolint:paralleltest
-// because we are using t.Setenv.
-func TestGetClients(t *testing.T) { //nolint:gocognit
+//nolint:paralleltest // because we are using t.Setenv.
+func TestGetClients(t *testing.T) {
 	type args struct { //nolint:govet
 		ctx      context.Context
 		repoURI  string

--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -25,7 +25,8 @@ import (
 
 // RawResults contains results before a policy
 // is applied.
-// nolint
+//
+//nolint:govet
 type RawResults struct {
 	BinaryArtifactResults       BinaryArtifactData
 	BranchProtectionResults     BranchProtectionsData
@@ -77,7 +78,6 @@ type PackagingData struct {
 }
 
 // Package represents a package.
-// nolint
 type Package struct {
 	// TODO: not supported yet. This needs to be unique across
 	// ecosystems: purl, OSV, CPE, etc.

--- a/checks/all_checks_test.go
+++ b/checks/all_checks_test.go
@@ -23,12 +23,12 @@ import (
 
 func Test_registerCheck(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	type args struct {
 		name string
 		fn   checker.CheckFn
 	}
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name    string
 		args    args

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -57,7 +57,6 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 
 	rel1 := "release/v.1"
 	sha := "8fb3cb86082b17144a80402f5367ae65f06083bd"
-	//nolint:goconst
 	main := "main"
 	trueVal := true
 	falseVal := false

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -64,7 +64,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 
 	var oneVal int32 = 1
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name          string
 		expected      scut.TestReturn

--- a/checks/code_review_test.go
+++ b/checks/code_review_test.go
@@ -30,8 +30,7 @@ import (
 // TestCodeReview tests the code review checker.
 func TestCodereview(t *testing.T) {
 	t.Parallel()
-	//fieldalignment lint issue. Ignoring it as it is not important for this test.
-	//nolint
+	//nolint:goerr113
 	tests := []struct {
 		err       error
 		name      string

--- a/checks/contributors_test.go
+++ b/checks/contributors_test.go
@@ -29,8 +29,6 @@ import (
 // TestContributors tests the contributors check.
 func TestContributors(t *testing.T) {
 	t.Parallel()
-	//fieldalignment lint issue. Ignoring it as it is not important for this test.
-	//nolint
 	tests := []struct {
 		err      error
 		name     string
@@ -61,7 +59,6 @@ func TestContributors(t *testing.T) {
 			name: "Valid contributors with enough contributors and companies",
 			contrib: []clients.User{
 				{
-
 					Companies:        []string{"company1"},
 					NumContributions: 10,
 					Organizations: []clients.User{
@@ -146,7 +143,7 @@ func TestContributors(t *testing.T) {
 			},
 		},
 		{
-			err:     errors.New("error"),
+			err:     errors.New("error"), //nolint:goerr113
 			name:    "Error getting contributors",
 			contrib: []clients.User{},
 			expected: checker.CheckResult{

--- a/checks/dependency_update_tool.go
+++ b/checks/dependency_update_tool.go
@@ -26,7 +26,7 @@ import (
 // CheckDependencyUpdateTool is the exported name for Automatic-Depdendency-Update.
 const CheckDependencyUpdateTool = "Dependency-Update-Tool"
 
-// nolint
+//nolint:gochecknoinits
 func init() {
 	supportedRequestTypes := []checker.RequestType{
 		checker.FileBased,

--- a/checks/dependency_update_tool_test.go
+++ b/checks/dependency_update_tool_test.go
@@ -32,7 +32,7 @@ const (
 // TestDependencyUpdateTool tests the DependencyUpdateTool checker.
 func TestDependencyUpdateTool(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name              string
 		wantErr           bool

--- a/checks/evaluation/binary_artifacts_test.go
+++ b/checks/evaluation/binary_artifacts_test.go
@@ -24,7 +24,7 @@ import (
 // TestBinaryArtifacts tests the binary artifacts check.
 func TestBinaryArtifacts(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	type args struct {
 		name string
 		dl   checker.DetailLogger

--- a/checks/evaluation/ci_tests_test.go
+++ b/checks/evaluation/ci_tests_test.go
@@ -263,13 +263,13 @@ func Test_prHasSuccessStatus(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			got, err := prHasSuccessStatus(tt.args.r, tt.args.dl) //nolint:govet
-			if (err != nil) != tt.wantErr {                       //nolint:govet
-				t.Errorf("prHasSuccessStatus() error = %v, wantErr %v", err, tt.wantErr) //nolint:govet
+			got, err := prHasSuccessStatus(tt.args.r, tt.args.dl)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("prHasSuccessStatus() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want { //nolint:govet
-				t.Errorf("prHasSuccessStatus() got = %v, want %v", got, tt.want) //nolint:govet
+			if got != tt.want {
+				t.Errorf("prHasSuccessStatus() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
@@ -360,7 +360,7 @@ func Test_prHasSuccessfulCheckAdditional(t *testing.T) {
 				t.Errorf("prHasSuccessfulCheck() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want { //nolint:govet
+			if got != tt.want {
 				t.Errorf("prHasSuccessfulCheck() got = %v, want %v", got, tt.want)
 			}
 		})
@@ -449,8 +449,8 @@ func TestCITests(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			if got := CITests(tt.args.in0, tt.args.c, tt.args.dl); got.Score != tt.want { //nolint:govet
-				t.Errorf("CITests() = %v, want %v", got.Score, tt.want) //nolint:govet
+			if got := CITests(tt.args.in0, tt.args.c, tt.args.dl); got.Score != tt.want {
+				t.Errorf("CITests() = %v, want %v", got.Score, tt.want)
 			}
 		})
 	}

--- a/checks/evaluation/ci_tests_test.go
+++ b/checks/evaluation/ci_tests_test.go
@@ -130,8 +130,6 @@ func Test_isTest(t *testing.T) {
 func Test_prHasSuccessfulCheck(t *testing.T) {
 	t.Parallel()
 
-	//enabled nolint because this is a test
-	//nolint
 	tests := []struct {
 		name    string
 		args    checker.RevisionCIInfo

--- a/checks/evaluation/dependency_update_tool_test.go
+++ b/checks/evaluation/dependency_update_tool_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestDependencyUpdateTool(t *testing.T) {
 	t.Parallel()
-	//nolint
 	tests := []struct {
 		name     string
 		findings []finding.Finding

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -27,7 +27,7 @@ import (
 
 func Test_createScoreForGitHubActionsWorkflow(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name   string
 		r      worklowPinningResult
@@ -884,7 +884,7 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 		w          *worklowPinningResult
 		isGitHub   bool
 	}
-	tests := []struct { //nolint:govet
+	tests := []struct {
 		name string
 		want *worklowPinningResult
 		args args

--- a/checks/evaluation/security_policy_test.go
+++ b/checks/evaluation/security_policy_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestSecurityPolicy(t *testing.T) {
 	t.Parallel()
-	//nolint
 	tests := []struct {
 		name     string
 		findings []finding.Finding

--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -32,7 +32,8 @@ var (
 const releaseLookBack = 5
 
 // SignedReleases applies the score policy for the Signed-Releases check.
-// nolint
+//
+//nolint:gocognit
 func SignedReleases(name string, dl checker.DetailLogger, r *checker.SignedReleasesData) checker.CheckResult {
 	if r == nil {
 		e := sce.WithMessage(sce.ErrScorecardInternal, "empty raw data")

--- a/checks/evaluation/vulnerabilities_test.go
+++ b/checks/evaluation/vulnerabilities_test.go
@@ -25,18 +25,18 @@ import (
 // TestVulnerabilities tests the vulnerabilities checker.
 func TestVulnerabilities(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name     string
-		findings     []finding.Finding
-		result     scut.TestReturn
+		findings []finding.Finding
+		result   scut.TestReturn
 		expected []struct {
 			lineNumber uint
 		}
 	}{
 		{
 			name: "no vulnerabilities",
-			findings: []finding.Finding {
+			findings: []finding.Finding{
 				{
 					Probe:   "hasOSVVulnerabilities",
 					Outcome: finding.OutcomePositive,
@@ -48,7 +48,7 @@ func TestVulnerabilities(t *testing.T) {
 		},
 		{
 			name: "three vulnerabilities",
-			findings: []finding.Finding {
+			findings: []finding.Finding{
 				{
 					Probe:   "hasOSVVulnerabilities",
 					Outcome: finding.OutcomeNegative,
@@ -63,13 +63,13 @@ func TestVulnerabilities(t *testing.T) {
 				},
 			},
 			result: scut.TestReturn{
-				Score: 7,
+				Score:        7,
 				NumberOfWarn: 3,
 			},
 		},
 		{
 			name: "twelve vulnerabilities to check that score is not less than 0",
-			findings: []finding.Finding {
+			findings: []finding.Finding{
 				{
 					Probe:   "hasOSVVulnerabilities",
 					Outcome: finding.OutcomeNegative,
@@ -120,13 +120,13 @@ func TestVulnerabilities(t *testing.T) {
 				},
 			},
 			result: scut.TestReturn{
-				Score: 0,
+				Score:        0,
 				NumberOfWarn: 12,
 			},
 		},
 		{
-			name: "invalid findings",
-			findings: []finding.Finding {},
+			name:     "invalid findings",
+			findings: []finding.Finding{},
 			result: scut.TestReturn{
 				Score: -1,
 				Error: sce.ErrScorecardInternal,

--- a/checks/evaluation/webhooks_test.go
+++ b/checks/evaluation/webhooks_test.go
@@ -25,7 +25,7 @@ import (
 // TestWebhooks tests the webhooks check.
 func TestWebhooks(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	type args struct {
 		name string
 		dl   checker.DetailLogger

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -401,7 +401,7 @@ func TestGetLineNumber(t *testing.T) {
 	type args struct {
 		pos *actionlint.Pos
 	}
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name string
 		args args
@@ -488,7 +488,7 @@ func TestGetUses(t *testing.T) {
 	type args struct {
 		step *actionlint.Step
 	}
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name string
 		args args
@@ -562,7 +562,7 @@ func Test_getWith(t *testing.T) {
 	type args struct {
 		step *actionlint.Step
 	}
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name string
 		args args
@@ -648,7 +648,7 @@ func Test_getRun(t *testing.T) {
 	type args struct {
 		step *actionlint.Step
 	}
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name string
 		args args
@@ -746,7 +746,7 @@ func Test_stepsMatch(t *testing.T) {
 		stepToMatch *JobMatcherStep
 		step        *actionlint.Step
 	}
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name string
 		args args

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -135,7 +135,7 @@ func TestIsTemplateFile(t *testing.T) {
 // TestCheckFileContainsCommands tests if the content starts with a comment.
 func TestCheckFileContainsCommands(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	type args struct {
 		content []byte
 		comment string
@@ -397,7 +397,7 @@ func Test_isTestdataFile(t *testing.T) {
 // TestOnMatchingFileContentDo tests the OnMatchingFileContent function.
 func TestOnMatchingFileContent(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name                   string
 		wantErr                bool
@@ -515,7 +515,7 @@ func TestOnMatchingFileContent(t *testing.T) {
 			t.Parallel()
 			x := func(path string, content []byte, args ...interface{}) (bool, error) {
 				if tt.shouldFuncFail {
-					//nolint
+					//nolint:goerr113
 					return false, errors.New("test error")
 				}
 				if tt.shouldGetPredicateFail {
@@ -542,8 +542,6 @@ func TestOnMatchingFileContent(t *testing.T) {
 }
 
 // TestOnAllFilesDo tests the OnAllFilesDo function.
-//
-//nolint:gocognit
 func TestOnAllFilesDo(t *testing.T) {
 	t.Parallel()
 
@@ -584,7 +582,7 @@ func TestOnAllFilesDo(t *testing.T) {
 	alwaysFail := func(path string, args ...interface{}) (bool, error) {
 		return false, errTest
 	}
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name         string
 		onFile       DoWhileTrueOnFilename

--- a/checks/fuzzing_test.go
+++ b/checks/fuzzing_test.go
@@ -30,7 +30,7 @@ import (
 // TestFuzzing is a test function for Fuzzing.
 func TestFuzzing(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name        string
 		langs       []clients.Language
@@ -139,7 +139,7 @@ func TestFuzzing(t *testing.T) {
 			mockFuzz.EXPECT().Search(gomock.Any()).
 				DoAndReturn(func(q clients.SearchRequest) (clients.SearchResponse, error) {
 					if tt.wantErr {
-						//nolint
+						//nolint:goerr113
 						return clients.SearchResponse{}, errors.New("error")
 					}
 					return tt.response, nil
@@ -148,7 +148,7 @@ func TestFuzzing(t *testing.T) {
 			mockFuzz.EXPECT().ListFiles(gomock.Any()).Return(tt.fileName, nil).AnyTimes()
 			mockFuzz.EXPECT().GetFileContent(gomock.Any()).DoAndReturn(func(f string) (string, error) {
 				if tt.wantErr {
-					//nolint
+					//nolint:goerr113
 					return "", errors.New("error")
 				}
 				return tt.fileContent, nil

--- a/checks/maintained_test.go
+++ b/checks/maintained_test.go
@@ -27,9 +27,9 @@ import (
 	scut "github.com/ossf/scorecard/v4/utests"
 )
 
-// ignoring the linter for cyclomatic complexity because it is a test func
 // TestMaintained tests the maintained check.
-//nolint
+//
+//nolint:gocognit // ignoring the linter for cyclomatic complexity because it is a test func
 func Test_Maintained(t *testing.T) {
 	t.Parallel()
 	threeHundredDaysAgo := time.Now().AddDate(0, 0, -300)
@@ -38,14 +38,13 @@ func Test_Maintained(t *testing.T) {
 	oneDayAgo := time.Now().AddDate(0, 0, -1)
 	ownerAssociation := clients.RepoAssociationOwner
 	noneAssociation := clients.RepoAssociationNone
-	// fieldalignment lint issue. Ignoring it as it is not important for this test.
 	someone := clients.User{
 		Login: "someone",
 	}
 	otheruser := clients.User{
 		Login: "someone-else",
 	}
-	//nolint
+	//nolint:govet,goerr113
 	tests := []struct {
 		err        error
 		name       string
@@ -339,7 +338,7 @@ func Test_Maintained(t *testing.T) {
 				}
 				return tt.isarchived, nil
 			})
-
+			//nolint:nestif
 			if tt.archiveerr == nil {
 				mockRepo.EXPECT().ListCommits().DoAndReturn(
 					func() ([]clients.Commit, error) {

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -28,7 +28,7 @@ import (
 	scut "github.com/ossf/scorecard/v4/utests"
 )
 
-// nolint
+//nolint:lll
 func TestGithubTokenPermissions(t *testing.T) {
 	t.Parallel()
 

--- a/checks/raw/branch_protection_test.go
+++ b/checks/raw/branch_protection_test.go
@@ -63,7 +63,7 @@ func (ba branchesArg) getBranch(b string) (*clients.BranchRef, error) {
 
 func TestBranchProtection(t *testing.T) {
 	t.Parallel()
-	//nolint: govet
+	//nolint:govet
 	tests := []struct {
 		name        string
 		branches    branchesArg

--- a/checks/raw/branch_protection_test.go
+++ b/checks/raw/branch_protection_test.go
@@ -33,7 +33,7 @@ var (
 	mainBranchName    = "main"
 )
 
-// nolint: govet
+//nolint:govet
 type branchArg struct {
 	err           error
 	name          string

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -129,7 +129,7 @@ func Test_checkDependencyFileExists(t *testing.T) {
 // TestDependencyUpdateTool tests the DependencyUpdateTool function.
 func TestDependencyUpdateTool(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name              string
 		wantErr           bool

--- a/checks/raw/fuzzing_test.go
+++ b/checks/raw/fuzzing_test.go
@@ -30,7 +30,7 @@ import (
 // Test_checkOSSFuzz is a test function for checkOSSFuzz.
 func Test_checkOSSFuzz(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name        string
 		want        bool
@@ -76,7 +76,7 @@ func Test_checkOSSFuzz(t *testing.T) {
 			mockFuzz.EXPECT().Search(gomock.Any()).
 				DoAndReturn(func(q clients.SearchRequest) (clients.SearchResponse, error) {
 					if tt.wantErr {
-						//nolint
+						//nolint:goerr113
 						return clients.SearchResponse{}, errors.New("error")
 					}
 					return tt.response, nil
@@ -106,7 +106,7 @@ func Test_checkOSSFuzz(t *testing.T) {
 // Test_checkCFLite is a test function for checkCFLite.
 func Test_checkCFLite(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name        string
 		want        bool
@@ -138,7 +138,7 @@ func Test_checkCFLite(t *testing.T) {
 			mockFuzz.EXPECT().ListFiles(gomock.Any()).Return(tt.fileName, nil).AnyTimes()
 			mockFuzz.EXPECT().GetFileContent(gomock.Any()).DoAndReturn(func(f string) (string, error) {
 				if tt.wantErr {
-					//nolint
+					//nolint:goerr113
 					return "", errors.New("error")
 				}
 				return tt.fileContent, nil
@@ -160,7 +160,7 @@ func Test_checkCFLite(t *testing.T) {
 
 func Test_fuzzFileAndFuncMatchPattern(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name              string
 		expectedFileMatch bool
@@ -235,7 +235,7 @@ func Test_fuzzFileAndFuncMatchPattern(t *testing.T) {
 
 func Test_checkFuzzFunc(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name        string
 		want        bool
@@ -490,7 +490,7 @@ func Test_checkFuzzFunc(t *testing.T) {
 			mockClient.EXPECT().ListFiles(gomock.Any()).Return(tt.fileName, nil).AnyTimes()
 			mockClient.EXPECT().GetFileContent(gomock.Any()).DoAndReturn(func(f string) ([]byte, error) {
 				if tt.wantErr {
-					//nolint
+					//nolint:goerr113
 					return nil, errors.New("error")
 				}
 				return []byte(tt.fileContent), nil
@@ -510,7 +510,6 @@ func Test_checkFuzzFunc(t *testing.T) {
 
 func Test_getProminentLanguages(t *testing.T) {
 	t.Parallel()
-	//nolint
 	tests := []struct {
 		name      string
 		languages []clients.Language

--- a/checks/raw/gitlab/packaging_test.go
+++ b/checks/raw/gitlab/packaging_test.go
@@ -27,7 +27,7 @@ import (
 func TestGitlabPackagingYamlCheck(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name       string
 		lineNumber uint
@@ -100,7 +100,7 @@ func TestGitlabPackagingYamlCheck(t *testing.T) {
 func TestGitlabPackagingPackager(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name       string
 		lineNumber uint

--- a/checks/raw/gitlab/packaging_test.go
+++ b/checks/raw/gitlab/packaging_test.go
@@ -136,7 +136,7 @@ func TestGitlabPackagingPackager(t *testing.T) {
 
 			moqRepoClient.EXPECT().GetFileContent(tt.filename).
 				DoAndReturn(func(b string) ([]byte, error) {
-					//nolint: errcheck
+					//nolint:errcheck
 					content, _ := os.ReadFile(b)
 					return content, nil
 				}).AnyTimes()
@@ -150,7 +150,7 @@ func TestGitlabPackagingPackager(t *testing.T) {
 				Repo:       moqRepo,
 			}
 
-			//nolint: errcheck
+			//nolint:errcheck
 			packagingData, _ := Packaging(&req)
 
 			if !tt.exists {

--- a/checks/raw/license_test.go
+++ b/checks/raw/license_test.go
@@ -646,7 +646,7 @@ func TestLicenseFileCheck(t *testing.T) {
 		},
 	}
 
-	//nolint: paralleltest
+	//nolint:paralleltest
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		for _, ext := range tt.extensions {

--- a/checks/raw/maintained_test.go
+++ b/checks/raw/maintained_test.go
@@ -78,7 +78,7 @@ func TestMaintained(t *testing.T) {
 	})
 
 	t.Run("returns error if IsArchived fails", func(t *testing.T) {
-		mockRepoClient.EXPECT().IsArchived().Return(false, fmt.Errorf("some error")) // nolint: goerr113
+		mockRepoClient.EXPECT().IsArchived().Return(false, fmt.Errorf("some error")) //nolint:goerr113
 
 		_, err := Maintained(req)
 		if err == nil {
@@ -88,7 +88,7 @@ func TestMaintained(t *testing.T) {
 
 	t.Run("returns error if ListCommits fails", func(t *testing.T) {
 		mockRepoClient.EXPECT().IsArchived().Return(false, nil)
-		mockRepoClient.EXPECT().ListCommits().Return(nil, fmt.Errorf("some error")) // nolint: goerr113
+		mockRepoClient.EXPECT().ListCommits().Return(nil, fmt.Errorf("some error")) //nolint:goerr113
 
 		_, err := Maintained(req)
 		if err == nil {
@@ -99,7 +99,7 @@ func TestMaintained(t *testing.T) {
 	t.Run("returns error if ListIssues fails", func(t *testing.T) {
 		mockRepoClient.EXPECT().IsArchived().Return(false, nil)
 		mockRepoClient.EXPECT().ListCommits().Return([]clients.Commit{}, nil)
-		mockRepoClient.EXPECT().ListIssues().Return(nil, fmt.Errorf("some error")) // nolint: goerr113
+		mockRepoClient.EXPECT().ListIssues().Return(nil, fmt.Errorf("some error")) //nolint:goerr113
 
 		_, err := Maintained(req)
 		if err == nil {
@@ -111,7 +111,7 @@ func TestMaintained(t *testing.T) {
 		mockRepoClient.EXPECT().IsArchived().Return(false, nil)
 		mockRepoClient.EXPECT().ListCommits().Return([]clients.Commit{}, nil)
 		mockRepoClient.EXPECT().ListIssues().Return([]clients.Issue{}, nil)
-		mockRepoClient.EXPECT().GetCreatedAt().Return(time.Time{}, fmt.Errorf("some error")) // nolint: goerr113
+		mockRepoClient.EXPECT().GetCreatedAt().Return(time.Time{}, fmt.Errorf("some error")) //nolint:goerr113
 
 		_, err := Maintained(req)
 		if err == nil {

--- a/checks/raw/permissions.go
+++ b/checks/raw/permissions.go
@@ -93,7 +93,7 @@ var validateGitHubActionTokenPermissions fileparser.DoWhileTrueOnFileContent = f
 	}
 
 	// 1. Top-level permission definitions.
-	//nolint
+	//nolint:lll
 	// https://docs.github.com/en/actions/reference/authentication-in-a-workflow#example-1-passing-the-github_token-as-an-input,
 	// https://github.blog/changelog/2021-04-20-github-actions-control-permissions-for-github_token/,
 	// https://docs.github.com/en/actions/reference/authentication-in-a-workflow#modifying-the-permissions-for-the-github_token.
@@ -359,14 +359,13 @@ func isSARIFUploadWorkflow(workflow *actionlint.Workflow, fp string, pdata *perm
 }
 
 func isAllowedWorkflow(workflow *actionlint.Workflow, fp string, pdata *permissionCbData) bool {
+	//nolint:lll
 	allowlist := map[string]bool{
-		//nolint
 		// CodeQl analysis workflow automatically sends sarif file to GitHub.
 		// https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/uploading-a-sarif-file-to-github#about-sarif-file-uploads-for-code-scanning.
 		// `The CodeQL action uploads the SARIF file automatically when it completes analysis`.
 		"github/codeql-action/analyze": true,
 
-		//nolint
 		// Third-party scanning tools use the SARIF-upload action from code-ql.
 		// https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/uploading-a-sarif-file-to-github#uploading-a-code-scanning-analysis-with-github-actions
 		// We only support CodeQl today.

--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -323,7 +323,7 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 		}
 	}
 
-	//nolint
+	//nolint:lll
 	// The file need not have a FROM statement,
 	// https://github.com/tensorflow/tensorflow/blob/master/tensorflow/tools/dockerfiles/partials/jupyter.partial.Dockerfile.
 

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -34,7 +34,7 @@ import (
 func TestGithubWorkflowPinning(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		warns    int
 		err      error
@@ -196,7 +196,7 @@ func TestGithubWorkflowPinningPattern(t *testing.T) {
 func TestNonGithubWorkflowPinning(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		warns    int
 		err      error
@@ -271,7 +271,7 @@ func TestNonGithubWorkflowPinning(t *testing.T) {
 func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		unpinned         int
 		processingErrors int
@@ -331,7 +331,7 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 func TestDockerfilePinning(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		warns    int
 		err      error
@@ -579,7 +579,7 @@ func TestDockerfileInvalidFiles(t *testing.T) {
 
 func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet,lll
 	tests := []struct {
 		name             string
 		filename         string
@@ -594,7 +594,6 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 		{
 			name:     "dockerfile downloads",
 			filename: "./testdata/Dockerfile-download-lines",
-			//nolint
 			expected: []struct {
 				snippet   string
 				startLine uint
@@ -678,7 +677,6 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 		{
 			name:     "dockerfile downloads multi-run",
 			filename: "./testdata/Dockerfile-download-multi-runs",
-			//nolint
 			expected: []struct {
 				snippet   string
 				startLine uint
@@ -775,7 +773,7 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 
 func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet,lll
 	tests := []struct {
 		name     string
 		filename string
@@ -789,7 +787,6 @@ func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 		{
 			name:     "shell downloads",
 			filename: "./testdata/shell-download-lines.sh",
-			//nolint
 			expected: []struct {
 				snippet   string
 				startLine uint
@@ -960,7 +957,7 @@ func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 
 func TestDockerfilePinningWihoutHash(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		warns    int
 		err      error
@@ -1015,7 +1012,7 @@ func TestDockerfilePinningWihoutHash(t *testing.T) {
 
 func TestDockerfileScriptDownload(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		unpinned         int
 		processingErrors int
@@ -1131,7 +1128,7 @@ func TestDockerfileScriptDownload(t *testing.T) {
 
 func TestDockerfileScriptDownloadInfo(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name             string
 		filename         string
@@ -1185,7 +1182,7 @@ func TestDockerfileScriptDownloadInfo(t *testing.T) {
 
 func TestShellScriptDownload(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name             string
 		filename         string
@@ -1268,7 +1265,7 @@ func TestShellScriptDownload(t *testing.T) {
 
 func TestShellScriptDownloadPinned(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name     string
 		filename string
@@ -1318,7 +1315,7 @@ func TestShellScriptDownloadPinned(t *testing.T) {
 
 func TestGitHubWorflowRunDownload(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name             string
 		filename         string

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -63,7 +63,7 @@ func Test_isSecurityPolicyFilename(t *testing.T) {
 // TestSecurityPolicy tests the security policy.
 func TestSecurityPolicy(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name    string
 		files   []string

--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -1089,7 +1089,6 @@ func validateShellFileAndRecord(pathfn string, startLine, endLine uint, content 
 		// TODO: support other interpreters.
 		// Example: https://github.com/apache/airflow/blob/main/scripts/ci/kubernetes/ci_run_kubernetes_tests.sh#L75
 		// HOST_PYTHON_VERSION=$(python3 -c 'import sys; print(f"{sys.version_info[0]}.{sys.version_info[1]}")')``
-		// nolint
 		if ok && isShellInterpreterOrCommand([]string{i}) {
 			start, end := getLine(startLine, endLine, node)
 			e := validateShellFileAndRecord(pathfn, start, end,

--- a/checks/raw/vulnerabilities_test.go
+++ b/checks/raw/vulnerabilities_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestVulnerabilities(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name            string
 		want            checker.VulnerabilitiesData
@@ -49,7 +49,7 @@ func TestVulnerabilities(t *testing.T) {
 		{
 			name:    "err response",
 			wantErr: true,
-			//nolint
+			//nolint:goerr113
 			err:           errors.New("error"),
 			vulnsResponse: clients.VulnerabilitiesResponse{},
 		},
@@ -93,7 +93,7 @@ func TestVulnerabilities(t *testing.T) {
 			mockVulnClient.EXPECT().ListUnfixedVulnerabilities(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ctx context.Context, commit string, localPath string) (clients.VulnerabilitiesResponse, error) {
 					if tt.vulnsError {
-						//nolint
+						//nolint:goerr113
 						return clients.VulnerabilitiesResponse{}, errors.New("error")
 					}
 					return tt.vulnsResponse, tt.err

--- a/checks/raw/webhooks_test.go
+++ b/checks/raw/webhooks_test.go
@@ -29,7 +29,7 @@ import (
 
 func TestWebhooks(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name                   string
 		err                    error

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -34,7 +34,7 @@ import (
 func Test_SAST(t *testing.T) {
 	t.Parallel()
 
-	//nolint: govet, goerr113
+	//nolint:govet,goerr113
 	tests := []struct {
 		name          string
 		err           error

--- a/checks/security_policy_test.go
+++ b/checks/security_policy_test.go
@@ -28,7 +28,7 @@ import (
 
 func TestSecurityPolicy(t *testing.T) {
 	t.Parallel()
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name    string
 		path    string

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -28,8 +28,6 @@ import (
 
 func TestSignedRelease(t *testing.T) {
 	t.Parallel()
-	//fieldalignment lint issue. Ignoring it as it is not important for this test.
-	//nolint
 	tests := []struct {
 		err      error
 		name     string
@@ -363,12 +361,13 @@ func TestSignedRelease(t *testing.T) {
 				Score: 8,
 			},
 		},
+
 		{
 			name: "Error getting releases",
-			err:  errors.New("Error getting releases"),
+			err:  errors.New("Error getting releases"), //nolint:goerr113
 			expected: checker.CheckResult{
 				Score: -1,
-				Error: errors.New("Error getting releases"),
+				Error: errors.New("Error getting releases"), //nolint:goerr113
 			},
 		},
 	}

--- a/checks/webhook_test.go
+++ b/checks/webhook_test.go
@@ -26,7 +26,7 @@ import (
 	scut "github.com/ossf/scorecard/v4/utests"
 )
 
-//nolint:tparallel,paralleltest // since t.Setenv is used
+//nolint:paralleltest // since t.Setenv is used
 func TestWebhooks(t *testing.T) {
 	tests := []struct {
 		expected checker.CheckResult

--- a/clients/cii_http_client.go
+++ b/clients/cii_http_client.go
@@ -38,7 +38,7 @@ func (transport *expBackoffTransport) RoundTrip(req *http.Request) (*http.Respon
 	for i := 0; i < int(transport.numRetries); i++ {
 		resp, err := http.DefaultClient.Do(req)
 		if err != nil || resp.StatusCode != http.StatusTooManyRequests {
-			//nolint: wrapcheck
+			//nolint:wrapcheck
 			return resp, err
 		}
 		time.Sleep(time.Duration(math.Pow(2, float64(i))) * time.Second)

--- a/clients/git/client_test.go
+++ b/clients/git/client_test.go
@@ -36,7 +36,7 @@ func createTestRepo(t *testing.T) (path string) {
 		t.Fatalf("Failed to create temporary directory: %v", err)
 	}
 	t.Cleanup(func() {
-		os.RemoveAll(dir) // nolint:errcheck
+		os.RemoveAll(dir)
 	})
 	r, err := gitV5.PlainInit(dir, false)
 	if err != nil {

--- a/clients/githubrepo/checkruns.go
+++ b/clients/githubrepo/checkruns.go
@@ -67,7 +67,7 @@ type checkRunsGraphqlData struct {
 
 type checkRunsByRef = map[string][]clients.CheckRun
 
-// nolint: govet
+//nolint:govet
 type checkrunsHandler struct {
 	client         *github.Client
 	graphClient    *githubv4.Client

--- a/clients/githubrepo/graphql.go
+++ b/clients/githubrepo/graphql.go
@@ -106,7 +106,7 @@ type graphqlData struct {
 		} `graphql:"object(expression: $commitExpression)"`
 		Issues struct {
 			Nodes []struct {
-				//nolint: revive,stylecheck // naming according to githubv4 convention.
+				//nolint:revive,stylecheck // naming according to githubv4 convention.
 				Url               *string
 				AuthorAssociation *string
 				Author            struct {

--- a/clients/githubrepo/graphql.go
+++ b/clients/githubrepo/graphql.go
@@ -239,7 +239,6 @@ func (handler *graphqlHandler) isArchived() (bool, error) {
 	return handler.archived, nil
 }
 
-// nolint
 func commitsFrom(data *graphqlData, repoOwner, repoName string) ([]clients.Commit, error) {
 	ret := make([]clients.Commit, 0)
 	for _, commit := range data.Repository.Object.Commit.History.Nodes {

--- a/clients/githubrepo/repo_test.go
+++ b/clients/githubrepo/repo_test.go
@@ -20,8 +20,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-// nolint:paralleltest
-// because we are using t.Setenv.
+//nolint:paralleltest // because we are using t.Setenv.
 func TestRepoURL_IsValid(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/clients/githubrepo/roundtripper/rate_limit_test.go
+++ b/clients/githubrepo/roundtripper/rate_limit_test.go
@@ -27,27 +27,28 @@ func TestRoundTrip(t *testing.T) {
 	var requestCount int
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Customize the response headers and body based on the test scenario
+		//nolint:errcheck
 		switch r.URL.Path {
 		case "/error":
 			w.WriteHeader(http.StatusInternalServerError)
-			w.Write([]byte("Internal Server Error")) // nolint: errcheck
+			w.Write([]byte("Internal Server Error"))
 		case "/retry":
 			requestCount++
 			if requestCount == 2 {
 				// Second request: Return successful response
 				w.Header().Set("X-RateLimit-Remaining", "10")
 				w.WriteHeader(http.StatusOK)
-				w.Write([]byte("Success")) // nolint: errcheck
+				w.Write([]byte("Success"))
 			} else {
 				// First request: Return Retry-After header
 				w.Header().Set("Retry-After", "1")
 				w.WriteHeader(http.StatusTooManyRequests)
-				w.Write([]byte("Rate Limit Exceeded")) // nolint: errcheck
+				w.Write([]byte("Rate Limit Exceeded"))
 			}
 		case "/success":
 			w.Header().Set("X-RateLimit-Remaining", "10")
 			w.WriteHeader(http.StatusOK)
-			w.Write([]byte("Success")) // nolint: errcheck
+			w.Write([]byte("Success"))
 		}
 	}))
 	t.Cleanup(func() {

--- a/clients/githubrepo/roundtripper/roundtripper.go
+++ b/clients/githubrepo/roundtripper/roundtripper.go
@@ -17,7 +17,7 @@ package roundtripper
 
 import (
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"os"
 	"strconv"
@@ -37,11 +37,13 @@ const (
 	githubAppInstallationID = "GITHUB_APP_INSTALLATION_ID"
 )
 
+var errGithubCredentials = errors.New("an error occurred while getting GitHub credentials")
+
 // NewTransport returns a configured http.Transport for use with GitHub.
 func NewTransport(ctx context.Context, logger *log.Logger) http.RoundTripper {
 	transport := http.DefaultTransport
 
-	//nolint
+	//nolint:nestif
 	if tokenAccessor := tokens.MakeTokenAccessor(); tokenAccessor != nil {
 		// Use GitHub PAT
 		transport = makeGitHubTransport(transport, tokenAccessor)
@@ -60,7 +62,8 @@ func NewTransport(ctx context.Context, logger *log.Logger) http.RoundTripper {
 		}
 	} else {
 		// TODO(log): Improve error message
-		logger.Error(fmt.Errorf("an error occurred while getting GitHub credentials"), "GitHub token env var is not set. Please read https://github.com/ossf/scorecard#authentication")
+		//nolint:lll
+		logger.Error(errGithubCredentials, "GitHub token env var is not set. Please read https://github.com/ossf/scorecard#authentication")
 	}
 
 	return MakeCensusTransport(MakeRateLimitedTransport(transport, logger))

--- a/clients/githubrepo/roundtripper/tokens/server/main.go
+++ b/clients/githubrepo/roundtripper/tokens/server/main.go
@@ -36,13 +36,13 @@ func main() {
 	}
 	rpc.HandleHTTP()
 
-	//nolint: gosec // using `localhost:8080` for gosec102 causes connection refused errors.
+	//nolint:gosec // using `localhost:8080` for gosec102 causes connection refused errors.
 	l, err := net.Listen("tcp", ":8080")
 	if err != nil {
 		panic(err)
 	}
 
-	//nolint: gosec // internal server.
+	//nolint:gosec // internal server.
 	if err := http.Serve(l, nil); err != nil {
 		panic(err)
 	}

--- a/clients/githubrepo/tarball.go
+++ b/clients/githubrepo/tarball.go
@@ -161,7 +161,7 @@ func (handler *tarballHandler) getTarball() error {
 	return nil
 }
 
-// nolint: gocognit
+//nolint:gocognit
 func (handler *tarballHandler) extractTarball() error {
 	in, err := os.OpenFile(handler.tempTarFile, os.O_RDONLY, 0o644)
 	if err != nil {

--- a/clients/githubrepo/tarball.go
+++ b/clients/githubrepo/tarball.go
@@ -213,7 +213,7 @@ func (handler *tarballHandler) extractTarball() error {
 				return fmt.Errorf("os.Create: %w", err)
 			}
 
-			//nolint: gosec
+			//nolint:gosec
 			// Potential for DoS vulnerability via decompression bomb.
 			// Since such an attack will only impact a single shard, ignoring this for now.
 			if _, err := io.Copy(outFile, tr); err != nil {

--- a/clients/githubrepo/tarball_test.go
+++ b/clients/githubrepo/tarball_test.go
@@ -79,7 +79,7 @@ func setup(inputFile string) (tarballHandler, error) {
 	return tarballHandler, nil
 }
 
-// nolint: gocognit
+//nolint:gocognit
 func TestExtractTarball(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {

--- a/clients/gitlabrepo/branches.go
+++ b/clients/gitlabrepo/branches.go
@@ -62,7 +62,7 @@ type (
 		options ...gitlab.RequestOptionFunc) (*gitlab.ProjectApprovals, *gitlab.Response, error)
 )
 
-// nolint: nestif
+//nolint:nestif
 func (handler *branchesHandler) setup() error {
 	handler.once.Do(func() {
 		if !strings.EqualFold(handler.repourl.commitSHA, clients.HeadSHA) {

--- a/clients/gitlabrepo/branches_test.go
+++ b/clients/gitlabrepo/branches_test.go
@@ -110,10 +110,10 @@ func TestGetBranches(t *testing.T) {
 
 			handler.once.Do(func() {})
 
-			// nolint: errcheck
+			//nolint:errcheck
 			br, _ := handler.getBranch(tt.branchName)
 
-			// nolint: unconvert
+			//nolint:unconvert
 			if string(*br.Name) != tt.expectedBranchName {
 				t.Errorf("Branch Name (%s) didn't match expected value (%s)", *br.Name, tt.expectedBranchName)
 			}

--- a/clients/gitlabrepo/contributors.go
+++ b/clients/gitlabrepo/contributors.go
@@ -62,7 +62,7 @@ func (handler *contributorsHandler) retrieveContributors(project string) ([]*git
 			},
 		)
 		if err != nil {
-			//nolint wrapcheck
+			//nolint:wrapcheck
 			return nil, err
 		}
 
@@ -78,7 +78,7 @@ func (handler *contributorsHandler) retrieveContributors(project string) ([]*git
 func (handler *contributorsHandler) retrieveUsers(queryName string) ([]*gitlab.User, error) {
 	users, _, err := handler.glClient.Search.Users(queryName, &gitlab.SearchOptions{})
 	if err != nil {
-		//nolint wrapcheck
+		//nolint:wrapcheck
 		return nil, err
 	}
 	return users, nil

--- a/clients/gitlabrepo/graphql.go
+++ b/clients/gitlabrepo/graphql.go
@@ -28,7 +28,6 @@ import (
 	"golang.org/x/oauth2"
 )
 
-//nolint:govet
 type graphqlHandler struct {
 	err         error
 	client      *http.Client
@@ -49,7 +48,6 @@ func (handler *graphqlHandler) init(ctx context.Context, repourl *repoURL) {
 	handler.graphClient = graphql.NewClient(fmt.Sprintf("%s/api/graphql", repourl.Host()), handler.client)
 }
 
-//nolint:govet
 type graphqlData struct {
 	Project struct {
 		MergeRequests struct {

--- a/clients/gitlabrepo/tarball.go
+++ b/clients/gitlabrepo/tarball.go
@@ -204,7 +204,7 @@ func (handler *tarballHandler) apiFunction(url, tempDir string, repoFile *os.Fil
 	return nil
 }
 
-// nolint: gocognit
+//nolint:gocognit
 func (handler *tarballHandler) extractTarball() error {
 	in, err := os.OpenFile(handler.tempTarFile, os.O_RDONLY, 0o644)
 	if err != nil {

--- a/clients/gitlabrepo/tarball.go
+++ b/clients/gitlabrepo/tarball.go
@@ -256,7 +256,7 @@ func (handler *tarballHandler) extractTarball() error {
 				return fmt.Errorf("os.Create: %w", err)
 			}
 
-			//nolint: gosec
+			//nolint:gosec
 			// Potential for DoS vulnerability via decompression bomb.
 			// Since such an attack will only impact a single shard, ignoring this for now.
 			if _, err := io.Copy(outFile, tr); err != nil {

--- a/clients/gitlabrepo/tarball_test.go
+++ b/clients/gitlabrepo/tarball_test.go
@@ -71,7 +71,7 @@ func setup(inputFile string) (tarballHandler, error) {
 	return tarballHandler, nil
 }
 
-// nolint: gocognit
+//nolint:gocognit
 func TestExtractTarball(t *testing.T) {
 	t.Parallel()
 	testcases := []struct {

--- a/cmd/internal/nuget/client.go
+++ b/cmd/internal/nuget/client.go
@@ -58,11 +58,11 @@ func (n packageRegistrationCatalogRoot) latestVersion(manager pmc.Client) (strin
 		page := n.Pages[pageIndex]
 		if page.Packages == nil {
 			err := decodeResponseFromClient(func() (*http.Response, error) {
-				//nolint: wrapcheck
+				//nolint:wrapcheck
 				return manager.GetURI(page.ID)
 			},
 				func(rc io.ReadCloser) error {
-					//nolint: wrapcheck
+					//nolint:wrapcheck
 					return json.NewDecoder(rc).Decode(&page)
 				}, "nuget package registration page")
 			if err != nil {
@@ -170,12 +170,12 @@ func (c *NugetClient) packageSpec(packageBaseURL, registrationBaseURL, packageNa
 	}
 	packageSpecResults := &packageNuspec{}
 	err = decodeResponseFromClient(func() (*http.Response, error) {
-		//nolint: wrapcheck
+		//nolint:wrapcheck
 		return c.Manager.Get(
 			packageBaseURL+"%[1]v/"+lastPackageVersion+"/%[1]v.nuspec", lowerCasePackageName)
 	},
 		func(rc io.ReadCloser) error {
-			//nolint: wrapcheck
+			//nolint:wrapcheck
 			return xml.NewDecoder(rc).Decode(packageSpecResults)
 		}, "nuget package spec")
 
@@ -193,11 +193,11 @@ func (c *NugetClient) baseUrls() (string, string, error) {
 	indexURL := "https://api.nuget.org/v3/index.json"
 	indexResults := &indexResults{}
 	err := decodeResponseFromClient(func() (*http.Response, error) {
-		//nolint: wrapcheck
+		//nolint:wrapcheck
 		return c.Manager.GetURI(indexURL)
 	},
 		func(rc io.ReadCloser) error {
-			//nolint: wrapcheck
+			//nolint:wrapcheck
 			return json.NewDecoder(rc).Decode(indexResults)
 		}, "nuget index json")
 	if err != nil {
@@ -219,11 +219,11 @@ func (c *NugetClient) baseUrls() (string, string, error) {
 func (c *NugetClient) latestListedVersion(baseURL, packageName string) (string, error) {
 	packageRegistrationCatalogRoot := &packageRegistrationCatalogRoot{}
 	err := decodeResponseFromClient(func() (*http.Response, error) {
-		//nolint: wrapcheck
+		//nolint:wrapcheck
 		return c.Manager.Get(baseURL+"%s/index.json", packageName)
 	},
 		func(rc io.ReadCloser) error {
-			//nolint: wrapcheck
+			//nolint:wrapcheck
 			return json.NewDecoder(rc).Decode(packageRegistrationCatalogRoot)
 		}, "nuget package registration index json")
 	if err != nil {

--- a/cmd/internal/nuget/client.go
+++ b/cmd/internal/nuget/client.go
@@ -240,8 +240,8 @@ func isSupportedProjectURL(projectURL string) bool {
 
 // Nuget semver diverges from Semantic Versioning.
 // This method returns the Nuget represntation of version and pre release strings.
-// nolint: lll // long URL
-// more info: https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#where-nugetversion-diverges-from-semantic-versioning
+//
+//nolint:lll // https://learn.microsoft.com/en-us/nuget/concepts/package-versioning#where-nugetversion-diverges-from-semantic-versioning
 func parseNugetSemVer(versionString string) (base, preReleaseSuffix string) {
 	metadataAndVersion := strings.Split(versionString, "+")
 	prereleaseAndVersions := strings.Split(metadataAndVersion[0], "-")

--- a/cmd/internal/nuget/client_test.go
+++ b/cmd/internal/nuget/client_test.go
@@ -390,7 +390,7 @@ func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 				resultPackageRegistrationPages: []resultPackagePage{},
 				resultPackageSpec:              "",
 			},
-			//nolint
+			//nolint:lll
 			want:    "internal error: failed to parse nuget package registration index json: invalid character 'e' in literal true (expecting 'r')",
 			wantErr: true,
 		},
@@ -443,7 +443,7 @@ func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 				},
 				resultPackageSpec: "",
 			},
-			//nolint
+			//nolint:lll
 			want:    "internal error: failed to parse nuget package registration page: invalid character 'e' in literal true (expecting 'r')",
 			wantErr: true,
 		},
@@ -514,7 +514,7 @@ func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 				resultPackageSpec:              "",
 				version:                        "",
 			},
-			//nolint
+			//nolint:lll
 			want:    "internal error: failed to parse nuget package registration index json: failed to unmarshal json: json: cannot unmarshal number into Go struct field Alias.listed of type bool",
 			wantErr: true,
 		},
@@ -580,7 +580,7 @@ func nugetIndexOrPageTestResults(url string, test *nugetTest) (*http.Response, e
 	urlResponseIndex := slices.IndexFunc(test.args.resultPackageRegistrationPages,
 		func(page resultPackagePage) bool { return page.url == url })
 	if urlResponseIndex == -1 {
-		//nolint
+		//nolint:goerr113
 		return nil, errors.New("error")
 	}
 	page := test.args.resultPackageRegistrationPages[urlResponseIndex]
@@ -597,13 +597,13 @@ func nugetPackageIndexAndSpecResponse(t *testing.T, url string, test *nugetTest)
 		}
 		t.Errorf("fetchGitRepositoryFromNuget() version = %v, expected version = %v", url, test.args.version)
 	}
-	//nolint
+	//nolint:goerr113
 	return nil, errors.New("error")
 }
 
 func testResult(wantErr bool, responseFileName string) (*http.Response, error) {
 	if wantErr && responseFileName == "" {
-		//nolint
+		//nolint:goerr113
 		return nil, errors.New("error")
 	}
 	if wantErr && responseFileName == "text" {

--- a/cmd/internal/packagemanager/client.go
+++ b/cmd/internal/packagemanager/client.go
@@ -29,12 +29,10 @@ type Client interface {
 
 type PackageManagerClient struct{}
 
-//nolint:noctx
 func (c *PackageManagerClient) Get(url, packageName string) (*http.Response, error) {
 	return c.getRemoteURL(fmt.Sprintf(url, packageName))
 }
 
-//nolint:noctx
 func (c *PackageManagerClient) GetURI(url string) (*http.Response, error) {
 	return c.getRemoteURL(url)
 }

--- a/cmd/internal/packagemanager/client.go
+++ b/cmd/internal/packagemanager/client.go
@@ -29,22 +29,22 @@ type Client interface {
 
 type PackageManagerClient struct{}
 
-// nolint: noctx
+//nolint:noctx
 func (c *PackageManagerClient) Get(url, packageName string) (*http.Response, error) {
 	return c.getRemoteURL(fmt.Sprintf(url, packageName))
 }
 
-// nolint: noctx
+//nolint:noctx
 func (c *PackageManagerClient) GetURI(url string) (*http.Response, error) {
 	return c.getRemoteURL(url)
 }
 
-//nolint: noctx
+//nolint:noctx
 func (c *PackageManagerClient) getRemoteURL(url string) (*http.Response, error) {
 	const timeout = 10
 	client := &http.Client{
 		Timeout: timeout * time.Second,
 	}
-	//nolint
+	//nolint:wrapcheck
 	return client.Get(url)
 }

--- a/cmd/internal/packagemanager/client.go
+++ b/cmd/internal/packagemanager/client.go
@@ -39,7 +39,7 @@ func (c *PackageManagerClient) GetURI(url string) (*http.Response, error) {
 	return c.getRemoteURL(url)
 }
 
-// nolint: noctx
+//nolint: noctx
 func (c *PackageManagerClient) getRemoteURL(url string) (*http.Response, error) {
 	const timeout = 10
 	client := &http.Client{

--- a/cmd/internal/packagemanager/client_test.go
+++ b/cmd/internal/packagemanager/client_test.go
@@ -51,10 +51,8 @@ func Test_GetURI_calls_client_get_with_input(t *testing.T) {
 				if r.URL.Path != tt.wantURL {
 					t.Errorf("Expected to request '%s', got: %s", tt.wantURL, r.URL.Path)
 				}
-				// nolint
 				w.WriteHeader(http.StatusOK)
-				// nolint
-				w.Write([]byte(tt.wantResponse))
+				w.Write([]byte(tt.wantResponse)) //nolint:errcheck
 			}))
 			defer server.Close()
 			client := PackageManagerClient{}
@@ -107,10 +105,8 @@ func Test_Get_calls_client_get_with_input(t *testing.T) {
 				if r.URL.Path != tt.wantURL {
 					t.Errorf("Expected to request '%s', got: %s", tt.wantURL, r.URL.Path)
 				}
-				// nolint
 				w.WriteHeader(http.StatusOK)
-				// nolint
-				w.Write([]byte(tt.wantResponse))
+				w.Write([]byte(tt.wantResponse)) //nolint:errcheck
 			}))
 			defer server.Close()
 			client := PackageManagerClient{}

--- a/cmd/package_managers_test.go
+++ b/cmd/package_managers_test.go
@@ -141,7 +141,7 @@ func Test_fetchGitRepositoryFromNPM(t *testing.T) {
 			p.EXPECT().Get(gomock.Any(), tt.args.packageName).
 				DoAndReturn(func(url, packageName string) (*http.Response, error) {
 					if tt.wantErr && tt.args.result == "" {
-						//nolint
+						//nolint:goerr113
 						return nil, errors.New("error")
 					}
 
@@ -314,10 +314,9 @@ func Test_fetchGitRepositoryFromPYPI(t *testing.T) {
 	}{
 		{
 			name: "fetchGitRepositoryFromPYPI",
-			//nolint
 			args: args{
 				packageName: "some-package",
-				//nolint
+				//nolint:lll
 				result: `
 {
   "info": {
@@ -451,7 +450,7 @@ func Test_fetchGitRepositoryFromPYPI(t *testing.T) {
 			p.EXPECT().Get(gomock.Any(), tt.args.packageName).
 				DoAndReturn(func(url, packageName string) (*http.Response, error) {
 					if tt.wantErr && tt.args.result == "" {
-						//nolint
+						//nolint:goerr113
 						return nil, errors.New("error")
 					}
 
@@ -486,10 +485,9 @@ func Test_fetchGitRepositoryFromRubyGems(t *testing.T) {
 	}{
 		{
 			name: "fetchGitRepositoryFromPYPI",
-			//nolint
 			args: args{
 				packageName: "npm-package",
-				//nolint
+				//nolint:lll
 				result: `
 {
   "name": "color",
@@ -609,10 +607,9 @@ func Test_fetchGitRepositoryFromRubyGems(t *testing.T) {
 		},
 		{
 			name: "empty project url",
-			//nolint
 			args: args{
 				packageName: "npm-package",
-				//nolint
+				//nolint:lll
 				result: `
 				{
   "name": "color",
@@ -720,7 +717,7 @@ func Test_fetchGitRepositoryFromRubyGems(t *testing.T) {
 			p.EXPECT().Get(gomock.Any(), tt.args.packageName).
 				DoAndReturn(func(url, packageName string) (*http.Response, error) {
 					if tt.wantErr && tt.args.result == "" {
-						//nolint
+						//nolint:goerr113
 						return nil, errors.New("error")
 					}
 
@@ -755,22 +752,18 @@ func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 	}{
 		{
 			name: "Return repository from nuget client",
-			//nolint
 			args: args{
 				packageName: "nuget-package",
-				//nolint
-				result: "nuget",
+				result:      "nuget",
 			},
 			want:    "nuget",
 			wantErr: false,
 		},
 		{
 			name: "Error from nuget client",
-			//nolint
 			args: args{
 				packageName: "nuget-package",
-				//nolint
-				result: "",
+				result:      "",
 			},
 			want:    "",
 			wantErr: true,
@@ -785,7 +778,7 @@ func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 			n.EXPECT().GitRepositoryByPackageName(tt.args.packageName).
 				DoAndReturn(func(packageName string) (string, error) {
 					if tt.wantErr && tt.args.result == "" {
-						//nolint
+						//nolint:goerr113
 						return "", errors.New("error")
 					}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -96,7 +96,7 @@ func serveCmd(o *options.Options) *cobra.Command {
 				port = "8080"
 			}
 			logger.Info("Listening on localhost:" + port + "\n")
-			//nolint: gosec // unsused.
+			//nolint:gosec // unsused.
 			err = http.ListenAndServe(fmt.Sprintf("0.0.0.0:%s", port), nil)
 			if err != nil {
 				// TODO(log): Should this actually panic?

--- a/cron/config/config.go
+++ b/cron/config/config.go
@@ -154,7 +154,7 @@ func getFloat64ConfigValue(envVar string, byteValue []byte, fieldName, configNam
 
 	switch value.Kind() {
 	case reflect.String:
-		//nolint: wrapcheck, gomnd
+		//nolint:wrapcheck,gomnd
 		return strconv.ParseFloat(value.String(), 64)
 	case reflect.Float32, reflect.Float64:
 		return value.Float(), nil

--- a/cron/config/config_test.go
+++ b/cron/config/config_test.go
@@ -70,7 +70,7 @@ func getByteValueFromFile(filename string) ([]byte, error) {
 	if filename == "" {
 		return nil, nil
 	}
-	//nolint
+	//nolint:wrapcheck
 	return os.ReadFile(filename)
 }
 

--- a/cron/data/summary.go
+++ b/cron/data/summary.go
@@ -126,7 +126,7 @@ func GetBucketSummary(ctx context.Context, bucketURL string) (*BucketSummary, er
 			summary.getOrCreate(creationTime).shardsExpected = int(metadata.GetNumShard())
 			summary.getOrCreate(creationTime).shardMetadata = keyData
 		default:
-			//nolint: goerr113
+			//nolint:goerr113
 			return nil, fmt.Errorf("found unrecognized file: %s", key)
 		}
 	}

--- a/cron/internal/bq/main.go
+++ b/cron/internal/bq/main.go
@@ -50,7 +50,7 @@ func transferDataToBq(ctx context.Context,
 		if webhookURL == "" {
 			continue
 		}
-		//nolint: noctx, gosec // variable URL is ok here.
+		//nolint:noctx,gosec // variable URL is ok here.
 		resp, err := http.Post(webhookURL, "application/json", bytes.NewBuffer(shards.Metadata()))
 		if err != nil {
 			return fmt.Errorf("error during http.Post to %s: %w", webhookURL, err)

--- a/cron/internal/controller/bucket_test.go
+++ b/cron/internal/controller/bucket_test.go
@@ -22,7 +22,6 @@ import (
 
 //nolint:tparallel,paralleltest // since t.Setenv is used
 func TestGetPrefix(t *testing.T) {
-	//nolint:govet
 	testcases := []struct {
 		name       string
 		url        string

--- a/cron/internal/controller/bucket_test.go
+++ b/cron/internal/controller/bucket_test.go
@@ -20,7 +20,7 @@ import (
 	"testing"
 )
 
-//nolint:tparallel,paralleltest // since t.Setenv is used
+//nolint:paralleltest // since t.Setenv is used
 func TestGetPrefix(t *testing.T) {
 	testcases := []struct {
 		name       string

--- a/cron/internal/format/json_test.go
+++ b/cron/internal/format/json_test.go
@@ -66,7 +66,7 @@ func jsonMockDocRead() *mockDoc {
 	return &m
 }
 
-// nolint
+//nolint:gocognit
 func TestJSONOutput(t *testing.T) {
 	t.Parallel()
 
@@ -80,7 +80,7 @@ func TestJSONOutput(t *testing.T) {
 	}
 
 	checkDocs := jsonMockDocRead()
-
+	//nolint:govet
 	tests := []struct {
 		name        string
 		expected    string

--- a/cron/internal/format/mock_doc.go
+++ b/cron/internal/format/mock_doc.go
@@ -70,8 +70,7 @@ type mockDoc struct {
 }
 
 func (d *mockDoc) GetCheck(name string) (docs.CheckDoc, error) {
-	//nolint: gosimple
-	m, _ := d.checks[name]
+	m := d.checks[name]
 	return &m, nil
 }
 

--- a/cron/internal/format/schema_gen_test.go
+++ b/cron/internal/format/schema_gen_test.go
@@ -22,10 +22,10 @@ import (
 	"github.com/google/go-cmp/cmp"
 )
 
-//nolint
 func Test_GenerateBQSchema(t *testing.T) {
 	t.Parallel()
 
+	//nolint:govet
 	tests := []struct {
 		name      string
 		path      string
@@ -80,10 +80,10 @@ func Test_GenerateBQSchema(t *testing.T) {
 	}
 }
 
-//nolint
 func Test_GenerateJSONSchema(t *testing.T) {
 	t.Parallel()
 
+	//nolint:govet
 	tests := []struct {
 		name      string
 		path      string

--- a/cron/internal/pubsub/publisher_test.go
+++ b/cron/internal/pubsub/publisher_test.go
@@ -33,13 +33,13 @@ func (topic *mockSucceedTopic) Send(ctx context.Context, msg *pubsub.Message) er
 type mockFailTopic struct{}
 
 func (topic *mockFailTopic) Send(ctx context.Context, msg *pubsub.Message) error {
-	//nolint: goerr113
+	//nolint:goerr113
 	return fmt.Errorf("mockFailTopic failed to send")
 }
 
 func TestPublish(t *testing.T) {
 	t.Parallel()
-	//nolint: govet
+	//nolint:govet
 	testcases := []struct {
 		numErrors uint64
 		name      string

--- a/cron/internal/pubsub/subscriber_gocloud.go
+++ b/cron/internal/pubsub/subscriber_gocloud.go
@@ -37,7 +37,6 @@ type gocloudSubscriber struct {
 	msg          *pubsub.Message
 }
 
-//nolint:unused,deadcode
 func createGocloudSubscriber(ctx context.Context, subscriptionURL string) (*gocloudSubscriber, error) {
 	subscription, err := pubsub.OpenSubscription(ctx, subscriptionURL)
 	if err != nil {

--- a/cron/internal/pubsub/subscriber_gocloud_test.go
+++ b/cron/internal/pubsub/subscriber_gocloud_test.go
@@ -65,7 +65,7 @@ func TestSubscriber(t *testing.T) {
 		{
 			name:            "ReceiveFails",
 			hasErrOnReceive: true,
-			//nolint: goerr113
+			//nolint:goerr113
 			errOnReceive: errors.New("mock Receive failure"),
 		},
 		{
@@ -78,7 +78,7 @@ func TestSubscriber(t *testing.T) {
 				},
 			},
 			hasErrOnShutdown: true,
-			//nolint: goerr113
+			//nolint:goerr113
 			errOnShutdown: errors.New("mock Shutdown close"),
 		},
 	}

--- a/cron/internal/webhook/main.go
+++ b/cron/internal/webhook/main.go
@@ -81,7 +81,7 @@ func scriptHandler(w http.ResponseWriter, r *http.Request) {
 func main() {
 	http.HandleFunc("/", scriptHandler)
 	log.Printf("Starting HTTP server on port 8080 ...\n")
-	// nolint:gosec // internal server.
+	//nolint:gosec // internal server.
 	if err := http.ListenAndServe(":8080", nil); err != nil {
 		log.Fatal(err)
 	}

--- a/cron/internal/worker/main.go
+++ b/cron/internal/worker/main.go
@@ -220,7 +220,7 @@ func processRequest(ctx context.Context,
 			}
 			errorMsg := fmt.Sprintf("check %s has a runtime error: %v", check.Name, check.Error)
 			if !(*ignoreRuntimeErrors) {
-				//nolint: goerr113
+				//nolint:goerr113
 				return errors.New(errorMsg)
 			}
 			// TODO(log): Previously Warn. Consider logging an error here.

--- a/dependencydiff/dependencydiff_test.go
+++ b/dependencydiff/dependencydiff_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func Test_initRepoAndClientByChecks(t *testing.T) {
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name                           string
 		dCtx                           dependencydiffContext
@@ -112,7 +112,7 @@ func Test_getScorecardCheckResults(t *testing.T) {
 }
 
 func Test_mapDependencyEcosystemNaming(t *testing.T) {
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		name      string
 		deps      []dependency
@@ -167,7 +167,6 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			//nolint
 			err := mapDependencyEcosystemNaming(tt.deps)
 			if tt.errWanted != nil && errors.Is(tt.errWanted, err) {
 				t.Errorf("not a wanted error, want:%v, got:%v", tt.errWanted, err)
@@ -178,7 +177,6 @@ func Test_mapDependencyEcosystemNaming(t *testing.T) {
 }
 
 func Test_isSpecifiedByUser(t *testing.T) {
-	//nolint
 	tests := []struct {
 		name               string
 		ct                 pkg.ChangeType
@@ -216,7 +214,6 @@ func Test_isSpecifiedByUser(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
-			//nolint
 			result := isSpecifiedByUser(tt.ct, tt.changeTypesToCheck)
 			if result != tt.resultWanted {
 				t.Errorf("result (%v) != result wanted (%v)", result, tt.resultWanted)

--- a/dependencydiff/mapping.go
+++ b/dependencydiff/mapping.go
@@ -22,7 +22,6 @@ import (
 type ecosystem string
 
 // OSV ecosystem naming data source: https://ossf.github.io/osv-schema/#affectedpackage-field
-//nolint
 const (
 	// The Go ecosystem.
 	ecosystemGo ecosystem = "Go"
@@ -30,7 +29,7 @@ const (
 	// The NPM ecosystem.
 	ecosystemNpm ecosystem = "npm"
 
-	// The Android ecosystem
+	// The Android ecosystem.
 	ecosystemAndroid ecosystem = "Android" //nolint:unused
 
 	// The crates.io ecosystem for RUST.

--- a/docs/checks/impl.go
+++ b/docs/checks/impl.go
@@ -50,7 +50,7 @@ func Read() (Doc, error) {
 func (d *DocImpl) GetCheck(name string) (CheckDoc, error) {
 	ic, exists := d.internaldoc.InternalChecks[name]
 	if !exists {
-		//nolint: wrapcheck
+		//nolint:wrapcheck
 		return nil, sce.CreateInternal(errCheckNotExist, "")
 	}
 	// Set the name and URL.
@@ -63,7 +63,7 @@ func (d *DocImpl) GetCheck(name string) (CheckDoc, error) {
 func (d *DocImpl) GetChecks() []CheckDoc {
 	var checks []CheckDoc
 	for k := range d.internaldoc.InternalChecks {
-		//nolint: errcheck
+		//nolint:errcheck
 		check, _ := d.GetCheck(k)
 		checks = append(checks, check)
 	}

--- a/docs/checks/internal/generate/main.go
+++ b/docs/checks/internal/generate/main.go
@@ -23,7 +23,7 @@ import (
 
 func main() {
 	if len(os.Args) != 2 {
-		//nolint: goerr113
+		//nolint:goerr113
 		panic(fmt.Errorf("usage: %s filename", os.Args[0]))
 	}
 	yamlFile := os.Args[1]

--- a/finding/finding.go
+++ b/finding/finding.go
@@ -43,7 +43,8 @@ const (
 )
 
 // Location represents the location of a finding.
-// nolint: govet
+//
+//nolint:govet
 type Location struct {
 	Type      FileType `json:"type"`
 	Path      string   `json:"path"`
@@ -93,7 +94,8 @@ const (
 )
 
 // Finding represents a finding.
-// nolint: govet
+//
+//nolint:govet
 type Finding struct {
 	Probe       string             `json:"probe"`
 	Outcome     Outcome            `json:"outcome"`
@@ -117,7 +119,7 @@ var errInvalid = errors.New("invalid")
 func FromBytes(content []byte, probeID string) (*Finding, error) {
 	p, err := probe.FromBytes(content, probeID)
 	if err != nil {
-		// nolint
+		//nolint:wrapcheck
 		return nil, err
 	}
 	f := &Finding{

--- a/finding/finding_test.go
+++ b/finding/finding_test.go
@@ -38,7 +38,7 @@ func Test_FromBytes(t *testing.T) {
 	positiveOutcome := OutcomePositive
 	negativeOutcome := OutcomeNegative
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		id       string

--- a/finding/probe/probe.go
+++ b/finding/probe/probe.go
@@ -51,14 +51,12 @@ type Remediation struct {
 	Effort RemediationEffort `json:"effort"`
 }
 
-// nolint: govet
 type yamlRemediation struct {
 	Text     []string          `yaml:"text"`
 	Markdown []string          `yaml:"markdown"`
 	Effort   RemediationEffort `yaml:"effort"`
 }
 
-// nolint: govet
 type yamlProbe struct {
 	ID             string          `yaml:"id"`
 	Short          string          `yaml:"short"`
@@ -67,7 +65,7 @@ type yamlProbe struct {
 	Remediation    yamlRemediation `yaml:"remediation"`
 }
 
-// nolint: govet
+//nolint:govet
 type Probe struct {
 	ID             string
 	Short          string
@@ -154,7 +152,6 @@ func (r *RemediationEffort) UnmarshalYAML(n *yaml.Node) error {
 		return fmt.Errorf("%w: %w", errInvalid, err)
 	}
 
-	// nolint:goconst
 	switch n.Value {
 	case "Low":
 		*r = RemediationEffortLow

--- a/finding/probe/probe_test.go
+++ b/finding/probe/probe_test.go
@@ -29,7 +29,7 @@ func errCmp(e1, e2 error) bool {
 
 func Test_FromBytes(t *testing.T) {
 	t.Parallel()
-	// nolint: govet
+	//nolint:govet
 	tests := []struct {
 		name  string
 		id    string

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -16,12 +16,10 @@
 package options
 
 import (
-	"os"
 	"testing"
 )
 
-// Cannot run parallel tests because of the ENV variables.
-// nolint
+//nolint:paralleltest // because we are using t.Setenv.
 func TestOptions_Validate(t *testing.T) {
 	type fields struct {
 		Repo              string
@@ -110,8 +108,7 @@ func TestOptions_Validate(t *testing.T) {
 				EnableScorecardV6: tt.fields.EnableScorecardV6,
 			}
 			if o.EnableSarif {
-				os.Setenv(EnvVarEnableSarif, "1")
-				defer os.Unsetenv(EnvVarEnableSarif)
+				t.Setenv(EnvVarEnableSarif, "1")
 			}
 
 			if err := o.Validate(); (err != nil) != tt.wantErr {

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -27,7 +27,6 @@ import (
 	"github.com/ossf/scorecard/v4/log"
 )
 
-//nolint:govet
 type jsonCheckResult struct {
 	Name       string
 	Details    []string
@@ -49,7 +48,7 @@ type jsonCheckDocumentationV2 struct {
 	// Can be extended if needed.
 }
 
-// nolint: govet
+//nolint:govet
 type jsonCheckResultV2 struct {
 	Details []string                 `json:"details"`
 	Score   int                      `json:"score"`

--- a/pkg/json_probe_results.go
+++ b/pkg/json_probe_results.go
@@ -24,8 +24,6 @@ import (
 )
 
 // JSONScorecardProbeResult exports results as JSON for flat findings without checks.
-//
-//nolint:govet
 type JSONScorecardProbeResult struct {
 	Date      string            `json:"date"`
 	Repo      jsonRepoV2        `json:"repo"`

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -307,7 +307,7 @@ func (r *jsonScorecardRawResult) addTokenPermissionsRawResults(tp *checker.Token
 		}
 
 		if t.LocationType == nil {
-			//nolint
+			//nolint:goerr113
 			return errors.New("locationType is nil")
 		}
 
@@ -351,7 +351,7 @@ func (r *jsonScorecardRawResult) addPackagingRawResults(pk *checker.PackagingDat
 			continue
 		}
 		if p.File == nil {
-			//nolint
+			//nolint:goerr113
 			return errors.New("file field is nil")
 		}
 

--- a/pkg/json_test.go
+++ b/pkg/json_test.go
@@ -66,7 +66,7 @@ func jsonMockDocRead() *mockDoc {
 	return &m
 }
 
-// nolint
+//nolint:gocognit
 func TestJSONOutput(t *testing.T) {
 	t.Parallel()
 
@@ -82,6 +82,7 @@ func TestJSONOutput(t *testing.T) {
 
 	checkDocs := jsonMockDocRead()
 
+	//nolint:govet
 	tests := []struct {
 		name        string
 		expected    string

--- a/pkg/mock_doc.go
+++ b/pkg/mock_doc.go
@@ -70,8 +70,7 @@ type mockDoc struct {
 }
 
 func (d *mockDoc) GetCheck(name string) (docs.CheckDoc, error) {
-	//nolint: gosimple
-	m, _ := d.checks[name]
+	m := d.checks[name]
 	return &m, nil
 }
 

--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -40,7 +40,6 @@ type text struct {
 	Text string `json:"text,omitempty"`
 }
 
-// nolint
 type region struct {
 	StartLine   *uint `json:"startLine,omitempty"`
 	EndLine     *uint `json:"endLine,omitempty"`
@@ -62,16 +61,15 @@ type physicalLocation struct {
 	ArtifactLocation artifactLocation `json:"artifactLocation"`
 }
 
-//nolint:govet
+//nolint:govet,lll
 type location struct {
 	PhysicalLocation physicalLocation `json:"physicalLocation"`
-	//nolint
 	// This is optional https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#location-object.
 	Message        *text `json:"message,omitempty"`
 	HasRemediation bool  `json:"-"`
 }
 
-// nolint
+//nolint:govet
 type relatedLocation struct {
 	ID               int              `json:"id"`
 	PhysicalLocation physicalLocation `json:"physicalLocation"`
@@ -124,7 +122,7 @@ type tool struct {
 	Driver driver `json:"driver"`
 }
 
-// nolint
+//nolint:govet
 type result struct {
 	RuleID           string            `json:"ruleId"`
 	Level            string            `json:"level,omitempty"` // Optional.
@@ -338,7 +336,7 @@ func detailsToLocations(details []checker.CheckDetail,
 ) []location {
 	locs := []location{}
 
-	//nolint
+	//nolint:lll
 	// Populate the locations.
 	// Note https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/sarif-support-for-code-scanning#result-object
 	// "Only the first value of this array is used. All other values are ignored."
@@ -429,7 +427,7 @@ func createSARIFRun(uri, toolName, version, commit string, t time.Time,
 	return run{
 		Tool:    createSARIFTool(uri, toolName, version),
 		Results: []result{},
-		//nolint
+		//nolint:lll
 		// See https://docs.github.com/en/code-security/code-scanning/integrating-with-code-scanning/sarif-support-for-code-scanning#runautomationdetails-object.
 		AutomationDetails: automationDetails{
 			// Time formatting: https://pkg.go.dev/time#pkg-constants.
@@ -613,7 +611,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 	writer io.Writer, checkDocs docs.Doc, policy *spol.ScorecardPolicy,
 	opts *options.Options,
 ) error {
-	//nolint
+	//nolint:lll
 	// https://docs.oasis-open.org/sarif/sarif/v2.1.0/cs01/sarif-v2.1.0-cs01.html.
 	// We only support GitHub-supported properties:
 	// see https://docs.github.com/en/code-security/secure-coding/integrating-with-code-scanning/sarif-support-for-code-scanning#supported-sarif-output-file-properties,
@@ -621,8 +619,8 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 	sarif := createSARIFHeader()
 	runs := make(map[string]*run)
 
-	//nolint
 	for _, check := range r.Checks {
+		check := check
 		doc, err := checkDocs.GetCheck(check.Name)
 		if err != nil {
 			return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("GetCheck: %v: %s", err, check.Name))
@@ -692,6 +690,7 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
 			run.Results = append(run.Results, cr)
 		} else {
 			for _, loc := range locs {
+				loc := loc
 				// Use the location's message (check's detail's message) as message.
 				msg := messageWithScore(loc.Message.Text, check.Score)
 				cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &loc)

--- a/pkg/sarif_test.go
+++ b/pkg/sarif_test.go
@@ -99,17 +99,8 @@ func sarifMockDocRead() *mockDoc {
 	return &m
 }
 
-// nolint
 func TestSARIFOutput(t *testing.T) {
 	t.Parallel()
-
-	type Check struct {
-		Risk        string   `yaml:"-"`
-		Short       string   `yaml:"short"`
-		Description string   `yaml:"description"`
-		Remediation []string `yaml:"remediation"`
-		Tags        string   `yaml:"tags"`
-	}
 
 	repoCommit := "68bc59901773ab4c051dfcea0cc4201a1567ab32"
 	scorecardCommit := "ccbc59901773ab4c051dfcea0cc4201a1567abdd"
@@ -122,6 +113,7 @@ func TestSARIFOutput(t *testing.T) {
 
 	checkDocs := sarifMockDocRead()
 
+	//nolint:govet
 	tests := []struct {
 		name        string
 		expected    string

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -44,7 +44,6 @@ type RepoInfo struct {
 }
 
 // ScorecardResult struct is returned on a successful Scorecard run.
-// nolint
 type ScorecardResult struct {
 	Repo       RepoInfo
 	Date       time.Time

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -29,7 +29,7 @@ import (
 func TestPolicyRead(t *testing.T) {
 	t.Parallel()
 
-	//nolint
+	//nolint:govet
 	tests := []struct {
 		err      error
 		name     string

--- a/probes/contributorsFromOrgOrCompany/impl.go
+++ b/probes/contributorsFromOrgOrCompany/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package contributorsFromOrgOrCompany
 
 import (

--- a/probes/contributorsFromOrgOrCompany/impl_test.go
+++ b/probes/contributorsFromOrgOrCompany/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package contributorsFromOrgOrCompany
 
 import (
@@ -37,7 +37,7 @@ type User struct {
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithCLibFuzzer/impl.go
+++ b/probes/fuzzedWithCLibFuzzer/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithCLibFuzzer
 
 import (

--- a/probes/fuzzedWithCLibFuzzer/impl_test.go
+++ b/probes/fuzzedWithCLibFuzzer/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithCLibFuzzer
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithClusterFuzzLite/impl.go
+++ b/probes/fuzzedWithClusterFuzzLite/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithClusterFuzzLite
 
 import (

--- a/probes/fuzzedWithClusterFuzzLite/impl_test.go
+++ b/probes/fuzzedWithClusterFuzzLite/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithClusterFuzzLite
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithCppLibFuzzer/impl.go
+++ b/probes/fuzzedWithCppLibFuzzer/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithCppLibFuzzer
 
 import (

--- a/probes/fuzzedWithCppLibFuzzer/impl_test.go
+++ b/probes/fuzzedWithCppLibFuzzer/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithCppLibFuzzer
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithGoNative/impl.go
+++ b/probes/fuzzedWithGoNative/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithGoNative
 
 import (

--- a/probes/fuzzedWithGoNative/impl_test.go
+++ b/probes/fuzzedWithGoNative/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithGoNative
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithJavaJazzerFuzzer/impl.go
+++ b/probes/fuzzedWithJavaJazzerFuzzer/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithJavaJazzerFuzzer
 
 import (

--- a/probes/fuzzedWithJavaJazzerFuzzer/impl_test.go
+++ b/probes/fuzzedWithJavaJazzerFuzzer/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithJavaJazzerFuzzer
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithOSSFuzz/impl.go
+++ b/probes/fuzzedWithOSSFuzz/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithOSSFuzz
 
 import (

--- a/probes/fuzzedWithOSSFuzz/impl_test.go
+++ b/probes/fuzzedWithOSSFuzz/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithOSSFuzz
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithPropertyBasedHaskell/impl.go
+++ b/probes/fuzzedWithPropertyBasedHaskell/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPropertyBasedHaskell
 
 import (

--- a/probes/fuzzedWithPropertyBasedHaskell/impl_test.go
+++ b/probes/fuzzedWithPropertyBasedHaskell/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPropertyBasedHaskell
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithPropertyBasedJavascript/impl.go
+++ b/probes/fuzzedWithPropertyBasedJavascript/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPropertyBasedJavascript
 
 import (

--- a/probes/fuzzedWithPropertyBasedJavascript/impl_test.go
+++ b/probes/fuzzedWithPropertyBasedJavascript/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPropertyBasedJavascript
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithPropertyBasedTypescript/impl.go
+++ b/probes/fuzzedWithPropertyBasedTypescript/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPropertyBasedTypescript
 
 import (

--- a/probes/fuzzedWithPropertyBasedTypescript/impl_test.go
+++ b/probes/fuzzedWithPropertyBasedTypescript/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPropertyBasedTypescript
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithPythonAtheris/impl.go
+++ b/probes/fuzzedWithPythonAtheris/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPythonAtheris
 
 import (

--- a/probes/fuzzedWithPythonAtheris/impl_test.go
+++ b/probes/fuzzedWithPythonAtheris/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithPythonAtheris
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithRustCargofuzz/impl.go
+++ b/probes/fuzzedWithRustCargofuzz/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithRustCargofuzz
 
 import (

--- a/probes/fuzzedWithRustCargofuzz/impl_test.go
+++ b/probes/fuzzedWithRustCargofuzz/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithRustCargofuzz
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/fuzzedWithSwiftLibFuzzer/impl.go
+++ b/probes/fuzzedWithSwiftLibFuzzer/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithSwiftLibFuzzer
 
 import (

--- a/probes/fuzzedWithSwiftLibFuzzer/impl_test.go
+++ b/probes/fuzzedWithSwiftLibFuzzer/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package fuzzedWithSwiftLibFuzzer
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/hasDangerousWorkflowScriptInjection/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasDangerousWorkflowScriptInjection
 
 import (

--- a/probes/hasDangerousWorkflowScriptInjection/impl_test.go
+++ b/probes/hasDangerousWorkflowScriptInjection/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasDangerousWorkflowScriptInjection
 
 import (
@@ -27,7 +27,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/hasDangerousWorkflowUntrustedCheckout/impl.go
+++ b/probes/hasDangerousWorkflowUntrustedCheckout/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasDangerousWorkflowUntrustedCheckout
 
 import (

--- a/probes/hasDangerousWorkflowUntrustedCheckout/impl_test.go
+++ b/probes/hasDangerousWorkflowUntrustedCheckout/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasDangerousWorkflowUntrustedCheckout
 
 import (
@@ -27,7 +27,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/hasFSFOrOSIApprovedLicense/impl.go
+++ b/probes/hasFSFOrOSIApprovedLicense/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasFSFOrOSIApprovedLicense
 
 import (

--- a/probes/hasFSFOrOSIApprovedLicense/impl_test.go
+++ b/probes/hasFSFOrOSIApprovedLicense/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasFSFOrOSIApprovedLicense
 
 import (
@@ -27,7 +27,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/hasLicenseFile/impl.go
+++ b/probes/hasLicenseFile/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasLicenseFile
 
 import (

--- a/probes/hasLicenseFile/impl_test.go
+++ b/probes/hasLicenseFile/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasLicenseFile
 
 import (
@@ -27,7 +27,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/hasLicenseFileAtTopDir/impl.go
+++ b/probes/hasLicenseFileAtTopDir/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasLicenseFileAtTopDir
 
 import (

--- a/probes/hasLicenseFileAtTopDir/impl_test.go
+++ b/probes/hasLicenseFileAtTopDir/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasLicenseFileAtTopDir
 
 import (
@@ -27,7 +27,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/hasOSVVulnerabilities/impl.go
+++ b/probes/hasOSVVulnerabilities/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasOSVVulnerabilities
 
 import (

--- a/probes/hasOSVVulnerabilities/impl_test.go
+++ b/probes/hasOSVVulnerabilities/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package hasOSVVulnerabilities
 
 import (
@@ -29,7 +29,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name            string
 		raw             *checker.RawResults

--- a/probes/hasOSVVulnerabilities/impl_test.go
+++ b/probes/hasOSVVulnerabilities/impl_test.go
@@ -88,11 +88,11 @@ func Test_Run(t *testing.T) {
 				Probe:   "hasOSVVulnerabilities",
 				Message: "Project is vulnerable to: foo",
 				Remediation: &probe.Remediation{
-					//nolint
+					//nolint:lll
 					Text: `Fix the foo by following information from https://osv.dev/foo.
 If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
 If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on OSV-Scanner repository.`,
-					//nolint
+					//nolint:lll
 					Markdown: `Fix the foo by following information from [OSV](https://osv.dev/foo).
 If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
 If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml ([example](https://github.com/google/osv.dev/blob/eb99b02ec8895fe5b87d1e76675ddad79a15f817/vulnfeeds/osv-scanner.toml)) file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on [OSV-Scanner repository](https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id).`,

--- a/probes/packagedWithAutomatedWorkflow/impl.go
+++ b/probes/packagedWithAutomatedWorkflow/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package packagedWithAutomatedWorkflow
 
 import (

--- a/probes/packagedWithAutomatedWorkflow/impl_test.go
+++ b/probes/packagedWithAutomatedWorkflow/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package packagedWithAutomatedWorkflow
 
 import (
@@ -28,7 +28,7 @@ import (
 func Test_Run(t *testing.T) {
 	msg := "msg"
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/sastToolCodeQLInstalled/impl.go
+++ b/probes/sastToolCodeQLInstalled/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package sastToolCodeQLInstalled
 
 import (

--- a/probes/sastToolCodeQLInstalled/impl_test.go
+++ b/probes/sastToolCodeQLInstalled/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package sastToolCodeQLInstalled
 
 import (
@@ -27,7 +27,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/sastToolRunsOnAllCommits/impl.go
+++ b/probes/sastToolRunsOnAllCommits/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package sastToolRunsOnAllCommits
 
 import (

--- a/probes/sastToolRunsOnAllCommits/impl_test.go
+++ b/probes/sastToolRunsOnAllCommits/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package sastToolRunsOnAllCommits
 
 import (

--- a/probes/sastToolRunsOnAllCommits/impl_test.go
+++ b/probes/sastToolRunsOnAllCommits/impl_test.go
@@ -27,7 +27,6 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
 	tests := []struct {
 		name             string
 		raw              *checker.RawResults

--- a/probes/sastToolSonarInstalled/impl.go
+++ b/probes/sastToolSonarInstalled/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package sastToolSonarInstalled
 
 import (

--- a/probes/sastToolSonarInstalled/impl_test.go
+++ b/probes/sastToolSonarInstalled/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package sastToolSonarInstalled
 
 import (
@@ -27,7 +27,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/securityPolicyContainsLinks/impl.go
+++ b/probes/securityPolicyContainsLinks/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyContainsLinks
 
 import (

--- a/probes/securityPolicyContainsLinks/impl_test.go
+++ b/probes/securityPolicyContainsLinks/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyContainsLinks
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/securityPolicyContainsText/impl.go
+++ b/probes/securityPolicyContainsText/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyContainsText
 
 import (

--- a/probes/securityPolicyContainsText/impl_test.go
+++ b/probes/securityPolicyContainsText/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyContainsText
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/securityPolicyContainsVulnerabilityDisclosure/impl.go
+++ b/probes/securityPolicyContainsVulnerabilityDisclosure/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyContainsVulnerabilityDisclosure
 
 import (

--- a/probes/securityPolicyContainsVulnerabilityDisclosure/impl_test.go
+++ b/probes/securityPolicyContainsVulnerabilityDisclosure/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyContainsVulnerabilityDisclosure
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/securityPolicyPresent/impl.go
+++ b/probes/securityPolicyPresent/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyPresent
 
 import (

--- a/probes/securityPolicyPresent/impl_test.go
+++ b/probes/securityPolicyPresent/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package securityPolicyPresent
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/toolDependabotInstalled/impl.go
+++ b/probes/toolDependabotInstalled/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package toolDependabotInstalled
 
 import (

--- a/probes/toolDependabotInstalled/impl_test.go
+++ b/probes/toolDependabotInstalled/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package toolDependabotInstalled
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/toolPyUpInstalled/impl.go
+++ b/probes/toolPyUpInstalled/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package toolPyUpInstalled
 
 import (

--- a/probes/toolPyUpInstalled/impl_test.go
+++ b/probes/toolPyUpInstalled/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package toolPyUpInstalled
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/probes/toolRenovateInstalled/impl.go
+++ b/probes/toolRenovateInstalled/impl.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package toolRenovateInstalled
 
 import (

--- a/probes/toolRenovateInstalled/impl_test.go
+++ b/probes/toolRenovateInstalled/impl_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// nolint:stylecheck
+//nolint:stylecheck
 package toolRenovateInstalled
 
 import (
@@ -28,7 +28,7 @@ import (
 
 func Test_Run(t *testing.T) {
 	t.Parallel()
-	// nolint:govet
+	//nolint:govet
 	tests := []struct {
 		name     string
 		raw      *checker.RawResults

--- a/remediation/remediations.go
+++ b/remediation/remediations.go
@@ -29,7 +29,7 @@ var errInvalidArg = errors.New("invalid argument")
 
 var (
 	workflowText = "update your workflow using https://app.stepsecurity.io/secureworkflow/%s/%s/%s?enable=%s"
-	//nolint
+	//nolint:lll
 	workflowMarkdown  = "update your workflow using [https://app.stepsecurity.io](https://app.stepsecurity.io/secureworkflow/%s/%s/%s?enable=%s)"
 	dockerfilePinText = "pin your Docker image by updating %[1]s to %[1]s@%s"
 )

--- a/rule/rule.go
+++ b/rule/rule.go
@@ -49,14 +49,13 @@ type Remediation struct {
 	Effort RemediationEffort `json:"effort"`
 }
 
-// nolint: govet
 type jsonRemediation struct {
 	Text     []string          `yaml:"text"`
 	Markdown []string          `yaml:"markdown"`
 	Effort   RemediationEffort `yaml:"effort"`
 }
 
-// nolint: govet
+//nolint:govet
 type jsonRule struct {
 	Short          string          `yaml:"short"`
 	Desc           string          `yaml:"desc"`
@@ -82,7 +81,7 @@ const (
 	RiskCritical
 )
 
-// nolint: govet
+//nolint:govet
 type Rule struct {
 	Name        string
 	Short       string
@@ -170,7 +169,7 @@ func (r *RemediationEffort) UnmarshalYAML(n *yaml.Node) error {
 		return fmt.Errorf("%w: %w", errInvalid, err)
 	}
 
-	// nolint:goconst
+	//nolint:goconst
 	switch n.Value {
 	case "Low":
 		*r = RemediationEffortLow

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -34,7 +34,7 @@ var testfs embed.FS
 
 func Test_New(t *testing.T) {
 	t.Parallel()
-	// nolint: govet
+	//nolint: govet
 	tests := []struct {
 		name string
 		id   string

--- a/rule/rule_test.go
+++ b/rule/rule_test.go
@@ -34,7 +34,7 @@ var testfs embed.FS
 
 func Test_New(t *testing.T) {
 	t.Parallel()
-	//nolint: govet
+	//nolint:govet
 	tests := []struct {
 		name string
 		id   string

--- a/utests/utlib.go
+++ b/utests/utlib.go
@@ -79,7 +79,7 @@ func getTestReturn(cr *checker.CheckResult, logger *TestDetailLogger) (*TestRetu
 	for _, v := range logger.messages {
 		switch v.Type {
 		default:
-			//nolint: goerr113
+			//nolint:goerr113
 			return nil, fmt.Errorf("invalid type %v", v.Type)
 		case checker.DetailInfo:
 			ret.NumberOfInfo++

--- a/utests/utlib.go
+++ b/utests/utlib.go
@@ -99,7 +99,8 @@ func errCmp(e1, e2 error) bool {
 }
 
 // ValidateTestReturn validates expected TestReturn with actual checker.CheckResult values.
-// nolint: thelper
+//
+//nolint:thelper
 func ValidateTestReturn(
 	t *testing.T,
 	name string,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

linter change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- The various `//nolint` directives aren't formatted properly and end up in doc strings. This syntax is from the docs here https://go.dev/doc/comment

> Directive comments such as //go:generate are not considered part of a doc comment and are omitted from rendered documentation. Gofmt moves directive comments to the end of the doc comment, preceded by a blank line. For example:
> ```
> package regexp
> 
> // An Op is a single regular expression operator.
> //
> //go:generate stringer -type Op -trimprefix Op
> type Op uint8
> ```
> A directive comment is a line matching the regular expression //(line |extern |export |[a-z0-9]+:[a-z0-9]). Tools that define their own directives should use the form //toolname:directive.
- Some `//nolint` directives are too broad and are hiding bugs.

#### What is the new behavior (if this is a feature change)?**
- The `nolintlint` linter is enabled to enforce directive comments
  - `//nolint` directives without a sublinter are prohibited. They should all include specific linter(s) so we don't hide other bugs. e.g.`//nolint:my-linter,some-other-linter`.
  - unused `//nolint` directives are removed
 - two loop aliasing bugs are fixed

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #3588 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
This PR is large sorry. Here are the functional changes I've highlighted from the diff using some `grep`ing and trimming
```console
git diff main | grep -E "^[+-]\s" | grep -v "nolint"`
```

simple alternative
```diff
diff --git a/cron/internal/format/mock_doc.go b/cron/internal/format/mock_doc.go
index 782d3fbc..ebcde284 100644
--- a/cron/internal/format/mock_doc.go
+++ b/cron/internal/format/mock_doc.go
@@ -73,2 +73 @@ func (d *mockDoc) GetCheck(name string) (docs.CheckDoc, error) {
-	//nolint: gosimple
-	m, _ := d.checks[name]
+	m := d.checks[name]
```

simple alternative
```diff
diff --git a/options/options_test.go b/options/options_test.go
index 8098e8eb..91e5ed9c 100644
--- a/options/options_test.go
+++ b/options/options_test.go
@@ -113,2 +111 @@ func TestOptions_Validate(t *testing.T) {
-				os.Setenv(EnvVarEnableSarif, "1")
-				defer os.Unsetenv(EnvVarEnableSarif)
+				t.Setenv(EnvVarEnableSarif, "1")
```

simple alternative
```diff
diff --git a/pkg/mock_doc.go b/pkg/mock_doc.go
index 1baa2a84..dd565acf 100644
--- a/pkg/mock_doc.go
+++ b/pkg/mock_doc.go
@@ -73,2 +73 @@ func (d *mockDoc) GetCheck(name string) (docs.CheckDoc, error) {
-	//nolint: gosimple
-	m, _ := d.checks[name]
+	m := d.checks[name]
```

This one is a loop alias bug you can view [here](https://github.com/ossf/scorecard/blob/fbffff18e0fb62e55c1f1420c1f11d764a2de073/pkg/sarif.go#L632-L701).
> G601: Implicit memory aliasing in for loop. (gosec)
```diff
diff --git a/pkg/sarif.go b/pkg/sarif.go
index 30f43d01..8ecf9e9d 100644
--- a/pkg/sarif.go
+++ b/pkg/sarif.go
@@ -632,0 +630 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
+		check := check
@@ -701,0 +700 @@ func (r *ScorecardResult) AsSARIF(showDetails bool, logLevel log.Level,
+				loc := loc
```

Unused struct
```diff
diff --git a/pkg/sarif_test.go b/pkg/sarif_test.go
index 1fa37e52..49d8e719 100644
--- a/pkg/sarif_test.go
+++ b/pkg/sarif_test.go
@@ -106,8 +104,0 @@ func TestSARIFOutput(t *testing.T) {
-	type Check struct {
-		Risk        string   `yaml:"-"`
-		Short       string   `yaml:"short"`
-		Description string   `yaml:"description"`
-		Remediation []string `yaml:"remediation"`
-		Tags        string   `yaml:"tags"`
-	}
-
```

moved dynamic error to a package level var:
```diff
--- a/clients/githubrepo/roundtripper/roundtripper.go
+++ b/clients/githubrepo/roundtripper/roundtripper.go
@@ -20 +20 @@ import (
-	"fmt"
+	"errors"
@@ -39,0 +40,2 @@ const (
+var errGithubCredentials = errors.New("an error occurred while getting GitHub credentials")
+
@@ -63 +65,2 @@ func NewTransport(ctx context.Context, logger *log.Logger) http.RoundTripper {
-		logger.Error(fmt.Errorf("an error occurred while getting GitHub credentials"), "GitHub token env var is not set. Please read https://github.com/ossf/scorecard#authentication")
+		//nolint:lll
+		logger.Error(errGithubCredentials, "GitHub token env var is not set. Please read https://github.com/ossf/scorecard#authentication")
```
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
