### PR TITLE
:seedling: fix rangeValCopy linter issues

### DIFF
--- a/cron/internal/format/json_raw_results.go
+++ b/cron/internal/format/json_raw_results.go
@@ -201,9 +201,9 @@ func addDependencyUpdateToolRawResults(r *jsonScorecardRawResult,
 	return nil
 }
 
-//nolint:unparam
 func addBranchProtectionRawResults(r *jsonScorecardRawResult, bp *checker.BranchProtectionsData) error {
 	r.Results.BranchProtections = []jsonBranchProtection{}
+	//nolint:gocritic
 	for _, v := range bp.Branches {
 		var bp *jsonBranchProtectionSettings
 		if v.Protected != nil && *v.Protected {

--- a/pkg/json_raw_results.go
+++ b/pkg/json_raw_results.go
@@ -703,9 +703,9 @@ func (r *jsonScorecardRawResult) addDependencyUpdateToolRawResults(dut *checker.
 	return nil
 }
 
-//nolint:unparam
 func (r *jsonScorecardRawResult) addBranchProtectionRawResults(bp *checker.BranchProtectionsData) error {
 	branches := []jsonBranchProtection{}
+	//nolint:gocritic
 	for _, v := range bp.Branches {
 		var bp *jsonBranchProtectionSettings
 		if v.Protected != nil && *v.Protected {

--- a/pkg/json_test.go
+++ b/pkg/json_test.go
@@ -74,11 +74,11 @@ func TestJSONOutput(t *testing.T) {
 	scorecardCommit := "ccbc59901773ab4c051dfcea0cc4201a1567abdd"
 	scorecardVersion := "1.2.3"
 	repoName := "org/name"
-	date, e := time.Parse(time.RFC3339, "2023-03-02T10:30:43-06:00")
-	t.Logf("date: %v", date)
-	if e != nil {
-		panic(fmt.Errorf("time.Parse: %w", e))
+	date, err := time.Parse(time.RFC3339, "2023-03-02T10:30:43-06:00")
+	if err != nil {
+		t.Fatalf("time.Parse: %v", err)
 	}
+	t.Logf("date: %v", date)
 
 	checkDocs := jsonMockDocRead()
 

--- a/pkg/scorecard_result_test.go
+++ b/pkg/scorecard_result_test.go
@@ -17,7 +17,6 @@ package pkg
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"os"
 	"testing"
 	"time"
@@ -33,11 +32,11 @@ import (
 func mockScorecardResultCheck1(t *testing.T) *ScorecardResult {
 	t.Helper()
 	// Helper variables to mock Scorecard results
-	date, e := time.Parse(time.RFC3339, "2023-03-02T10:30:43-06:00")
-	t.Logf("date: %v", date)
-	if e != nil {
-		panic(fmt.Errorf("time.Parse: %w", e))
+	date, err := time.Parse(time.RFC3339, "2023-03-02T10:30:43-06:00")
+	if err != nil {
+		t.Fatalf("time.Parse: %v", err)
 	}
+	t.Logf("date: %v", date)
 
 	return &ScorecardResult{
 		Repo: RepoInfo{


### PR DESCRIPTION
Adding the Required field to PullRequestReviewRule in #3728  made BranchRef slightly too big (>128 bytes) for the linter's `rangeValCopy` rule. This code isn't highly used, so just ignoring any potential inefficiency.

Not sure why the `staticcheck` linter started complaining about the date error checking, but fixed it while I was here.

#### What kind of change does this PR introduce?

linter fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
