### PR TITLE
🌱  differentiate between refs and sha gitab

### DIFF
--- a/clients/gitlabrepo/checkruns.go
+++ b/clients/gitlabrepo/checkruns.go
@@ -23,6 +23,8 @@ import (
 	"github.com/ossf/scorecard/v4/clients"
 )
 
+var gitCommitHashRegex = regexp.MustCompile(`^[a-fA-F0-9]{40}$`)
+
 type checkrunsHandler struct {
 	glClient *gitlab.Client
 	repourl  *repoURL
@@ -33,13 +35,10 @@ func (handler *checkrunsHandler) init(repourl *repoURL) {
 }
 
 func (handler *checkrunsHandler) listCheckRunsForRef(ref string) ([]clients.CheckRun, error) {
-	commit := regexp.MustCompile("^[a-f0-9]{40}$")
-	options := gitlab.ListProjectPipelinesOptions{
-		ListOptions: gitlab.ListOptions{},
-	}
+	var options gitlab.ListProjectPipelinesOptions
 
 	// In Gitlab: ref refers to a branch or tag name, and sha refers to commit sha
-	if commit.MatchString(ref) {
+	if gitCommitHashRegex.MatchString(ref) {
 		options.SHA = &ref
 	} else {
 		options.Ref = &ref

--- a/clients/gitlabrepo/checkruns.go
+++ b/clients/gitlabrepo/checkruns.go
@@ -44,8 +44,7 @@ func (handler *checkrunsHandler) listCheckRunsForRef(ref string) ([]clients.Chec
 		options.Ref = &ref
 	}
 
-	pipelines, _, err := handler.glClient.Pipelines.ListProjectPipelines(
-		handler.repourl.projectID, &options)
+	pipelines, _, err := handler.glClient.Pipelines.ListProjectPipelines(handler.repourl.projectID, &options)
 	if err != nil {
 		return nil, fmt.Errorf("request for pipelines returned error: %w", err)
 	}

--- a/clients/gitlabrepo/checkruns.go
+++ b/clients/gitlabrepo/checkruns.go
@@ -37,13 +37,16 @@ func (handler *checkrunsHandler) init(repourl *repoURL) {
 func (handler *checkrunsHandler) listCheckRunsForRef(ref string) ([]clients.CheckRun, error) {
 	var options gitlab.ListProjectPipelinesOptions
 
-	// In Gitlab: ref refers to a branch or tag name, and sha refers to commit sha
 	if gitCommitHashRegex.MatchString(ref) {
 		options.SHA = &ref
 	} else {
 		options.Ref = &ref
 	}
 
+	// Notes for Gitlab ListProjectPipelines endpoint:
+	// Only full SHA works for SHA param, Short SHA does not work
+	// Branch names work for Ref Param, tags and SHAs do not work
+	// Reference: https://docs.gitlab.com/ee/api/pipelines.html#list-project-pipelines
 	pipelines, _, err := handler.glClient.Pipelines.ListProjectPipelines(handler.repourl.projectID, &options)
 	if err != nil {
 		return nil, fmt.Errorf("request for pipelines returned error: %w", err)

--- a/clients/gitlabrepo/checkruns_test.go
+++ b/clients/gitlabrepo/checkruns_test.go
@@ -29,12 +29,14 @@ func Test_CheckRuns(t *testing.T) {
 	tests := []struct {
 		name         string
 		responsePath string
+		ref          string
 		want         []clients.CheckRun
 		wantErr      bool
 	}{
 		{
 			name:         "valid checkruns",
 			responsePath: "./testdata/valid-checkruns",
+			ref:          "main",
 			want: []clients.CheckRun{
 				{
 					Status:     "queued",
@@ -47,11 +49,13 @@ func Test_CheckRuns(t *testing.T) {
 		{
 			name:         "valid checkruns with zero results",
 			responsePath: "./testdata/valid-checkruns-1",
+			ref:          "eb94b618fb5865b26e80fdd8ae531b7a63ad851a",
 			wantErr:      false,
 		},
 		{
 			name:         "failure fetching the checkruns",
 			responsePath: "./testdata/invalid-checkruns-result",
+			ref:          "main",
 			wantErr:      true,
 		},
 	}
@@ -77,7 +81,7 @@ func Test_CheckRuns(t *testing.T) {
 				commitSHA: clients.HeadSHA,
 			}
 			handler.init(&repoURL)
-			got, err := handler.listCheckRunsForRef("main")
+			got, err := handler.listCheckRunsForRef(tt.ref)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("checkRuns error: %v, wantedErr: %t", err, tt.wantErr)
 			}


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Adds a check to `listCheckRunsForRef` in the Gitlab Handler to differentiate between shas and branches/tags and makes appropriate changes to the gitlab api call based on that check. 

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`listCheckRunsForRef` in the GItlab Handler takes in a `ref` string, but assumes that the ref is a sha when making the gitlab api call. Gitlab API sometimes handles refs as a branch or tag name, while sha refers to a commit hash. If in the future we passed in a branch or tag to `listCheckRunsForRef` the API would fail since we would handle it as a sha. 

#### What is the new behavior (if this is a feature change)?**

Added a check to compare the passed in `ref` string against a regex matching a SHA value. If there is a match we handle the ref as a SHA, otherwise we handle it as a ref (branch/tag)

- [x] Tests for the changes have been updated

#### Which issue(s) this PR fixes

Fixes #3395 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
