### PR TITLE
:seedling: allow repo contributors to call scdiff workflow

### DIFF
--- a/.github/workflows/scdiff.yml
+++ b/.github/workflows/scdiff.yml
@@ -1,7 +1,7 @@
 name: scdiff PR evaluation
 on:
   issue_comment:
-    types: [created, edited]
+    types: [created]
 
 permissions: read-all
 
@@ -61,7 +61,7 @@ jobs:
         uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 # v6.4.1
         with:
           script: |
-            const allowedAssociations = ["COLLABORATOR", "MEMBER", "OWNER"];
+            const allowedAssociations = ["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"];
             authorAssociation = '${{ github.event.comment.author_association }}'
             if (!allowedAssociations.includes(authorAssociation)) {
               core.setFailed("You don't have access to run scdiff");


### PR DESCRIPTION


#### What kind of change does this PR introduce?

workflow fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- The functionality was limited to members, owners, and collaborators, as I had thought that would cover all of the maintainers. But my association for [this comment](https://github.com/ossf/scorecard/pull/3680#issuecomment-1815290915) was as a contributor (can check with the [api response](https://api.github.com/repos/ossf/scorecard/issues/comments/1815290915)). So my attempt to call it [here](https://github.com/ossf/scorecard/actions/runs/6896330152/job/18762213022) failed

```
Error: You don't have access to run scdiff
```

#### What is the new behavior (if this is a feature change)?**
- Repo contributors can call scdiff
- also removes the edited trigger. codecov edits PR comments a few times, which causes this action to trigger 3x. It ends up skipped though since it doesnt have the command in it, but might as well remove it

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
