### PR TITLE
:bug: revert making RequiredPullRequestReviews a pointer

### DIFF
--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -93,7 +93,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &trueVal,
 							Contexts:             []string{"foo"},
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &trueVal,
 							RequireCodeOwnerReviews:      &trueVal,
 							RequiredApprovingReviewCount: &oneVal,
@@ -112,7 +113,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &falseVal,
 							Contexts:             nil,
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &falseVal,
 							RequireCodeOwnerReviews:      &falseVal,
 							RequiredApprovingReviewCount: &zeroVal,
@@ -151,7 +153,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &falseVal,
 							Contexts:             nil,
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &falseVal,
 							RequireCodeOwnerReviews:      &falseVal,
 							RequiredApprovingReviewCount: &zeroVal,
@@ -186,7 +189,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &trueVal,
 							Contexts:             []string{"foo"},
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &trueVal,
 							RequireCodeOwnerReviews:      &trueVal,
 							RequiredApprovingReviewCount: &oneVal,
@@ -207,7 +211,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &falseVal,
 							Contexts:             nil,
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &falseVal,
 							RequireCodeOwnerReviews:      &falseVal,
 							RequiredApprovingReviewCount: &zeroVal,
@@ -242,7 +247,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &trueVal,
 							Contexts:             []string{"foo"},
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &trueVal,
 							RequireCodeOwnerReviews:      &trueVal,
 							RequiredApprovingReviewCount: &oneVal,
@@ -263,7 +269,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &trueVal,
 							Contexts:             []string{"foo"},
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &trueVal,
 							RequireCodeOwnerReviews:      &trueVal,
 							RequiredApprovingReviewCount: &oneVal,
@@ -299,7 +306,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &falseVal,
 							Contexts:             nil,
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &falseVal,
 							RequireCodeOwnerReviews:      &falseVal,
 							RequiredApprovingReviewCount: &zeroVal,
@@ -337,7 +345,8 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 							UpToDateBeforeMerge:  &falseVal,
 							Contexts:             nil,
 						},
