### PR TITLE
:seedling: speedup slowest e2e tests

### DIFF
--- a/e2e/attestor_policy_test.go
+++ b/e2e/attestor_policy_test.go
@@ -15,6 +15,8 @@
 package e2e
 
 import (
+	"context"
+	"fmt"
 	"os"
 	"strings"
 
@@ -24,11 +26,16 @@ import (
 
 	"github.com/ossf/scorecard/v4/attestor/command"
 	"github.com/ossf/scorecard/v4/attestor/policy"
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/checks"
+	"github.com/ossf/scorecard/v4/clients"
+	sclog "github.com/ossf/scorecard/v4/log"
+	"github.com/ossf/scorecard/v4/pkg"
 )
 
 var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 	Context("E2E TEST:Validating scorecard attestation policy", func() {
-		It("Should attest to repos based on policy", func() {
+		It("Should attest to known good repos based on policy", func() {
 			tt := []struct {
 				name     string
 				repoURL  string
@@ -45,123 +52,6 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 						PreventUnpinnedDependencies: true,
 					},
 					expected: policy.Pass,
-				},
-				{
-					name:    "test bad repo with vulnerabilities prevented but no known vulnerabilities",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						PreventKnownVulnerabilities: true,
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test bad repo with ignored binary artifact",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts: true,
-						AllowedBinaryArtifacts: []string{"test-binary-artifact-*"},
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test bad repo with binary artifact",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts: true,
-					},
-					expected: policy.Fail,
-				},
-				{
-					name:    "test bad repo with ignored dep by path",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						PreventUnpinnedDependencies: true,
-						AllowedUnpinnedDependencies: []policy.Dependency{{Filepath: "Dockerfile"}},
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test bad repo without ignored dep",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						PreventUnpinnedDependencies: true,
-					},
-					expected: policy.Fail,
-				},
-				{
-					name:    "test bad repo with ignored dep by name",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						PreventUnpinnedDependencies: true,
-						AllowedUnpinnedDependencies: []policy.Dependency{{PackageName: "static-debian11"}, {PackageName: "golang"}},
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test bad repo with everything ignored",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						PreventBinaryArtifacts:      true,
-						AllowedBinaryArtifacts:      []string{"test-binary-artifact-*"},
-						PreventKnownVulnerabilities: true,
-						PreventUnpinnedDependencies: true,
-						AllowedUnpinnedDependencies: []policy.Dependency{{Filepath: "Dockerfile"}},
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test repo with simple code review requirements",
-					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
-					policy: policy.AttestationPolicy{
-						EnsureCodeReviewed: true,
-						CodeReviewRequirements: policy.CodeReviewRequirements{
-							MinReviewers: 1,
-						},
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test code reviews required but repo doesn't have code reviews",
-					repoURL: "https://github.com/ossf-tests/scorecard-binauthz-test-bad",
-					policy: policy.AttestationPolicy{
-						EnsureCodeReviewed: true,
-					},
-					expected: policy.Fail,
-				},
-				{
-					name:    "test code reviews required with min reviewers",
-					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
-					policy: policy.AttestationPolicy{
-						EnsureCodeReviewed: true,
-						CodeReviewRequirements: policy.CodeReviewRequirements{
-							MinReviewers: 1,
-						},
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test code reviews required with min reviewers and required reviewers",
-					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
-					policy: policy.AttestationPolicy{
-						EnsureCodeReviewed: true,
-						CodeReviewRequirements: policy.CodeReviewRequirements{
-							MinReviewers:      1,
-							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},
-						},
-					},
-					expected: policy.Pass,
-				},
-				{
-					name:    "test code reviews required with too many min reviewers but matching required reviewers",
-					repoURL: "https://github.com/ossf-tests/scorecard-attestor-code-review-e2e",
-					policy: policy.AttestationPolicy{
-						EnsureCodeReviewed: true,
-						CodeReviewRequirements: policy.CodeReviewRequirements{
-							MinReviewers:      2,
-							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},
-						},
-					},
-					expected: policy.Fail,
 				},
 			}
 
@@ -184,3 +74,179 @@ var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
 		})
 	})
 })
