### PR TITLE
:seedling: update GitLab `CI-Tests` e2e to reflect 30 commits

### DIFF
--- a/e2e/ci_tests_test.go
+++ b/e2e/ci_tests_test.go
@@ -121,13 +121,13 @@ var _ = Describe("E2E TEST:"+checks.CheckCITests, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         8,
+				Score:         6,
 				NumberOfWarn:  0,
 				NumberOfInfo:  0,
-				NumberOfDebug: 13,
+				NumberOfDebug: 22,
 			}
 			result := checks.CITests(&req)
-			Expect(result.Score).Should(BeNumerically("==", expected.Score))
+			Expect(scut.ValidateTestReturn(nil, "CI tests at commit - GitLab", &expected, &result, &dl)).Should(BeTrue())
 			Expect(result.Error).Should(BeNil())
 			Expect(repoClient.Close()).Should(BeNil())
 		})


### PR DESCRIPTION
Follow up test fix from #3672,  which not only fixed the --commit-depth option, but also fixed the default commit depth for GitLab repos. Previously GitLab repos looked back 20 commits because that was GitLab's default for the commits API. Now, GitLab repos look back 30 commits, so the proportions of this e2e test changed.

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
the test was written when 20 commits were analyzed, but #3672 made it so 30 commits are analyzed

#### What is the new behavior (if this is a feature change)?**
e2e test values reflect 30 commits 

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
