### PR TITLE
:bug: Fix OSV URI in probe remediation text

### DIFF
--- a/probes/hasOSVVulnerabilities/def.yml
+++ b/probes/hasOSVVulnerabilities/def.yml
@@ -24,10 +24,10 @@ outcome:
 remediation:
   effort: High
   text:
-    - Fix the ${{ metadata.osvid }} by following information from https://osv.dev/${{ metadata.osvid }}.
+    - Fix the ${{ metadata.osvid }} by following information from https://osv.dev/${{ metadata.osvid }} .
     - If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
     - If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on OSV-Scanner repository.
   markdown:
-    - Fix the ${{ metadata.osvid }} by following information from [OSV](https://osv.dev/${{ metadata.osvid }}).
+    - Fix the ${{ metadata.osvid }} by following information from [OSV](https://osv.dev/${{ metadata.osvid }}) .
     - If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
     - If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml ([example](https://github.com/google/osv.dev/blob/eb99b02ec8895fe5b87d1e76675ddad79a15f817/vulnfeeds/osv-scanner.toml)) file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on [OSV-Scanner repository](https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id).

--- a/probes/hasOSVVulnerabilities/impl.go
+++ b/probes/hasOSVVulnerabilities/impl.go
@@ -62,6 +62,9 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	IDs := grouper.Group(aliasVulnerabilities)
 
 	for _, vuln := range IDs {
+		if len(vuln.IDs) == 0 {
+			return nil, Probe, errNoVulnID
+		}
 		f, err := finding.NewWith(fs, Probe,
 			"Project contains OSV vulnerabilities", nil,
 			finding.OutcomeNegative)
@@ -69,9 +72,6 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 			return nil, Probe, fmt.Errorf("create finding: %w", err)
 		}
 		f = f.WithMessage("Project is vulnerable to: " + strings.Join(vuln.IDs, " / "))
-		if len(vuln.IDs) == 0 {
-			return nil, Probe, errNoVulnID
-		}
 		f = f.WithRemediationMetadata(map[string]string{
 			"osvid": vuln.IDs[0],
 		})

--- a/probes/hasOSVVulnerabilities/impl.go
+++ b/probes/hasOSVVulnerabilities/impl.go
@@ -17,6 +17,7 @@ package hasOSVVulnerabilities
 
 import (
 	"embed"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -31,6 +32,8 @@ import (
 var fs embed.FS
 
 const Probe = "hasOSVVulnerabilities"
+
+var errNoVulnID = errors.New("no vuln ID")
 
 func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	if raw == nil {
@@ -65,10 +68,12 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		if err != nil {
 			return nil, Probe, fmt.Errorf("create finding: %w", err)
 		}
-		f = f.WithMessage(fmt.Sprintf("Project is vulnerable to: %s",
-			strings.Join(vuln.IDs, " / ")))
+		f = f.WithMessage("Project is vulnerable to: " + strings.Join(vuln.IDs, " / "))
+		if len(vuln.IDs) == 0 {
+			return nil, Probe, errNoVulnID
+		}
 		f = f.WithRemediationMetadata(map[string]string{
-			"osvid": strings.Join(vuln.IDs[:], ","),
+			"osvid": vuln.IDs[0],
 		})
 		findings = append(findings, *f)
 	}

--- a/probes/hasOSVVulnerabilities/impl_test.go
+++ b/probes/hasOSVVulnerabilities/impl_test.go
@@ -88,10 +88,40 @@ func Test_Run(t *testing.T) {
 				Probe:   "hasOSVVulnerabilities",
 				Message: "Project is vulnerable to: foo",
 				Remediation: &probe.Remediation{
-					Text: `Fix the foo by following information from https://osv.dev/foo.
+					Text: `Fix the foo by following information from https://osv.dev/foo .
 If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
 If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on OSV-Scanner repository.`,
-					Markdown: `Fix the foo by following information from [OSV](https://osv.dev/foo).
+					Markdown: `Fix the foo by following information from [OSV](https://osv.dev/foo) .
+If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
+If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml ([example](https://github.com/google/osv.dev/blob/eb99b02ec8895fe5b87d1e76675ddad79a15f817/vulnfeeds/osv-scanner.toml)) file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on [OSV-Scanner repository](https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id).`,
+					Effort: 3,
+				},
+			},
+		},
+		{
+			name: "only one vuln ID appears in the findings remediation text.",
+			raw: &checker.RawResults{
+				VulnerabilitiesResults: checker.VulnerabilitiesData{
+					Vulnerabilities: []clients.Vulnerability{
+						{ID: "foo"},
+						{
+							ID:      "bar",
+							Aliases: []string{"foo"},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeNegative,
+			},
+			expectedFinding: &finding.Finding{
+				Probe:   "hasOSVVulnerabilities",
+				Message: "Project is vulnerable to: bar / foo",
+				Remediation: &probe.Remediation{
+					Text: `Fix the bar by following information from https://osv.dev/bar .
+If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
+If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on OSV-Scanner repository.`,
+					Markdown: `Fix the bar by following information from [OSV](https://osv.dev/bar) .
 If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
 If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml ([example](https://github.com/google/osv.dev/blob/eb99b02ec8895fe5b87d1e76675ddad79a15f817/vulnfeeds/osv-scanner.toml)) file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on [OSV-Scanner repository](https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id).`,
 					Effort: 3,

--- a/probes/hasOSVVulnerabilities/impl_test.go
+++ b/probes/hasOSVVulnerabilities/impl_test.go
@@ -16,6 +16,7 @@
 package hasOSVVulnerabilities
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
@@ -24,7 +25,6 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/clients"
 	"github.com/ossf/scorecard/v4/finding"
-	"github.com/ossf/scorecard/v4/finding/probe"
 )
 
 func Test_Run(t *testing.T) {
@@ -61,73 +61,6 @@ func Test_Run(t *testing.T) {
 				finding.OutcomePositive,
 			},
 		},
-		{
-			name: "vulnerabilities not present",
-			raw: &checker.RawResults{
-				VulnerabilitiesResults: checker.VulnerabilitiesData{
-					Vulnerabilities: []clients.Vulnerability{},
-				},
-			},
-			outcomes: []finding.Outcome{
-				finding.OutcomePositive,
-			},
-		},
-		{
-			name: "vulnerabilities and metadata present. 'foo' must appear in the findings remediation text.",
-			raw: &checker.RawResults{
-				VulnerabilitiesResults: checker.VulnerabilitiesData{
-					Vulnerabilities: []clients.Vulnerability{
-						{ID: "foo"},
-					},
-				},
-			},
-			outcomes: []finding.Outcome{
-				finding.OutcomeNegative,
-			},
-			expectedFinding: &finding.Finding{
-				Probe:   "hasOSVVulnerabilities",
-				Message: "Project is vulnerable to: foo",
-				Remediation: &probe.Remediation{
-					Text: `Fix the foo by following information from https://osv.dev/foo .
-If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
-If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on OSV-Scanner repository.`,
-					Markdown: `Fix the foo by following information from [OSV](https://osv.dev/foo) .
-If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
-If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml ([example](https://github.com/google/osv.dev/blob/eb99b02ec8895fe5b87d1e76675ddad79a15f817/vulnfeeds/osv-scanner.toml)) file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on [OSV-Scanner repository](https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id).`,
-					Effort: 3,
-				},
-			},
-		},
-		{
-			name: "only one vuln ID appears in the findings remediation text.",
-			raw: &checker.RawResults{
-				VulnerabilitiesResults: checker.VulnerabilitiesData{
-					Vulnerabilities: []clients.Vulnerability{
-						{ID: "foo"},
-						{
-							ID:      "bar",
-							Aliases: []string{"foo"},
-						},
-					},
-				},
-			},
-			outcomes: []finding.Outcome{
-				finding.OutcomeNegative,
-			},
-			expectedFinding: &finding.Finding{
-				Probe:   "hasOSVVulnerabilities",
-				Message: "Project is vulnerable to: bar / foo",
-				Remediation: &probe.Remediation{
-					Text: `Fix the bar by following information from https://osv.dev/bar .
-If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
-If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on OSV-Scanner repository.`,
-					Markdown: `Fix the bar by following information from [OSV](https://osv.dev/bar) .
-If the vulnerability is in a dependency, update the dependency to a non-vulnerable version. If no update is available, consider whether to remove the dependency.
-If you believe the vulnerability does not affect your project, the vulnerability can be ignored. To ignore, create an osv-scanner.toml ([example](https://github.com/google/osv.dev/blob/eb99b02ec8895fe5b87d1e76675ddad79a15f817/vulnfeeds/osv-scanner.toml)) file next to the dependency manifest (e.g. package-lock.json) and specify the ID to ignore and reason. Details on the structure of osv-scanner.toml can be found on [OSV-Scanner repository](https://github.com/google/osv-scanner#ignore-vulnerabilities-by-id).`,
-					Effort: 3,
-				},
-			},
-		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
@@ -158,6 +91,75 @@ If you believe the vulnerability does not affect your project, the vulnerability
 					if diff := cmp.Diff(tt.expectedFinding, f); diff != "" {
 						t.Errorf("mismatch (-want +got):\n%s", diff)
 					}
+				}
+			}
+		})
+	}
+}
+
+func TestRun_remediation(t *testing.T) {
+	t.Parallel()
+	//nolint:govet
+	tests := []struct {
+		name              string
+		raw               *checker.RawResults
+		wantRemediation   bool
+		remediationSubstr string
+		err               error
+	}{
+		{
+			name: "no remediation needed",
+			raw: &checker.RawResults{
+				VulnerabilitiesResults: checker.VulnerabilitiesData{
+					Vulnerabilities: []clients.Vulnerability{},
+				},
+			},
+			wantRemediation: false,
+		},
+		{
+			name: "vulnerabilities and metadata present. 'foo' must appear in the findings remediation text.",
+			raw: &checker.RawResults{
+				VulnerabilitiesResults: checker.VulnerabilitiesData{
+					Vulnerabilities: []clients.Vulnerability{
+						{ID: "foo"},
+					},
+				},
+			},
+			wantRemediation:   true,
+			remediationSubstr: "Fix the foo",
+		},
+		{
+			name: "only one vuln ID appears in the findings remediation text link.",
+			raw: &checker.RawResults{
+				VulnerabilitiesResults: checker.VulnerabilitiesData{
+					Vulnerabilities: []clients.Vulnerability{
+						{ID: "foo"},
+						{
+							ID:      "bar",
+							Aliases: []string{"foo"},
+						},
+					},
+				},
+			},
+			wantRemediation:   true,
+			remediationSubstr: "https://osv.dev/bar .",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			findings, _, err := Run(tt.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			for i := range findings {
+				gotRemediation := findings[i].Remediation != nil
+				if tt.wantRemediation != gotRemediation {
+					t.Errorf("wanted remediation?: %t, had remediation?: %t", tt.wantRemediation, gotRemediation)
+				}
+				if tt.wantRemediation && !strings.Contains(findings[i].Remediation.Text, tt.remediationSubstr) {
+					t.Errorf("wanted to find substr %q in remediation text, but didn't", tt.remediationSubstr)
 				}
 			}
 		})


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The OSV IDs are joined together when generating a link, leading to a broken link:
For example, if a vuln is known by both `foo` and `bar`, the link was `https://osv.dev/bar,foo` which is broken, but `https://osv.dev/bar` or `https://osv.dev/foo` would have worked.

#### What is the new behavior (if this is a feature change)?**
The first Vuln ID is used for the link, from the example above that leads to `https://osv.dev/bar`
Also added a space after the link, so the period wouldn't be interpreted as part of the link in the remediation text.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #3609
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
