### PR TITLE
:bug: Dependency-Update-Tool: ignore search commit data for repo clients which dont support it

### DIFF
--- a/checks/dependency_update_tool_test.go
+++ b/checks/dependency_update_tool_test.go
@@ -162,3 +162,21 @@ func TestDependencyUpdateTool(t *testing.T) {
 		})
 	}
 }
+
+func TestDependencyUpdateTool_noSearchCommits(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockRepo := mockrepo.NewMockRepoClient(ctrl)
+	files := []string{"README.md"}
+	mockRepo.EXPECT().ListFiles(gomock.Any()).Return(files, nil)
+	mockRepo.EXPECT().SearchCommits(gomock.Any()).Return(nil, clients.ErrUnsupportedFeature)
+	dl := scut.TestDetailLogger{}
+	c := &checker.CheckRequest{
+		RepoClient: mockRepo,
+		Dlogger:    &dl,
+	}
+	got := DependencyUpdateTool(c)
+	if got.Error != nil {
+		t.Errorf("got: %v, wanted ErrUnsupportedFeature not to propagate", got.Error)
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Repos which dont have any dependency update tool config files fallback to searching for dependabot commits. For local repos, this search isn't supported and results in an error

#### What is the new behavior (if this is a feature change)?**
The primary data is the configuration files and the search commit data is just extra, so better to return some data than no data in this case.

We can eventually add the commit searching for local repos via #1709.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2985
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
