### PR TITLE
:sparkles: Support `.sigstore` bundles to check for signed releases

### DIFF
--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -42,7 +42,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with no assests",
+			name: "Releases with no assets",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -56,7 +56,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with assests without signed artifacts",
+			name: "Releases with assets without signed artifacts",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -75,7 +75,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with assests with signed artifacts-asc",
+			name: "Releases with assets with signed artifacts-asc",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -94,7 +94,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with assests with intoto SLSA provenance",
+			name: "Releases with assets with intoto SLSA provenance",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -113,7 +113,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with assests with signed artifacts-sig",
+			name: "Releases with assets with signed artifacts-sig",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -132,7 +132,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with assests with signed artifacts-sign",
+			name: "Releases with assets with signed artifacts-sign",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -151,7 +151,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with assests with signed artifacts-minisig",
+			name: "Releases with assets with signed artifacts-minisig",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -170,7 +170,26 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Releases with assests with signed and unsigned artifacts",
+			name: "Releases with assets with signed artifacts-sigstore",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.sigstore",
+							URL:  "http://foo.com/v1.0.0/foo.sigstore",
+						},
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 8,
+			},
+		},
+		{
+			name: "Releases with assets with signed and unsigned artifacts",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -193,7 +212,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Multiple Releases with assests with signed and unsigned artifacts",
+			name: "Multiple Releases with assets with signed and unsigned artifacts",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -231,7 +250,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "Some releases with assests with signed and unsigned artifacts",
+			name: "Some releases with assets with signed and unsigned artifacts",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -265,7 +284,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "6 Releases with assests with signed artifacts",
+			name: "6 Releases with assets with signed artifacts",
 			releases: []clients.Release{
 				{
 					TagName:         "v1.0.0",
@@ -372,7 +391,7 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
-			name: "9 Releases with assests with signed artifacts",
+			name: "9 Releases with assets with signed artifacts",
 			releases: []clients.Release{
 				release("v0.8.5"),
 				release("v0.8.4"),

--- a/probes/releasesAreSigned/impl.go
+++ b/probes/releasesAreSigned/impl.go
@@ -43,7 +43,7 @@ const (
 	ValueTypeReleaseAsset
 )
 
-var signatureExtensions = []string{".asc", ".minisig", ".sig", ".sign"}
+var signatureExtensions = []string{".asc", ".minisig", ".sig", ".sign", ".sigstore"}
 
 func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	if raw == nil {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Scorecard fails to detect `*.sigstore` signature bundles.

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #3771

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Support `.sigstore` bundles to check for signed releases
```
