### PR TITLE
:bug: Ignore unpinned dependencies in Dockerfiles in vendored directories

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -116,12 +116,6 @@ func fileIsInVendorDir(pathfn string) bool {
 	cleanedPath := filepath.Clean(pathfn)
 	splitCleanedPath := strings.Split(cleanedPath, "/")
 
-	// If the project vendors, this is likely to be how
-	// they do it. Therefore, check the first index
-	// before looping.
-	if splitCleanedPath[0] == "vendor" {
-		return true
-	}
 	for _, d := range splitCleanedPath {
 		if strings.EqualFold(d, "vendor") {
 			return true

--- a/checks/raw/testdata/vendor/Dockerfile-not-pinned-as
+++ b/checks/raw/testdata/vendor/Dockerfile-not-pinned-as
@@ -1,0 +1,32 @@
+
+# Copyright 2021 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+FROM python:3.7@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2 as base
+
+FROM python:3.7 as build
+ARG TARGETOS
+ARG TARGETARCH
+RUN CGO_ENABLED=0 make build-scorecard
+
+# Add spaces
+   FROM build
+RUN /hello-world
+
+FROM base as base2
+RUN ls
+
+FROM base2
+RUN ls
+
+FROM python@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This checks whether Dockerfiles being checked by Pinned Dependencies are in a `vendor` or `third_party` directory.

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**
With this PR, Scorecard will check whether any of the subdirectories that a file exists in is called either `vendor` or `third_party`.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
https://github.com/ossf/scorecard/issues/1095

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
Yes, scores will change, but that is inherited from https://github.com/ossf/scorecard/issues/1095

```release-note
Scorecard no longer considers unpinned Dockerfiles in `vendor` and `third_party` directories.
```
