### PR TITLE
Add .sigstore to the list of sign extensions

### DIFF
--- a/probes/releasesAreSigned/impl.go
+++ b/probes/releasesAreSigned/impl.go
@@ -43,7 +43,7 @@ const (
 	ValueTypeReleaseAsset
 )
 
-var signatureExtensions = []string{".asc", ".minisig", ".sig", ".sign"}
+var signatureExtensions = []string{".asc", ".minisig", ".sig", ".sign", ".sigstore"}
 
 func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	if raw == nil {


### PR DESCRIPTION
closes https://github.com/ossf/scorecard/pull/3772

```release-note
Add .sigstore to the list of sign extensions
```
