### PR TITLE
:seedling: refactor pinned dependencies

### DIFF
--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -22,8 +22,16 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/rule"
 	scut "github.com/ossf/scorecard/v4/utests"
 )
+
+var testRemediation = &rule.Remediation{
+	Patch:    stringAsPointer("test"),
+	Text:     "test",
+	Markdown: "test markdown",
+	Effort:   rule.RemediationEffortLow,
+}
 
 func Test_createScoreForGitHubActionsWorkflow(t *testing.T) {
 	t.Parallel()
@@ -303,40 +311,47 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDownloadThenRun,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDownloadThenRun,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeGoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeGoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -351,9 +366,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem pinned and 1 ecosystem unpinned",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{},
@@ -373,9 +389,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem partially pinned",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{},
@@ -423,9 +440,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned dependency shows warn message",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -497,9 +515,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned choco install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeChocoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeChocoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -514,9 +533,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned Dockerfile container image",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -531,9 +551,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned download then run",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDownloadThenRun,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDownloadThenRun,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -548,9 +569,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned go install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeGoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeGoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -565,9 +587,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned npm install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -582,9 +605,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned nuget install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNugetCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNugetCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -599,9 +623,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned pip install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -616,14 +641,16 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 1 ecosystem shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -638,14 +665,16 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 2 ecosystems shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeGoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeGoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -727,15 +756,17 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -760,8 +791,9 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -779,8 +811,9 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{
@@ -802,14 +835,16 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "Skipped objects and dependencies",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			processingErrors: []checker.ElementError{
@@ -848,6 +883,10 @@ func Test_PinningDependencies(t *testing.T) {
 	}
 }
 
+func stringAsPointer(s string) *string {
+	return &s
+}
+
 func Test_generateOwnerToDisplay(t *testing.T) {
 	t.Parallel()
 	tests := []struct { //nolint:govet
@@ -880,9 +919,9 @@ func Test_generateOwnerToDisplay(t *testing.T) {
 func Test_addWorkflowPinnedResult(t *testing.T) {
 	t.Parallel()
 	type args struct {
-		dependency *checker.Dependency
-		w          *worklowPinningResult
-		isGitHub   bool
+		w        *worklowPinningResult
+		outcome  finding.Outcome
+		isGitHub bool
 	}
 	tests := []struct {
 		name string
@@ -892,9 +931,7 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 		{
 			name: "add pinned GitHub-owned action dependency",
 			args: args{
-				dependency: &checker.Dependency{
-					Pinned: asBoolPointer(true),
-				},
+				outcome:  finding.OutcomePositive,
 				w:        &worklowPinningResult{},
 				isGitHub: true,
 			},
@@ -912,9 +949,7 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 		{
 			name: "add unpinned GitHub-owned action dependency",
 			args: args{
-				dependency: &checker.Dependency{
-					Pinned: asBoolPointer(false),
-				},
+				outcome:  finding.OutcomeNegative,
 				w:        &worklowPinningResult{},
 				isGitHub: true,
 			},
@@ -932,9 +967,7 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 		{
 			name: "add pinned Third-Party action dependency",
 			args: args{
-				dependency: &checker.Dependency{
-					Pinned: asBoolPointer(true),
-				},
+				outcome:  finding.OutcomePositive,
 				w:        &worklowPinningResult{},
 				isGitHub: false,
 			},
@@ -952,9 +985,7 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 		{
 			name: "add unpinned Third-Party action dependency",
 			args: args{
-				dependency: &checker.Dependency{
-					Pinned: asBoolPointer(false),
-				},
+				outcome:  finding.OutcomeNegative,
 				w:        &worklowPinningResult{},
 				isGitHub: false,
 			},
@@ -974,7 +1005,7 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			addWorkflowPinnedResult(tt.args.dependency, tt.args.w, tt.args.isGitHub)
+			addWorkflowPinnedResult(tt.args.outcome, tt.args.w, tt.args.isGitHub)
 			if tt.want.thirdParties != tt.args.w.thirdParties {
 				t.Errorf("addWorkflowPinnedResult Third-party GitHub actions mismatch (-want +got):"+
 					"\nThird-party pinned: %s\nThird-party total: %s",
@@ -1032,9 +1063,11 @@ func TestGenerateText(t *testing.T) {
 func TestUpdatePinningResults(t *testing.T) {
 	t.Parallel()
 	type args struct {
-		dependency *checker.Dependency
-		w          *worklowPinningResult
-		pr         map[checker.DependencyUseType]pinnedResult
+		snippet        *string
+		w              *worklowPinningResult
+		pr             map[checker.DependencyUseType]pinnedResult
+		dependencyType checker.DependencyUseType
+		outcome        finding.Outcome
 	}
 	type want struct {
 		w  *worklowPinningResult
@@ -1048,15 +1081,11 @@ func TestUpdatePinningResults(t *testing.T) {
 		{
 			name: "add pinned GitHub-owned action",
 			args: args{
-				dependency: &checker.Dependency{
-					Type: checker.DependencyUseTypeGHAction,
-					Location: &checker.File{
-						Snippet: "actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675",
-					},
-					Pinned: asBoolPointer(true),
-				},
-				w:  &worklowPinningResult{},
-				pr: make(map[checker.DependencyUseType]pinnedResult),
+				dependencyType: checker.DependencyUseTypeGHAction,
+				outcome:        finding.OutcomePositive,
+				snippet:        stringAsPointer("actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675"),
+				w:              &worklowPinningResult{},
+				pr:             make(map[checker.DependencyUseType]pinnedResult),
 			},
 			want: want{
 				w: &worklowPinningResult{
@@ -1075,15 +1104,11 @@ func TestUpdatePinningResults(t *testing.T) {
 		{
 			name: "add unpinned GitHub-owned action",
 			args: args{
-				dependency: &checker.Dependency{
-					Type: checker.DependencyUseTypeGHAction,
-					Location: &checker.File{
-						Snippet: "actions/checkout@v2",
-					},
-					Pinned: asBoolPointer(false),
-				},
-				w:  &worklowPinningResult{},
-				pr: make(map[checker.DependencyUseType]pinnedResult),
+				dependencyType: checker.DependencyUseTypeGHAction,
+				outcome:        finding.OutcomeNegative,
+				snippet:        stringAsPointer("actions/checkout@v2"),
+				w:              &worklowPinningResult{},
+				pr:             make(map[checker.DependencyUseType]pinnedResult),
 			},
 			want: want{
 				w: &worklowPinningResult{
@@ -1102,15 +1127,11 @@ func TestUpdatePinningResults(t *testing.T) {
 		{
 			name: "add pinned Third-party action",
 			args: args{
-				dependency: &checker.Dependency{
-					Type: checker.DependencyUseTypeGHAction,
-					Location: &checker.File{
-						Snippet: "other/checkout@ffa6706ff2127a749973072756f83c532e43ed02",
-					},
-					Pinned: asBoolPointer(true),
-				},
-				w:  &worklowPinningResult{},
-				pr: make(map[checker.DependencyUseType]pinnedResult),
+				dependencyType: checker.DependencyUseTypeGHAction,
+				outcome:        finding.OutcomePositive,
+				w:              &worklowPinningResult{},
+				snippet:        stringAsPointer("other/checkout@ffa6706ff2127a749973072756f83c532e43ed02"),
+				pr:             make(map[checker.DependencyUseType]pinnedResult),
 			},
 			want: want{
 				w: &worklowPinningResult{
@@ -1129,15 +1150,11 @@ func TestUpdatePinningResults(t *testing.T) {
 		{
 			name: "add unpinned Third-party action",
 			args: args{
-				dependency: &checker.Dependency{
-					Type: checker.DependencyUseTypeGHAction,
-					Location: &checker.File{
-						Snippet: "other/checkout@v2",
-					},
-					Pinned: asBoolPointer(false),
-				},
-				w:  &worklowPinningResult{},
-				pr: make(map[checker.DependencyUseType]pinnedResult),
+				dependencyType: checker.DependencyUseTypeGHAction,
+				snippet:        stringAsPointer("other/checkout@v2"),
+				outcome:        finding.OutcomeNegative,
+				w:              &worklowPinningResult{},
+				pr:             make(map[checker.DependencyUseType]pinnedResult),
 			},
 			want: want{
 				w: &worklowPinningResult{
@@ -1156,12 +1173,10 @@ func TestUpdatePinningResults(t *testing.T) {
 		{
 			name: "add pinned pip install",
 			args: args{
-				dependency: &checker.Dependency{
-					Type:   checker.DependencyUseTypePipCommand,
-					Pinned: asBoolPointer(true),
-				},
-				w:  &worklowPinningResult{},
-				pr: make(map[checker.DependencyUseType]pinnedResult),
+				dependencyType: checker.DependencyUseTypePipCommand,
+				outcome:        finding.OutcomePositive,
+				w:              &worklowPinningResult{},
+				pr:             make(map[checker.DependencyUseType]pinnedResult),
 			},
 			want: want{
 				w: &worklowPinningResult{},
@@ -1176,12 +1191,10 @@ func TestUpdatePinningResults(t *testing.T) {
 		{
 			name: "add unpinned pip install",
 			args: args{
-				dependency: &checker.Dependency{
-					Type:   checker.DependencyUseTypePipCommand,
-					Pinned: asBoolPointer(false),
-				},
-				w:  &worklowPinningResult{},
-				pr: make(map[checker.DependencyUseType]pinnedResult),
+				dependencyType: checker.DependencyUseTypePipCommand,
+				outcome:        finding.OutcomeNegative,
+				w:              &worklowPinningResult{},
+				pr:             make(map[checker.DependencyUseType]pinnedResult),
 			},
 			want: want{
 				w: &worklowPinningResult{},
@@ -1198,7 +1211,7 @@ func TestUpdatePinningResults(t *testing.T) {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
-			updatePinningResults(tc.args.dependency, tc.args.w, tc.args.pr)
+			updatePinningResults(tc.args.dependencyType, tc.args.outcome, tc.args.snippet, tc.args.w, tc.args.pr)
 			if tc.want.w.thirdParties != tc.args.w.thirdParties {
 				t.Errorf("updatePinningResults Third-party GitHub actions mismatch (-want +got):"+
 					"\nThird-party pinned: %s\nThird-party total: %s",

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -22,16 +22,8 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/finding"
-	"github.com/ossf/scorecard/v4/rule"
 	scut "github.com/ossf/scorecard/v4/utests"
 )
-
-var testRemediation = &rule.Remediation{
-	Patch:    stringAsPointer("test"),
-	Text:     "test",
-	Markdown: "test markdown",
-	Effort:   rule.RemediationEffortLow,
-}
 
 func Test_createScoreForGitHubActionsWorkflow(t *testing.T) {
 	t.Parallel()
@@ -311,47 +303,40 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDownloadThenRun,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDownloadThenRun,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeGoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeGoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -366,10 +351,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem pinned and 1 ecosystem unpinned",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{},
@@ -389,10 +373,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem partially pinned",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{},
@@ -440,10 +423,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned dependency shows warn message",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -515,10 +497,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned choco install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeChocoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeChocoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -533,10 +514,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned Dockerfile container image",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -551,10 +531,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned download then run",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDownloadThenRun,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDownloadThenRun,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -569,10 +548,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned go install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeGoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeGoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -587,10 +565,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned npm install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -605,10 +582,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned nuget install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNugetCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNugetCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -623,10 +599,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned pip install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -641,16 +616,14 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 1 ecosystem shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -665,16 +638,14 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 2 ecosystems shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeGoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeGoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -756,17 +727,15 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -791,9 +760,8 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -811,9 +779,8 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{
@@ -835,16 +802,14 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "Skipped objects and dependencies",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			processingErrors: []checker.ElementError{


### PR DESCRIPTION
#### What kind of change does this PR introduce?
The goal of this PR is to refactor the Pinned Dependencies evaluation to process findings instead of dependencies. The reason for doing this is to structure the code to resemble how it would look once it gets split into probes without modifying the score. As such, this is an intermediary code change towards migrating the Pinned Dependencies check into probes. Some of the code changes in this PR will be moved into probes in the near future.

My motivation for this PR is to reduce the review overhead. This PR is already substantial, and adding probes would add to that. As such, with this PR I want to refactor the code so it works as-is and make incremental steps towards migrating the check to probes.

The core change of this PR is an added step of converting the dependencies to findings and calculate the score + log from the findings instead of directly from the dependencies. Other code changes are utilities and tests around that core change.

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE

#### Does this PR introduce a user-facing change?
NONE

```release-note

```
