### PR TITLE
:seedling: Pinned dependencies: create findings from processing errors

### DIFF
--- a/checks/evaluation/pinned_dependencies.go
+++ b/checks/evaluation/pinned_dependencies.go
@@ -92,10 +92,21 @@ func probeRemToRuleRem(rem *probe.Remediation) *rule.Remediation {
 	}
 }
 
-func dependenciesToFindings(deps []checker.Dependency) ([]finding.Finding, error) {
+func dependenciesToFindings(r *checker.PinningDependenciesData) ([]finding.Finding, error) {
 	findings := make([]finding.Finding, 0)
-	for i := range deps {
-		rr := deps[i]
+
+	for _, e := range r.ProcessingErrors {
+		e := e
+		f := finding.Finding{
+			Message:  generateTextIncompleteResults(e),
+			Location: &e.Location,
+			Outcome:  finding.OutcomeNotAvailable,
+		}
+		findings = append(findings, f)
+	}
+
+	for i := range r.Dependencies {
+		rr := r.Dependencies[i]
 		if rr.Location == nil {
 			if rr.Msg == nil {
 				e := sce.WithMessage(sce.ErrScorecardInternal, "empty File field")
@@ -199,17 +210,7 @@ func PinningDependencies(name string, c *checker.CheckRequest,
 	pr := make(map[checker.DependencyUseType]pinnedResult)
 	dl := c.Dlogger
 
-	for _, e := range r.ProcessingErrors {
-		e := e
-		dl.Info(&checker.LogMessage{
-			Finding: &finding.Finding{
-				Message:  generateTextIncompleteResults(e),
-				Location: &e.Location,
-			},
-		})
-	}
-
-	findings, err := dependenciesToFindings(r.Dependencies)
+	findings, err := dependenciesToFindings(r)
 	if err != nil {
 		return checker.CreateRuntimeErrorResult(name, err)
 	}
@@ -246,6 +247,11 @@ func PinningDependencies(name string, c *checker.CheckRequest,
 				lm.Remediation = probeRemToRuleRem(f.Remediation)
 			}
 			dl.Warn(lm)
+		} else if f.Outcome == finding.OutcomeNotAvailable {
+			dl.Info(&checker.LogMessage{
+				Finding: &f,
+			})
+			continue
 		}
 		updatePinningResults(intToDepType[f.Values["dependencyType"]],
 			f.Outcome, f.Location.Snippet,

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -22,8 +22,16 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/rule"
 	scut "github.com/ossf/scorecard/v4/utests"
 )
+
+var testRemediation = &rule.Remediation{
+	Patch:    stringAsPointer("test"),
+	Text:     "test",
+	Markdown: "test markdown",
+	Effort:   rule.RemediationEffortLow,
+}
 
 func Test_createScoreForGitHubActionsWorkflow(t *testing.T) {
 	t.Parallel()
@@ -303,40 +311,47 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDownloadThenRun,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDownloadThenRun,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeGoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeGoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -351,9 +366,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem pinned and 1 ecosystem unpinned",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{},
@@ -373,9 +389,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem partially pinned",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{},
@@ -423,9 +440,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned dependency shows warn message",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -497,9 +515,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned choco install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeChocoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeChocoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -514,9 +533,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned Dockerfile container image",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -531,9 +551,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned download then run",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeDownloadThenRun,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeDownloadThenRun,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -548,9 +569,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned go install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeGoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeGoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -565,9 +587,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned npm install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -582,9 +605,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned nuget install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNugetCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNugetCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -599,9 +623,10 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned pip install",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -616,14 +641,16 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 1 ecosystem shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -638,14 +665,16 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 2 ecosystems shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypePipCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypePipCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeGoCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeGoCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -727,15 +756,17 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -760,8 +791,9 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			expected: scut.TestReturn{
@@ -779,8 +811,9 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:   checker.DependencyUseTypeGHAction,
-					Pinned: asBoolPointer(false),
+					Type:        checker.DependencyUseTypeGHAction,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
 					Location: &checker.File{
@@ -802,14 +835,16 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "Skipped objects and dependencies",
 			dependencies: []checker.Dependency{
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 				{
-					Location: &checker.File{},
-					Type:     checker.DependencyUseTypeNpmCommand,
-					Pinned:   asBoolPointer(false),
+					Location:    &checker.File{},
+					Type:        checker.DependencyUseTypeNpmCommand,
+					Pinned:      asBoolPointer(false),
+					Remediation: testRemediation,
 				},
 			},
 			processingErrors: []checker.ElementError{

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -22,16 +22,8 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/finding"
-	"github.com/ossf/scorecard/v4/rule"
 	scut "github.com/ossf/scorecard/v4/utests"
 )
-
-var testRemediation = &rule.Remediation{
-	Patch:    stringAsPointer("test"),
-	Text:     "test",
-	Markdown: "test markdown",
-	Effort:   rule.RemediationEffortLow,
-}
 
 func Test_createScoreForGitHubActionsWorkflow(t *testing.T) {
 	t.Parallel()
@@ -311,47 +303,40 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDownloadThenRun,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDownloadThenRun,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeGoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeGoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -366,10 +351,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem pinned and 1 ecosystem unpinned",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{},
@@ -389,10 +373,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "1 ecosystem partially pinned",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{},
@@ -440,10 +423,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned dependency shows warn message",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -515,10 +497,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned choco install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeChocoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeChocoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -533,10 +514,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned Dockerfile container image",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDockerfileContainerImage,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDockerfileContainerImage,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -551,10 +531,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned download then run",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeDownloadThenRun,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeDownloadThenRun,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -569,10 +548,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned go install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeGoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeGoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -587,10 +565,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned npm install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -605,10 +582,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned nuget install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNugetCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNugetCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -623,10 +599,9 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "unpinned pip install",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -641,16 +616,14 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 1 ecosystem shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -665,16 +638,14 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "2 unpinned dependencies for 2 ecosystems shows 2 warn messages",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypePipCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypePipCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeGoCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeGoCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -756,17 +727,15 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -791,9 +760,8 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "other/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 			},
 			expected: scut.TestReturn{
@@ -811,9 +779,8 @@ func Test_PinningDependencies(t *testing.T) {
 					Location: &checker.File{
 						Snippet: "actions/checkout@v2",
 					},
-					Type:        checker.DependencyUseTypeGHAction,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Type:   checker.DependencyUseTypeGHAction,
+					Pinned: asBoolPointer(false),
 				},
 				{
 					Location: &checker.File{
@@ -835,16 +802,14 @@ func Test_PinningDependencies(t *testing.T) {
 			name: "Skipped objects and dependencies",
 			dependencies: []checker.Dependency{
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 				{
-					Location:    &checker.File{},
-					Type:        checker.DependencyUseTypeNpmCommand,
-					Pinned:      asBoolPointer(false),
-					Remediation: testRemediation,
+					Location: &checker.File{},
+					Type:     checker.DependencyUseTypeNpmCommand,
+					Pinned:   asBoolPointer(false),
 				},
 			},
 			processingErrors: []checker.ElementError{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Refactoring
(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Currently processing errors are not converted to findings before evaluation logs them.

#### What is the new behavior (if this is a feature change)?**
Change the pinned dependencies evaluation so that processing errors are converted to findings with `OutcomeNotAvailable` before evaluation logs them.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?
NONE

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
