### PR TITLE
:seedling: configure dependabot to group (most) GitHub actions weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,10 +19,19 @@ updates:
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:
-      interval: "daily"
+      interval: "weekly"
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
+  groups:
+    github-actions:
+      patterns:
+        - "*"
+      # These actions directly influence the build process and are excluded from grouped updates
+      exclude-patterns:
+        - "actions/setup-go"
+        - "arduino/setup-protoc"
+        - "goreleaser/goreleaser-action"
 - package-ecosystem: docker
   directory: "/"
   schedule:


### PR DESCRIPTION
#### What kind of change does this PR introduce?

dependabot config change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- GitHub actions are their own PR
- Updates are sent daily

#### What is the new behavior (if this is a feature change)?**
- updates are sent weekly
- Most actions are grouped. Actions which influence the build/release process are excluded, so dependabot will send individual updates for those.
  * "actions/setup-go"
  * "arduino/setup-protoc"
  * "goreleaser/goreleaser-action"

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
