### PR TITLE
:bug: Only consider one organization per user

### DIFF
--- a/probes/contributorsFromOrgOrCompany/impl.go
+++ b/probes/contributorsFromOrgOrCompany/impl.go
@@ -60,12 +60,24 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 			continue
 		}
 
+		hasOrgForUser := false
+
 		for _, org := range user.Organizations {
-			entities[org.Login] = true
+			if _, ok := entities[org.Login]; !ok {
+				entities[org.Login] = true
+				hasOrgForUser = true
+				break
+			}
+		}
+		if hasOrgForUser {
+			continue
 		}
 
 		for _, comp := range user.Companies {
-			entities[comp] = true
+			if _, ok := entities[comp]; !ok {
+				entities[comp] = true
+				break
+			}
 		}
 	}
 

--- a/probes/contributorsFromOrgOrCompany/impl_test.go
+++ b/probes/contributorsFromOrgOrCompany/impl_test.go
@@ -65,8 +65,6 @@ func Test_Run(t *testing.T) {
 			},
 			outcomes: []finding.Outcome{
 				finding.OutcomePositive,
-				finding.OutcomePositive,
-				finding.OutcomePositive,
 			},
 		}, {
 			name: "Test multiple users",
@@ -99,10 +97,6 @@ func Test_Run(t *testing.T) {
 			outcomes: []finding.Outcome{
 				finding.OutcomePositive,
 				finding.OutcomePositive,
-				finding.OutcomePositive,
-				finding.OutcomePositive,
-				finding.OutcomePositive,
-				finding.OutcomePositive,
 			},
 		}, {
 			name: "Test multiple users where one user has insufficient contributions.",
@@ -133,8 +127,6 @@ func Test_Run(t *testing.T) {
 				},
 			},
 			outcomes: []finding.Outcome{
-				finding.OutcomePositive,
-				finding.OutcomePositive,
 				finding.OutcomePositive,
 			},
 		},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR limits the number of organizations Scorecard includes per contributor in a Contributors probe. 

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Currently, the probe considers all organizations of a user.

#### What is the new behavior (if this is a feature change)?**
The probe will maximum consider one organization per user.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
https://github.com/ossf/scorecard/issues/1024

#### Special notes for your reviewer
This changes the scoring of Scorecard, but that is the purpose of the issue that this PR fixed.

#### Does this PR introduce a user-facing change?
NONE


```release-note

```
