### PR TITLE
:seedling: make maintained values keys constants

### DIFF
--- a/checks/evaluation/maintained.go
+++ b/checks/evaluation/maintained.go
@@ -67,9 +67,9 @@ func Maintained(name string,
 		if f.Outcome == finding.OutcomePositive {
 			switch f.Probe {
 			case issueActivityByProjectMember.Probe:
-				numberOfIssuesUpdatedWithinThreshold = f.Values["numberOfIssuesUpdatedWithinThreshold"]
+				numberOfIssuesUpdatedWithinThreshold = f.Values[issueActivityByProjectMember.NoOfIssuesValue]
 			case hasRecentCommits.Probe:
-				commitsWithinThreshold = f.Values["commitsWithinThreshold"]
+				commitsWithinThreshold = f.Values[hasRecentCommits.CommitsValue]
 			}
 		}
 	}

--- a/probes/hasRecentCommits/impl.go
+++ b/probes/hasRecentCommits/impl.go
@@ -29,7 +29,9 @@ import (
 var fs embed.FS
 
 const (
-	lookBackDays = 90
+	lookBackDays  = 90
+	CommitsValue  = "commitsWithinThreshold"
+	LookBackValue = "lookBackDays"
 )
 
 const Probe = "hasRecentCommits"
@@ -60,8 +62,8 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 			return nil, Probe, fmt.Errorf("create finding: %w", err)
 		}
 		f = f.WithValues(map[string]int{
-			"commitsWithinThreshold": commitsWithinThreshold,
-			"lookBackDays":           90,
+			CommitsValue:  commitsWithinThreshold,
+			LookBackValue: lookBackDays,
 		})
 		findings = append(findings, *f)
 	} else {

--- a/probes/issueActivityByProjectMember/impl.go
+++ b/probes/issueActivityByProjectMember/impl.go
@@ -30,7 +30,8 @@ import (
 var fs embed.FS
 
 const (
-	lookBackDays = 90
+	lookBackDays    = 90
+	NoOfIssuesValue = "numberOfIssuesUpdatedWithinThreshold"
 )
 
 const Probe = "issueActivityByProjectMember"
@@ -60,7 +61,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 			return nil, Probe, fmt.Errorf("create finding: %w", err)
 		}
 		f = f.WithValues(map[string]int{
-			"numberOfIssuesUpdatedWithinThreshold": numberOfIssuesUpdatedWithinThreshold,
+			NoOfIssuesValue: numberOfIssuesUpdatedWithinThreshold,
 		})
 		findings = append(findings, *f)
 	} else {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Converts the Maintained finding value keys to constants as discussed in https://github.com/ossf/scorecard/issues/3641.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Part of https://github.com/ossf/scorecard/issues/3641

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
NONE

```release-note

```