-						RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+						RequiredPullRequestReviews: clients.PullRequestReviewRule{
+							Required:                     &trueVal,
 							DismissStaleReviews:          &falseVal,
 							RequireCodeOwnerReviews:      &falseVal,
 							RequiredApprovingReviewCount: &zeroVal,

--- a/checks/evaluation/branch_protection.go
+++ b/checks/evaluation/branch_protection.go
@@ -285,8 +285,7 @@ func nonAdminReviewProtection(branch *clients.BranchRef) (int, int) {
 	// Having at least 1 reviewer is twice as important as the other Tier 2 requirements.
 	const reviewerWeight = 2
 	max += reviewerWeight
-	if branch.BranchProtectionRule.RequiredPullRequestReviews != nil &&
-		branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount != nil &&
+	if branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount != nil &&
 		*branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount > 0 {
 		// We do not display anything here, it's done in nonAdminThoroughReviewProtection()
 		score += reviewerWeight
@@ -329,15 +328,14 @@ func adminReviewProtection(branch *clients.BranchRef, dl checker.DetailLogger) (
 	}
 
 	max++
-	if branch.BranchProtectionRule.RequiredPullRequestReviews != nil {
+	if branch.BranchProtectionRule.RequiredPullRequestReviews.Required != nil &&
+		*branch.BranchProtectionRule.RequiredPullRequestReviews.Required {
 		score++
 		info(dl, log, "PRs are required in order to make changes on branch '%s'", *branch.Name)
 	} else {
 		warn(dl, log, "PRs are not required to make changes on branch '%s'; or we don't have data to detect it."+
 			"If you think it might be the latter, make sure to run Scorecard with a PAT or use Repo "+
 			"Rules (that are always public) instead of Branch Protection settings", *branch.Name)
-		// Warning it here because since `RequiredPullRequestReviews` is nil, we won't check reviewers count afterwards
-		warn(dl, log, "No reviewers required to merge changes on branch '%s'", *branch.Name)
 	}
 
 	return score, max
@@ -349,8 +347,7 @@ func adminThoroughReviewProtection(branch *clients.BranchRef, dl checker.DetailL
 	// Only log information if the branch is protected.
 	log := branch.Protected != nil && *branch.Protected
 
-	if branch.BranchProtectionRule.RequiredPullRequestReviews != nil &&
-		branch.BranchProtectionRule.RequiredPullRequestReviews.DismissStaleReviews != nil {
+	if branch.BranchProtectionRule.RequiredPullRequestReviews.DismissStaleReviews != nil {
 		// Note: we don't increase max possible score for non-admin viewers.
 		max++
 		switch *branch.BranchProtectionRule.RequiredPullRequestReviews.DismissStaleReviews {
@@ -391,18 +388,16 @@ func nonAdminThoroughReviewProtection(branch *clients.BranchRef, dl checker.Deta
 
 	max++
 
-	// On this first check we exclude the case where PRs are not required to make changes,
-	// because it's already covered on adminReviewProtection function.
-	if branch.BranchProtectionRule.RequiredPullRequestReviews != nil &&
-		branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount != nil {
-		if *branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount >= minReviews {
-			info(dl, log, "number of required reviewers is %d on branch '%s'",
-				*branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount, *branch.Name)
-			score++
-		} else {
-			warn(dl, log, "number of required reviewers is %d on branch '%s', while the ideal suggested is %d",
-				*branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount, *branch.Name, minReviews)
-		}
+	var reviewers int32
+	if branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount != nil {
+		reviewers = *(branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount)
+	}
+	if reviewers >= minReviews {
+		info(dl, log, "number of required reviewers is %d on branch '%s'", reviewers, *branch.Name)
+		score++
+	} else {
+		warn(dl, log, "number of required reviewers is %d on branch '%s', while the ideal suggested is %d",
+			reviewers, *branch.Name, minReviews)
 	}
 
 	return score, max
@@ -416,8 +411,7 @@ func codeownerBranchProtection(
 
 	log := branch.Protected != nil && *branch.Protected
 
-	if branch.BranchProtectionRule.RequiredPullRequestReviews != nil &&
-		branch.BranchProtectionRule.RequiredPullRequestReviews.RequireCodeOwnerReviews != nil {
+	if branch.BranchProtectionRule.RequiredPullRequestReviews.RequireCodeOwnerReviews != nil {
 		switch *branch.BranchProtectionRule.RequiredPullRequestReviews.RequireCodeOwnerReviews {
 		case true:
 			info(dl, log, "codeowner review is required on branch '%s'", *branch.Name)

--- a/checks/evaluation/branch_protection.go
+++ b/checks/evaluation/branch_protection.go
@@ -285,8 +285,7 @@ func nonAdminReviewProtection(branch *clients.BranchRef) (int, int) {
 	// Having at least 1 reviewer is twice as important as the other Tier 2 requirements.
 	const reviewerWeight = 2
 	max += reviewerWeight
-	if branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount != nil &&
-		*branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount > 0 {
+	if valueOrZero(branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount) > 0 {
 		// We do not display anything here, it's done in nonAdminThoroughReviewProtection()
 		score += reviewerWeight
 	}
@@ -328,8 +327,7 @@ func adminReviewProtection(branch *clients.BranchRef, dl checker.DetailLogger) (
 	}
 
 	max++
-	if branch.BranchProtectionRule.RequiredPullRequestReviews.Required != nil &&
-		*branch.BranchProtectionRule.RequiredPullRequestReviews.Required {
+	if valueOrZero(branch.BranchProtectionRule.RequiredPullRequestReviews.Required) {
 		score++
 		info(dl, log, "PRs are required in order to make changes on branch '%s'", *branch.Name)
 	} else {
@@ -388,10 +386,7 @@ func nonAdminThoroughReviewProtection(branch *clients.BranchRef, dl checker.Deta
 
 	max++
 
-	var reviewers int32
-	if branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount != nil {
-		reviewers = *(branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount)
-	}
+	reviewers := valueOrZero(branch.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount)
 	if reviewers >= minReviews {
 		info(dl, log, "number of required reviewers is %d on branch '%s'", reviewers, *branch.Name)
 		score++
@@ -426,4 +421,13 @@ func codeownerBranchProtection(
 	}
 
 	return score, max
+}
+
+// returns the pointer's value if it exists, the type's zero-value otherwise.
+func valueOrZero[T any](ptr *T) T {
+	if ptr == nil {
+		var zero T
+		return zero
+	}
+	return *ptr
 }

--- a/checks/evaluation/branch_protection_test.go
+++ b/checks/evaluation/branch_protection_test.go
@@ -50,7 +50,7 @@ func TestIsBranchProtected(t *testing.T) {
 		expected        scut.TestReturn
 	}{
 		{
-			name: "Configs as they are right after creating new Branch Protection setting",
+			name: "GitHub default settings",
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         3,
@@ -62,12 +62,14 @@ func TestIsBranchProtected(t *testing.T) {
 				Name:      &branchVal,
 				Protected: &trueVal,
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &falseVal,
-					AllowForcePushes:           &falseVal,
-					RequireLinearHistory:       &falseVal,
-					EnforceAdmins:              &falseVal,
-					RequireLastPushApproval:    &falseVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:          &falseVal,
+					AllowForcePushes:        &falseVal,
+					RequireLinearHistory:    &falseVal,
+					EnforceAdmins:           &falseVal,
+					RequireLastPushApproval: &falseVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 					CheckRules: clients.StatusChecksRule{
 						RequiresStatusChecks: &trueVal,
 						Contexts:             nil,
@@ -103,7 +105,8 @@ func TestIsBranchProtected(t *testing.T) {
 				Name:      &branchVal,
 				Protected: &trueVal,
 				BranchProtectionRule: clients.BranchProtectionRule{
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &falseVal,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &zeroVal,
@@ -139,7 +142,8 @@ func TestIsBranchProtected(t *testing.T) {
 					RequireLinearHistory:    &falseVal,
 					AllowForcePushes:        &falseVal,
 					AllowDeletions:          &falseVal,
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &falseVal,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &zeroVal,
@@ -175,7 +179,9 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &falseVal,
 						Contexts:             nil,
 					},
-					RequiredPullRequestReviews: nil,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -202,7 +208,9 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &trueVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: nil,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -229,7 +237,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &trueVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &trueVal,
 						RequireCodeOwnerReviews:      &trueVal,
 						RequiredApprovingReviewCount: &zeroVal,
@@ -260,7 +269,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &trueVal,
 						Contexts:             nil,
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &falseVal,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &oneVal,
@@ -291,7 +301,6 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  nil,
 						Contexts:             nil,
 					},
-					RequiredPullRequestReviews: nil,
 				},
 			},
 		},
@@ -318,7 +327,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  nil,
 						Contexts:             nil,
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          nil,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &oneVal,
@@ -349,7 +359,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &falseVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &falseVal,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &zeroVal,
@@ -380,7 +391,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &falseVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &falseVal,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &zeroVal,
@@ -412,7 +424,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &falseVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &falseVal,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &zeroVal,
@@ -443,7 +456,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &falseVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &falseVal,
 						RequireCodeOwnerReviews:      &falseVal,
 						RequiredApprovingReviewCount: &zeroVal,
@@ -474,7 +488,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &trueVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &trueVal,
 						RequireCodeOwnerReviews:      &trueVal,
 						RequiredApprovingReviewCount: &oneVal,
@@ -505,7 +520,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &trueVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &trueVal,
 						RequireCodeOwnerReviews:      &trueVal,
 						RequiredApprovingReviewCount: &oneVal,
@@ -537,7 +553,8 @@ func TestIsBranchProtected(t *testing.T) {
 						UpToDateBeforeMerge:  &trueVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &trueVal,
 						RequireCodeOwnerReviews:      &trueVal,
 						RequiredApprovingReviewCount: &oneVal,

--- a/clients/branch.go
+++ b/clients/branch.go
@@ -23,11 +23,7 @@ type BranchRef struct {
 
 // BranchProtectionRule captures the settings enabled on a branch for security.
 type BranchProtectionRule struct {
-	// The nil value of this struct can mean either:
-	// 1. we can't tell if PRs are required to make changes; or
-	// 2. we know PRs are not required. The first case happens when Scorecard is run without admin token on
-	// a repo that uses the old Branch Protection setting (not the new Repo Rules, that are always public).
-	RequiredPullRequestReviews *PullRequestReviewRule
+	RequiredPullRequestReviews PullRequestReviewRule
 	AllowDeletions             *bool
 	AllowForcePushes           *bool
 	RequireLinearHistory       *bool
@@ -45,6 +41,7 @@ type StatusChecksRule struct {
 
 // PullRequestReviewRule captures settings on a PullRequest.
 type PullRequestReviewRule struct {
+	Required                     *bool // are PRs required
 	RequiredApprovingReviewCount *int32
 	DismissStaleReviews          *bool
 	RequireCodeOwnerReviews      *bool

--- a/clients/githubrepo/branches.go
+++ b/clients/githubrepo/branches.go
@@ -364,9 +364,9 @@ func copyNonAdminSettings(src interface{}, dst *clients.BranchProtectionRule) {
 
 		// we always have the data to know if PRs are required
 		if dst.RequiredPullRequestReviews.Required == nil {
-			dst.RequiredPullRequestReviews.Required = new(bool)
+			dst.RequiredPullRequestReviews.Required = asPtr(false)
 		}
-		// RequiredApprovingReviewCount is nil if PRs aren't required, or &num if PRs are required (including &0)
+		// GitHub returns nil for RequiredApprovingReviewCount when PRs aren't required and non-nil when they are
 		// RequiresCodeOwnerReviews is &false even if PRs aren't required, so we need it to be true
 		if v.RequiredApprovingReviewCount != nil || valueOrZero(v.RequiresCodeOwnerReviews) {
 			dst.RequiredPullRequestReviews.Required = asPtr(true)

--- a/clients/githubrepo/branches_test.go
+++ b/clients/githubrepo/branches_test.go
@@ -206,10 +206,12 @@ func Test_applyRepoRules(t *testing.T) {
 						RequiresStatusChecks: nil,
 						Contexts:             nil,
 					},
-					EnforceAdmins:              &trueVal,
-					RequireLastPushApproval:    nil, // this checkbox is enabled only if require status checks
-					RequireLinearHistory:       &falseVal,
-					RequiredPullRequestReviews: nil,
+					EnforceAdmins:           &trueVal,
+					RequireLastPushApproval: nil, // this checkbox is enabled only if require status checks
+					RequireLinearHistory:    &falseVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -221,11 +223,13 @@ func Test_applyRepoRules(t *testing.T) {
 			},
 			expected: &clients.BranchRef{
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &falseVal,
-					AllowForcePushes:           &trueVal,
-					RequireLinearHistory:       &falseVal,
-					EnforceAdmins:              &trueVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:       &falseVal,
+					AllowForcePushes:     &trueVal,
+					RequireLinearHistory: &falseVal,
+					EnforceAdmins:        &trueVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -237,11 +241,13 @@ func Test_applyRepoRules(t *testing.T) {
 			},
 			expected: &clients.BranchRef{
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &falseVal,
-					AllowForcePushes:           &trueVal,
-					RequireLinearHistory:       &falseVal,
-					EnforceAdmins:              &falseVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:       &falseVal,
+					AllowForcePushes:     &trueVal,
+					RequireLinearHistory: &falseVal,
+					EnforceAdmins:        &falseVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -258,11 +264,13 @@ func Test_applyRepoRules(t *testing.T) {
 			},
 			expected: &clients.BranchRef{
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &falseVal,
-					AllowForcePushes:           &falseVal,
-					EnforceAdmins:              &falseVal, // Downgrade: deletion does not enforce admins
-					RequireLinearHistory:       &falseVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:       &falseVal,
+					AllowForcePushes:     &falseVal,
+					EnforceAdmins:        &falseVal, // Downgrade: deletion does not enforce admins
+					RequireLinearHistory: &falseVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -280,11 +288,13 @@ func Test_applyRepoRules(t *testing.T) {
 			},
 			expected: &clients.BranchRef{
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &falseVal,
-					AllowForcePushes:           &falseVal,
-					EnforceAdmins:              &falseVal, // Maintain: deletion enforces but forcepush does not
-					RequireLinearHistory:       &falseVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:       &falseVal,
+					AllowForcePushes:     &falseVal,
+					EnforceAdmins:        &falseVal, // Maintain: deletion enforces but forcepush does not
+					RequireLinearHistory: &falseVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -301,11 +311,13 @@ func Test_applyRepoRules(t *testing.T) {
 			},
 			expected: &clients.BranchRef{
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &falseVal,
-					AllowForcePushes:           &falseVal,
-					EnforceAdmins:              &trueVal, // Maintain: base and rule are equal strictness
-					RequireLinearHistory:       &falseVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:       &falseVal,
+					AllowForcePushes:     &falseVal,
+					EnforceAdmins:        &trueVal, // Maintain: base and rule are equal strictness
+					RequireLinearHistory: &falseVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -317,11 +329,13 @@ func Test_applyRepoRules(t *testing.T) {
 			},
 			expected: &clients.BranchRef{
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &trueVal,
-					AllowForcePushes:           &falseVal,
-					EnforceAdmins:              &trueVal,
-					RequireLinearHistory:       &falseVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:       &trueVal,
+					AllowForcePushes:     &falseVal,
+					EnforceAdmins:        &trueVal,
+					RequireLinearHistory: &falseVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -333,11 +347,13 @@ func Test_applyRepoRules(t *testing.T) {
 			},
 			expected: &clients.BranchRef{
 				BranchProtectionRule: clients.BranchProtectionRule{
-					AllowDeletions:             &trueVal,
-					AllowForcePushes:           &trueVal,
-					RequireLinearHistory:       &trueVal,
-					EnforceAdmins:              &trueVal,
-					RequiredPullRequestReviews: nil,
+					AllowDeletions:       &trueVal,
+					AllowForcePushes:     &trueVal,
+					RequireLinearHistory: &trueVal,
+					EnforceAdmins:        &trueVal,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -362,7 +378,8 @@ func Test_applyRepoRules(t *testing.T) {
 					EnforceAdmins:           &trueVal,
 					RequireLastPushApproval: &trueVal,
 					RequireLinearHistory:    &falseVal,
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						RequiredApprovingReviewCount: &zeroVal,
 					},
 				},
@@ -392,7 +409,8 @@ func Test_applyRepoRules(t *testing.T) {
 					EnforceAdmins:           &trueVal,
 					RequireLinearHistory:    &falseVal,
 					RequireLastPushApproval: &trueVal,
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						DismissStaleReviews:          &trueVal,
 						RequireCodeOwnerReviews:      &trueVal,
 						RequiredApprovingReviewCount: &twoVal,
@@ -429,7 +447,9 @@ func Test_applyRepoRules(t *testing.T) {
 						RequiresStatusChecks: &trueVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: nil,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required: &falseVal,
+					},
 				},
 			},
 		},
@@ -495,7 +515,8 @@ func Test_applyRepoRules(t *testing.T) {
 						RequiresStatusChecks: &trueVal,
 						Contexts:             []string{"foo"},
 					},
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &trueVal,
 						RequiredApprovingReviewCount: &twoVal,
 						DismissStaleReviews:          &trueVal,
 						RequireCodeOwnerReviews:      &trueVal,
@@ -556,7 +577,10 @@ func Test_translationFromGithubAPIBranchProtectionData(t *testing.T) {
 						RequiresStatusChecks: nil,
 						Contexts:             []string{},
 					},
-					RequiredPullRequestReviews: nil,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						RequiredApprovingReviewCount: asPtr[int32](0),
+						RequireCodeOwnerReviews:      &falseVal,
+					},
 				},
 			},
 		},
@@ -591,7 +615,12 @@ func Test_translationFromGithubAPIBranchProtectionData(t *testing.T) {
 						RequiresStatusChecks: &falseVal,
 						Contexts:             []string{},
 					},
-					RequiredPullRequestReviews: nil,
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     &falseVal,
+						RequireCodeOwnerReviews:      &falseVal,
+						DismissStaleReviews:          &falseVal,
+						RequiredApprovingReviewCount: nil,
+					},
 				},
 			},
 		},

--- a/clients/gitlabrepo/branches.go
+++ b/clients/gitlabrepo/branches.go
@@ -193,7 +193,8 @@ func makeBranchRefFrom(branch *gitlab.Branch, protectedBranch *gitlab.ProtectedB
 		Contexts:             makeContextsFromResp(projectStatusChecks),
 	}
 
-	pullRequestReviewRule := &clients.PullRequestReviewRule{
+	pullRequestReviewRule := clients.PullRequestReviewRule{
+		// TODO how do we know if they're required?
 		DismissStaleReviews:     newTrue(),
 		RequireCodeOwnerReviews: &protectedBranch.CodeOwnerApprovalRequired,
 	}

--- a/cron/internal/format/json_raw_results.go
+++ b/cron/internal/format/json_raw_results.go
@@ -210,16 +210,14 @@ func addBranchProtectionRawResults(r *jsonScorecardRawResult, bp *checker.Branch
 			bp = &jsonBranchProtectionSettings{
 				AllowsDeletions:                     v.BranchProtectionRule.AllowDeletions,
 				AllowsForcePushes:                   v.BranchProtectionRule.AllowForcePushes,
+				RequiresCodeOwnerReviews:            v.BranchProtectionRule.RequiredPullRequestReviews.RequireCodeOwnerReviews,
 				RequiresLinearHistory:               v.BranchProtectionRule.RequireLinearHistory,
+				DismissesStaleReviews:               v.BranchProtectionRule.RequiredPullRequestReviews.DismissStaleReviews,
 				EnforcesAdmins:                      v.BranchProtectionRule.EnforceAdmins,
 				RequiresStatusChecks:                v.BranchProtectionRule.CheckRules.RequiresStatusChecks,
 				RequiresUpToDateBranchBeforeMerging: v.BranchProtectionRule.CheckRules.UpToDateBeforeMerge,
+				RequiredApprovingReviewCount:        v.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount,
 				StatusCheckContexts:                 v.BranchProtectionRule.CheckRules.Contexts,
-			}
-			if v.BranchProtectionRule.RequiredPullRequestReviews != nil {
-				bp.DismissesStaleReviews = v.BranchProtectionRule.RequiredPullRequestReviews.DismissStaleReviews
-				bp.RequiredApprovingReviewCount = v.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount
-				bp.RequiresCodeOwnerReviews = v.BranchProtectionRule.RequiredPullRequestReviews.RequireCodeOwnerReviews
 			}
 		}
 		r.Results.BranchProtections = append(r.Results.BranchProtections, jsonBranchProtection{

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -712,16 +712,14 @@ func (r *jsonScorecardRawResult) addBranchProtectionRawResults(bp *checker.Branc
 			bp = &jsonBranchProtectionSettings{
 				AllowsDeletions:                     v.BranchProtectionRule.AllowDeletions,
 				AllowsForcePushes:                   v.BranchProtectionRule.AllowForcePushes,
+				RequiresCodeOwnerReviews:            v.BranchProtectionRule.RequiredPullRequestReviews.RequireCodeOwnerReviews,
 				RequiresLinearHistory:               v.BranchProtectionRule.RequireLinearHistory,
+				DismissesStaleReviews:               v.BranchProtectionRule.RequiredPullRequestReviews.DismissStaleReviews,
 				EnforcesAdmins:                      v.BranchProtectionRule.EnforceAdmins,
 				RequiresStatusChecks:                v.BranchProtectionRule.CheckRules.RequiresStatusChecks,
 				RequiresUpToDateBranchBeforeMerging: v.BranchProtectionRule.CheckRules.UpToDateBeforeMerge,
+				RequiredApprovingReviewCount:        v.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount,
 				StatusCheckContexts:                 v.BranchProtectionRule.CheckRules.Contexts,
-			}
-			if v.BranchProtectionRule.RequiredPullRequestReviews != nil {
-				bp.DismissesStaleReviews = v.BranchProtectionRule.RequiredPullRequestReviews.DismissStaleReviews
-				bp.RequiredApprovingReviewCount = v.BranchProtectionRule.RequiredPullRequestReviews.RequiredApprovingReviewCount
-				bp.RequiresCodeOwnerReviews = v.BranchProtectionRule.RequiredPullRequestReviews.RequireCodeOwnerReviews
 			}
 		}
 		branches = append(branches, jsonBranchProtection{

--- a/pkg/json_raw_results_test.go
+++ b/pkg/json_raw_results_test.go
@@ -1114,7 +1114,8 @@ func TestJsonScorecardRawResult(t *testing.T) {
 				BranchProtectionRule: clients.BranchProtectionRule{
 					AllowDeletions:   boolPtr(true),
 					AllowForcePushes: boolPtr(false),
-					RequiredPullRequestReviews: &clients.PullRequestReviewRule{
+					RequiredPullRequestReviews: clients.PullRequestReviewRule{
+						Required:                     boolPtr(true),
 						RequireCodeOwnerReviews:      boolPtr(true),
 						DismissStaleReviews:          boolPtr(true),
 						RequiredApprovingReviewCount: intPtr(2),


### PR DESCRIPTION
While the current approach works with the tiered scoring, it wont work for probes or if we remove tiers. Making the struct nil to signal that PRs aren't required hides some of the data we do have.

This is especially problematic for repo rules, where we can infer all settings by what we see or don't see.

#### What kind of change does this PR introduce?

bug fix, followup of #3499

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
`RequiredPullRequestReviews` is a pointer

#### What is the new behavior (if this is a feature change)?**
`RequiredPullRequestReviews` is a struct again
there's a new field `Required *bool` to measure if the PRs are required

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

The most important changes are in `clients/githubrepo/branches.go`:
1. For admin tokens, Required is assumed to be `&false`, unless we have data otherwise.
2. For non admin tokens, Required is left nil, unless we have data otherwise.
3. For repo rules, Required is assumed to be `&false`, unless we have data otherwise.


In tests anything that had a non-nil `RequiredPullRequestReviews` was saying PRs were required:
```go
RequiredPullRequestReviews: &clients.PullRequestReviewRule{
```

Which is now represented by:
```go
RequiredPullRequestReviews: clients.PullRequestReviewRule{
	Required:                     &trueVal,
```

similarly, anything which was:
```go
RequiredPullRequestReviews: nil,
```

is now:
```go
RequiredPullRequestReviews: clients.PullRequestReviewRule{
	Required: &falseVal,
```

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
