### PR TITLE
:bug: Fix signed release error for empty gitlab repo

### DIFF
--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -15,6 +15,7 @@
 package evaluation
 
 import (
+	"errors"
 	"fmt"
 	"math"
 
@@ -24,6 +25,8 @@ import (
 	"github.com/ossf/scorecard/v4/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v4/probes/releasesHaveProvenance"
 )
+
+var errNoReleaseFound = errors.New("no release found")
 
 // SignedReleases applies the score policy for the Signed-Releases check.
 func SignedReleases(name string,
@@ -48,19 +51,13 @@ func SignedReleases(name string,
 
 		// Debug release name
 		if f.Outcome == finding.OutcomeNotApplicable {
-			dl.Warn(&checker.LogMessage{
-				Text: "no releases found",
-			})
 			// Generic summary.
 			return checker.CreateInconclusiveResult(name, "no releases found")
 		}
 		releaseName := getReleaseName(f)
 		if releaseName == "" {
-			dl.Warn(&checker.LogMessage{
-				Text: "no releases found",
-			})
 			// Generic summary.
-			return checker.CreateInconclusiveResult(name, "no releases found")
+			return checker.CreateRuntimeErrorResult(name, errNoReleaseFound)
 		}
 
 		if !contains(loggedReleases, releaseName) {
@@ -83,7 +80,7 @@ func SignedReleases(name string,
 
 		releaseName := getReleaseName(f)
 		if releaseName == "" {
-			return checker.CreateInconclusiveResult(name, "no releases found")
+			return checker.CreateRuntimeErrorResult(name, errNoReleaseFound)
 		}
 		if !contains(uniqueReleaseTags, releaseName) {
 			uniqueReleaseTags = append(uniqueReleaseTags, releaseName)

--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -47,14 +47,22 @@ func SignedReleases(name string,
 		f := &findings[i]
 
 		// Debug release name
-		releaseName := getReleaseName(f)
-		if releaseName == "" {
+		if f.Outcome == finding.OutcomeNotApplicable {
 			dl.Warn(&checker.LogMessage{
-				Text: "no GitHub releases found",
+				Text: "no releases found",
 			})
 			// Generic summary.
 			return checker.CreateInconclusiveResult(name, "no releases found")
 		}
+		releaseName := getReleaseName(f)
+		if releaseName == "" {
+			dl.Warn(&checker.LogMessage{
+				Text: "no releases found",
+			})
+			// Generic summary.
+			return checker.CreateInconclusiveResult(name, "no releases found")
+		}
+
 		if !contains(loggedReleases, releaseName) {
 			dl.Debug(&checker.LogMessage{
 				Text: fmt.Sprintf("GitHub release found: %s", releaseName),
@@ -63,13 +71,6 @@ func SignedReleases(name string,
 		}
 
 		// Check if outcome is NotApplicable
-		if f.Outcome == finding.OutcomeNotApplicable {
-			dl.Warn(&checker.LogMessage{
-				Text: "no GitHub releases found",
-			})
-			// Generic summary.
-			return checker.CreateInconclusiveResult(name, "no releases found")
-		}
 	}
 
 	totalPositive := 0

--- a/checks/evaluation/signed_releases_test.go
+++ b/checks/evaluation/signed_releases_test.go
@@ -38,12 +38,6 @@ const (
 	asset1 = 1
 	asset2 = 2
 	asset3 = 3
-	asset4 = 4
-	asset5 = 5
-	asset6 = 6
-	asset7 = 7
-	asset8 = 8
-	asset9 = 9
 )
 
 func signedProbe(release, asset int, outcome finding.Outcome) finding.Finding {
@@ -278,6 +272,62 @@ func TestSignedReleases(t *testing.T) {
 			got := SignedReleases(tt.name, tt.findings, &dl)
 			if !scut.ValidateTestReturn(t, tt.name, &tt.result, &got, &dl) {
 				t.Errorf("got %v, expected %v", got, tt.result)
+			}
+		})
+	}
+}
+
+func Test_getReleaseName(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		f *finding.Finding
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			name: "no release",
+			args: args{
+				f: &finding.Finding{
+					Values: map[string]int{},
+				},
+			},
+			want: "",
+		},
+		{
+			name: "release",
+			args: args{
+				f: &finding.Finding{
+					Values: map[string]int{
+						"v1": int(releasesAreSigned.ValueTypeRelease),
+					},
+					Probe: releasesAreSigned.Probe,
+				},
+			},
+			want: "v1",
+		},
+		{
+			name: "release and asset",
+			args: args{
+				f: &finding.Finding{
+					Values: map[string]int{
+						"v1":         int(releasesAreSigned.ValueTypeRelease),
+						"artifact-1": int(releasesAreSigned.ValueTypeReleaseAsset),
+					},
+					Probe: releasesAreSigned.Probe,
+				},
+			},
+			want: "v1",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := getReleaseName(tt.args.f); got != tt.want {
+				t.Errorf("getReleaseName() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION


#### What kind of change does this PR introduce?
- Fixed the issue where an empty gitlab repo is causing this error. `Error: check runtime error: Signed-Releases: internal error: could not get release name 2023/12/27 18:07:19 error during command execution: check runtime error: Signed-Releases: internal error: could not get release name exit status 1`

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