+
+var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
+	Context("E2E TEST:Validating scorecard attestation policy", func() {
+		It("Should attest to bad repos based on policy", func() {
+			tt := []struct {
+				name     string
+				repoURL  string
+				commit   string
+				policy   policy.AttestationPolicy
+				expected policy.PolicyResult
+			}{
+				{
+					name: "test bad repo with vulnerabilities prevented but no known vulnerabilities",
+					policy: policy.AttestationPolicy{
+						PreventKnownVulnerabilities: true,
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test bad repo with ignored binary artifact",
+					policy: policy.AttestationPolicy{
+						PreventBinaryArtifacts: true,
+						AllowedBinaryArtifacts: []string{"test-binary-artifact-*"},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test bad repo with binary artifact",
+					policy: policy.AttestationPolicy{
+						PreventBinaryArtifacts: true,
+					},
+					expected: policy.Fail,
+				},
+				{
+					name: "test bad repo with ignored dep by path",
+					policy: policy.AttestationPolicy{
+						PreventUnpinnedDependencies: true,
+						AllowedUnpinnedDependencies: []policy.Dependency{{Filepath: "Dockerfile"}},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test bad repo without ignored dep",
+					policy: policy.AttestationPolicy{
+						PreventUnpinnedDependencies: true,
+					},
+					expected: policy.Fail,
+				},
+				{
+					name: "test bad repo with ignored dep by name",
+					policy: policy.AttestationPolicy{
+						PreventUnpinnedDependencies: true,
+						AllowedUnpinnedDependencies: []policy.Dependency{{PackageName: "static-debian11"}, {PackageName: "golang"}},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test bad repo with everything ignored",
+					policy: policy.AttestationPolicy{
+						PreventBinaryArtifacts:      true,
+						AllowedBinaryArtifacts:      []string{"test-binary-artifact-*"},
+						PreventKnownVulnerabilities: true,
+						PreventUnpinnedDependencies: true,
+						AllowedUnpinnedDependencies: []policy.Dependency{{Filepath: "Dockerfile"}},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test code reviews required but repo doesn't have code reviews",
+					policy: policy.AttestationPolicy{
+						EnsureCodeReviewed: true,
+					},
+					expected: policy.Fail,
+				},
+			}
+			results, err := getScorecardResult("https://github.com/ossf-tests/scorecard-binauthz-test-bad")
+			Expect(err).Should(BeNil())
+			for _, tc := range tt {
+				got, err := tc.policy.EvaluateResults(&results.RawResults)
+				Expect(err).Should(BeNil())
+				Expect(got).Should(BeEquivalentTo(tc.expected))
+			}
+		})
+	})
+})
+
+var _ = Describe("E2E TEST PAT: scorecard-attestor policy", func() {
+	Context("E2E TEST:Validating scorecard attestation policy", func() {
+		It("Should attest to repos based on code review policy", func() {
+			tt := []struct {
+				name     string
+				repoURL  string
+				commit   string
+				policy   policy.AttestationPolicy
+				expected policy.PolicyResult
+			}{
+				{
+					name: "test repo with simple code review requirements",
+					policy: policy.AttestationPolicy{
+						EnsureCodeReviewed: true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers: 1,
+						},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test code reviews required with min reviewers",
+					policy: policy.AttestationPolicy{
+						EnsureCodeReviewed: true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers: 1,
+						},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test code reviews required with min reviewers and required reviewers",
+					policy: policy.AttestationPolicy{
+						EnsureCodeReviewed: true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers:      1,
+							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},
+						},
+					},
+					expected: policy.Pass,
+				},
+				{
+					name: "test code reviews required with too many min reviewers but matching required reviewers",
+					policy: policy.AttestationPolicy{
+						EnsureCodeReviewed: true,
+						CodeReviewRequirements: policy.CodeReviewRequirements{
+							MinReviewers:      2,
+							RequiredApprovers: []string{"spencerschrock", "laurentsimon", "naveensrinivasan", "azeemshaikh38", "raghavkaul"},
+						},
+					},
+					expected: policy.Fail,
+				},
+			}
+			results, err := getScorecardResult("https://github.com/ossf-tests/scorecard-attestor-code-review-e2e")
+			Expect(err).Should(BeNil())
+			for _, tc := range tt {
+				got, err := tc.policy.EvaluateResults(&results.RawResults)
+				Expect(err).Should(BeNil())
+				Expect(got).Should(BeEquivalentTo(tc.expected))
+			}
+		})
+	})
+})
+
+func getScorecardResult(repoURL string) (pkg.ScorecardResult, error) {
+	ctx := context.Background()
+	logger := sclog.NewLogger(sclog.DefaultLevel)
+
+	enabledChecks := map[string]checker.Check{
+		checks.CheckBinaryArtifacts: {
+			Fn: checks.BinaryArtifacts,
+		},
+		checks.CheckVulnerabilities: {
+			Fn: checks.Vulnerabilities,
+		},
+		checks.CheckCodeReview: {
+			Fn: checks.CodeReview,
+		},
+		checks.CheckPinnedDependencies: {
+			Fn: checks.PinningDependencies,
+		},
+	}
+	repo, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, err := checker.GetClients(
+		ctx, repoURL, "", logger)
+	if err != nil {
+		return pkg.ScorecardResult{}, fmt.Errorf("couldn't set up clients: %w", err)
+	}
+	//nolint:wrapcheck,lll
+	return pkg.RunScorecard(ctx, repo, clients.HeadSHA, 0, enabledChecks, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient)
+}

--- a/e2e/fuzzing_test.go
+++ b/e2e/fuzzing_test.go
@@ -34,7 +34,7 @@ var _ = Describe("E2E TEST:"+checks.CheckFuzzing, func() {
 	Context("E2E TEST:Validating use of fuzzing tools", func() {
 		It("Should return use of OSS-Fuzz", func() {
 			dl := scut.TestDetailLogger{}
-			repo, err := githubrepo.MakeGithubRepo("tensorflow/tensorflow")
+			repo, err := githubrepo.MakeGithubRepo("ossf/scorecard-webapp")
 			Expect(err).Should(BeNil())
 			repoClient := githubrepo.CreateGithubRepoClient(context.Background(), logger)
 			err = repoClient.InitRepo(repo, clients.HeadSHA, 0)
@@ -53,7 +53,7 @@ var _ = Describe("E2E TEST:"+checks.CheckFuzzing, func() {
 				Error:         nil,
 				Score:         checker.MaxResultScore,
 				NumberOfWarn:  0,
-				NumberOfInfo:  12,
+				NumberOfInfo:  3, // 1 for OSSFuzz, 2 for go native fuzzing
 				NumberOfDebug: 0,
 			}
 			result := checks.Fuzzing(&req)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

e2e test speedup

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Theres 2 tests which are 1-2 orders of magnitude slower than other e2e tests:
- "Should return use of OSS-Fuzz"
  * `tensorflow/tensorflow` is a really big repo and this test downloads the repo.
- "Should attest to repos based on policy"
  * this one runs scorecard repeatedly on the same repos

#### What is the new behavior (if this is a feature change)?**
- "Should return use of OSS-Fuzz"
  * `ossf/scorecard-webapp` is a much smaller repo which is fuzzed by OSSFuzz
- "Should attest to repos based on policy"
  * split into 3 smaller tests
    * Since only one test dealt with `ossf-tests/scorecard-binauthz-test-good`, I changed the existing test to just test this one.
    * for the other two repos ( `ossf-tests/scorecard-binauthz-test-bad` and `ossf-tests/scorecard-attestor-code-review-e2e`), I changed the tests so they only fetch the results once, and just test the various policies against it. 

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
