### PR TITLE
🌱 Add SAST Pysa probe

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -259,6 +259,8 @@ const (
 	SonarWorkflow SASTWorkflowType = "Sonar"
 	// SnykWorkflow represents a workflow that runs Snyk.
 	SnykWorkflow SASTWorkflowType = "Snyk"
+	// PysaWorkflow represents a workflow that runs Pysa.
+	PysaWorkflow SASTWorkflowType = "Pysa"
 )
 
 // SASTWorkflow represents a SAST workflow.

--- a/checks/evaluation/sast_test.go
+++ b/checks/evaluation/sast_test.go
@@ -54,7 +54,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: "Sonar and codeQL is installed",
+			name: "Sonar and codeQL is installed. Snyk and Pysa are not installed.",
 			findings: []finding.Finding{
 				{
 					Probe:   "sastToolCodeQLInstalled",
@@ -62,6 +62,10 @@ func TestSAST(t *testing.T) {
 				},
 				{
 					Probe:   "sastToolSnykInstalled",
+					Outcome: finding.OutcomeNegative,
+				},
+				{
+					Probe:   "sastToolPysaInstalled",
 					Outcome: finding.OutcomeNegative,
 				},
 				{
@@ -91,7 +95,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: `Sonar is installed. CodeQL is not installed.
+			name: `Sonar is installed. CodeQL, Snyk, Pysa are not installed.
 					Does not have info about whether SAST runs
 					on every commit.`,
 			findings: []finding.Finding{
@@ -101,6 +105,10 @@ func TestSAST(t *testing.T) {
 				},
 				{
 					Probe:   "sastToolSnykInstalled",
+					Outcome: finding.OutcomeNegative,
+				},
+				{
+					Probe:   "sastToolPysaInstalled",
 					Outcome: finding.OutcomeNegative,
 				},
 				{
@@ -126,7 +134,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: "Sonar and CodeQL are not installed",
+			name: "Sonar, CodeQL, Snyk and Pysa are not installed",
 			findings: []finding.Finding{
 				{
 					Probe:   "sastToolCodeQLInstalled",
@@ -134,6 +142,10 @@ func TestSAST(t *testing.T) {
 				},
 				{
 					Probe:   "sastToolSnykInstalled",
+					Outcome: finding.OutcomeNegative,
+				},
+				{
+					Probe:   "sastToolPysaInstalled",
 					Outcome: finding.OutcomeNegative,
 				},
 				{
@@ -176,6 +188,10 @@ func TestSAST(t *testing.T) {
 				},
 				{
 					Probe:   "sastToolSonarInstalled",
+					Outcome: finding.OutcomeNegative,
+				},
+				{
+					Probe:   "sastToolPysaInstalled",
 					Outcome: finding.OutcomeNegative,
 				},
 			},

--- a/checks/raw/sast_test.go
+++ b/checks/raw/sast_test.go
@@ -149,6 +149,29 @@ func TestSAST(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "Has Pysa",
+			files: []string{".github/workflows/github-pysa-workflow.yaml"},
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number: 1,
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Workflows: []checker.SASTWorkflow{
+					{
+						Type: checker.PysaWorkflow,
+						File: checker.File{
+							Path:   ".github/workflows/github-pysa-workflow.yaml",
+							Offset: checker.OffsetDefault,
+							Type:   finding.FileTypeSource,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below

--- a/checks/raw/testdata/.github/workflows/github-pysa-workflow.yaml
+++ b/checks/raw/testdata/.github/workflows/github-pysa-workflow.yaml
@@ -1,0 +1,22 @@
+name: Pysa Scan
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+name: Pysa
+
+jobs:
+  pysa:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Run Pysa Action
+        uses: facebook/pysa-action
+        with:
+          repo-directory: './'
+          requirements-path: 'requirements.txt'
+          infer-types: true

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ossf/scorecard/v4/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v4/probes/releasesHaveProvenance"
 	"github.com/ossf/scorecard/v4/probes/sastToolCodeQLInstalled"
+	"github.com/ossf/scorecard/v4/probes/sastToolPysaInstalled"
 	"github.com/ossf/scorecard/v4/probes/sastToolRunsOnAllCommits"
 	"github.com/ossf/scorecard/v4/probes/sastToolSnykInstalled"
 	"github.com/ossf/scorecard/v4/probes/sastToolSonarInstalled"
@@ -113,6 +114,7 @@ var (
 	}
 	SAST = []ProbeImpl{
 		sastToolCodeQLInstalled.Run,
+		sastToolPysaInstalled.Run,
 		sastToolSnykInstalled.Run,
 		sastToolRunsOnAllCommits.Run,
 		sastToolSonarInstalled.Run,

--- a/probes/sastToolPysaInstalled/def.yml
+++ b/probes/sastToolPysaInstalled/def.yml
@@ -1,0 +1,29 @@
+# Copyright 2023 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: sastToolPysaInstalled
+short: Check that the project uses the Pysa github action
+motivation: >
+  SAST is testing run on source code before the application is run. Using SAST tools can prevent known classes of bugs from being inadvertently introduced in the codebase.
+implementation: >
+  The implementation checks whether the project invokes the facebook/pysa-action action.
+outcome:
+  - If the project uses the facebook/pysa-action action, the probe returns one finding with OutcomePositive (1).
+  - If the project does not use the facebook/pysa-action action, the probe returns one finding with OutcomeNegative (0).
+remediation:
+  effort: Medium
+  text:
+    - Follow the steps in https://github.com/facebook/pysa-action
+  markdown:
+    - Follow the steps in https://github.com/facebook/pysa-action

--- a/probes/sastToolPysaInstalled/impl.go
+++ b/probes/sastToolPysaInstalled/impl.go
@@ -1,0 +1,60 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:stylecheck
+package sastToolPysaInstalled
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
+)
+
+//go:embed *.yml
+var fs embed.FS
+
+const Probe = "sastToolPysaInstalled"
+
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	if raw == nil {
+		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
+	}
+
+	r := raw.SASTResults
+
+	for _, wf := range r.Workflows {
+		if wf.Type == checker.PysaWorkflow {
+			f, err := finding.NewWith(fs, Probe,
+				"SAST tool installed: Pysa", nil,
+				finding.OutcomePositive)
+			if err != nil {
+				return nil, Probe, fmt.Errorf("create finding: %w", err)
+			}
+			f = f.WithLocation(&finding.Location{
+				Path: wf.File.Path,
+			})
+			return []finding.Finding{*f}, Probe, nil
+		}
+	}
+	f, err := finding.NewWith(fs, Probe,
+		"Pysa tool not installed", nil,
+		finding.OutcomeNegative)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("create finding: %w", err)
+	}
+	return []finding.Finding{*f}, Probe, nil
+}

--- a/probes/sastToolPysaInstalled/impl_test.go
+++ b/probes/sastToolPysaInstalled/impl_test.go
@@ -1,0 +1,112 @@
+// Copyright 2023 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:stylecheck
+package sastToolPysaInstalled
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/ossf/scorecard/v4/checker"
+	"github.com/ossf/scorecard/v4/finding"
+)
+
+func Test_Run(t *testing.T) {
+	t.Parallel()
+	//nolint:govet
+	tests := []struct {
+		name     string
+		raw      *checker.RawResults
+		outcomes []finding.Outcome
+		err      error
+	}{
+		{
+			name: "pysa present",
+			err:  nil,
+			raw: &checker.RawResults{
+				SASTResults: checker.SASTData{
+					Workflows: []checker.SASTWorkflow{
+						{
+							Type: checker.CodeQLWorkflow,
+						},
+						{
+							Type: checker.SnykWorkflow,
+						},
+						{
+							Type: checker.SonarWorkflow,
+						},
+						{
+							Type: checker.PysaWorkflow,
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomePositive,
+			},
+		},
+		{
+			name: "pysa not present",
+			err:  nil,
+			raw: &checker.RawResults{
+				SASTResults: checker.SASTData{
+					Workflows: []checker.SASTWorkflow{
+						{
+							Type: checker.SonarWorkflow,
+						},
+						{
+							Type: checker.CodeQLWorkflow,
+						},
+						{
+							Type: checker.SnykWorkflow,
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeNegative,
+			},
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings, s, err := Run(tt.raw)
+			if !cmp.Equal(tt.err, err, cmpopts.EquateErrors()) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tt.err, err, cmpopts.EquateErrors()))
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(Probe, s); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			if diff := cmp.Diff(len(tt.outcomes), len(findings)); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			for i := range tt.outcomes {
+				outcome := &tt.outcomes[i]
+				f := &findings[i]
+				if diff := cmp.Diff(*outcome, f.Outcome); diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Adds a probe checking the presence of Pysa SAST Github action (https://github.com/facebook/pysa-action)

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Scorecard will not recognize Pysa scanning as a SAST action

#### What is the new behavior (if this is a feature change)?**

Scorecard will recognize Pysa scanning as a SAST action.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Ref: https://github.com/ossf/scorecard/issues/2318

-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Yes, in that it will chnge scoring of projects that use Pysa and users may now see Pysa-related details in the output.

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
