### PR TITLE
:seedling: use a single source of truth for fuzzer names

### DIFF
--- a/internal/fuzzers/fuzzers.go
+++ b/internal/fuzzers/fuzzers.go
@@ -1,0 +1,32 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package fuzzers defines the string constants used when identifying supported fuzzer tools.
+package fuzzers
+
+const (
+	OSSFuzz                 = "OSSFuzz"
+	ClusterFuzzLite         = "ClusterFuzzLite"
+	BuiltInGo               = "GoBuiltInFuzzer"
+	PropertyBasedHaskell    = "HaskellPropertyBasedTesting"
+	PropertyBasedJavaScript = "JavaScriptPropertyBasedTesting"
+	PropertyBasedTypeScript = "TypeScriptPropertyBasedTesting"
+	PythonAtheris           = "PythonAtherisFuzzer"
+	CLibFuzzer              = "CLibFuzzer"
+	CppLibFuzzer            = "CppLibFuzzer"
+	SwiftLibFuzzer          = "SwiftLibFuzzer"
+	RustCargoFuzz           = "RustCargoFuzzer"
+	JavaJazzerFuzzer        = "JavaJazzerFuzzer"
+	// TODO: add more fuzzing check supports.
+)

--- a/probes/fuzzedWithCLibFuzzer/impl.go
+++ b/probes/fuzzedWithCLibFuzzer/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "CLibFuzzer")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.CLibFuzzer)
 }

--- a/probes/fuzzedWithCLibFuzzer/impl_test.go
+++ b/probes/fuzzedWithCLibFuzzer/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "CLibFuzzer",
+							Name: fuzzers.CLibFuzzer,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "CLibFuzzer",
+							Name: fuzzers.CLibFuzzer,
 						},
 						{
-							Name: "CLibFuzzer",
+							Name: fuzzers.CLibFuzzer,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "CLibFuzzer",
+							Name: fuzzers.CLibFuzzer,
 						},
 						{
 							Name: "not-CLibFuzzer",

--- a/probes/fuzzedWithClusterFuzzLite/impl.go
+++ b/probes/fuzzedWithClusterFuzzLite/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "ClusterFuzzLite")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.ClusterFuzzLite)
 }

--- a/probes/fuzzedWithClusterFuzzLite/impl_test.go
+++ b/probes/fuzzedWithClusterFuzzLite/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "ClusterFuzzLite",
+							Name: fuzzers.ClusterFuzzLite,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "ClusterFuzzLite",
+							Name: fuzzers.ClusterFuzzLite,
 						},
 						{
-							Name: "ClusterFuzzLite",
+							Name: fuzzers.ClusterFuzzLite,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "ClusterFuzzLite",
+							Name: fuzzers.ClusterFuzzLite,
 						},
 						{
 							Name: "not-ClusterFuzzLite",

--- a/probes/fuzzedWithCppLibFuzzer/impl.go
+++ b/probes/fuzzedWithCppLibFuzzer/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "CppLibFuzzer")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.CppLibFuzzer)
 }

--- a/probes/fuzzedWithCppLibFuzzer/impl_test.go
+++ b/probes/fuzzedWithCppLibFuzzer/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "CppLibFuzzer",
+							Name: fuzzers.CppLibFuzzer,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "CppLibFuzzer",
+							Name: fuzzers.CppLibFuzzer,
 						},
 						{
-							Name: "CppLibFuzzer",
+							Name: fuzzers.CppLibFuzzer,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "CppLibFuzzer",
+							Name: fuzzers.CppLibFuzzer,
 						},
 						{
 							Name: "not-CppLibFuzzer",

--- a/probes/fuzzedWithGoNative/impl.go
+++ b/probes/fuzzedWithGoNative/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "GoBuiltInFuzzer")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.BuiltInGo)
 }

--- a/probes/fuzzedWithGoNative/impl_test.go
+++ b/probes/fuzzedWithGoNative/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "GoBuiltInFuzzer",
+							Name: fuzzers.BuiltInGo,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "GoBuiltInFuzzer",
+							Name: fuzzers.BuiltInGo,
 						},
 						{
-							Name: "GoBuiltInFuzzer",
+							Name: fuzzers.BuiltInGo,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "GoBuiltInFuzzer",
+							Name: fuzzers.BuiltInGo,
 						},
 						{
 							Name: "not-GoBuiltInFuzzer",

--- a/probes/fuzzedWithJavaJazzerFuzzer/impl.go
+++ b/probes/fuzzedWithJavaJazzerFuzzer/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "JavaJazzerFuzzer")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.JavaJazzerFuzzer)
 }

--- a/probes/fuzzedWithJavaJazzerFuzzer/impl_test.go
+++ b/probes/fuzzedWithJavaJazzerFuzzer/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "JavaJazzerFuzzer",
+							Name: fuzzers.JavaJazzerFuzzer,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "JavaJazzerFuzzer",
+							Name: fuzzers.JavaJazzerFuzzer,
 						},
 						{
-							Name: "JavaJazzerFuzzer",
+							Name: fuzzers.JavaJazzerFuzzer,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "JavaJazzerFuzzer",
+							Name: fuzzers.JavaJazzerFuzzer,
 						},
 						{
 							Name: "not-JavaJazzerFuzzer",

--- a/probes/fuzzedWithOSSFuzz/impl.go
+++ b/probes/fuzzedWithOSSFuzz/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "OSSFuzz")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.OSSFuzz)
 }

--- a/probes/fuzzedWithOSSFuzz/impl_test.go
+++ b/probes/fuzzedWithOSSFuzz/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "OSSFuzz",
+							Name: fuzzers.OSSFuzz,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "OSSFuzz",
+							Name: fuzzers.OSSFuzz,
 						},
 						{
-							Name: "OSSFuzz",
+							Name: fuzzers.OSSFuzz,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "OSSFuzz",
+							Name: fuzzers.OSSFuzz,
 						},
 						{
 							Name: "not-OSSFuzz",

--- a/probes/fuzzedWithPropertyBasedHaskell/impl.go
+++ b/probes/fuzzedWithPropertyBasedHaskell/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "HaskellPropertyBasedTesting")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.PropertyBasedHaskell)
 }

--- a/probes/fuzzedWithPropertyBasedHaskell/impl_test.go
+++ b/probes/fuzzedWithPropertyBasedHaskell/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "HaskellPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedHaskell,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "HaskellPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedHaskell,
 						},
 						{
-							Name: "HaskellPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedHaskell,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "HaskellPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedHaskell,
 						},
 						{
 							Name: "not-HaskellPropertyBasedTesting",

--- a/probes/fuzzedWithPropertyBasedJavascript/impl.go
+++ b/probes/fuzzedWithPropertyBasedJavascript/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "JavaScriptPropertyBasedTesting")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.PropertyBasedJavaScript)
 }

--- a/probes/fuzzedWithPropertyBasedJavascript/impl_test.go
+++ b/probes/fuzzedWithPropertyBasedJavascript/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "JavaScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedJavaScript,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "JavaScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedJavaScript,
 						},
 						{
-							Name: "JavaScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedJavaScript,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "JavaScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedJavaScript,
 						},
 						{
 							Name: "not-JavaScriptPropertyBasedTesting",

--- a/probes/fuzzedWithPropertyBasedTypescript/impl.go
+++ b/probes/fuzzedWithPropertyBasedTypescript/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "TypeScriptPropertyBasedTesting")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.PropertyBasedTypeScript)
 }

--- a/probes/fuzzedWithPropertyBasedTypescript/impl_test.go
+++ b/probes/fuzzedWithPropertyBasedTypescript/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "TypeScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedTypeScript,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "TypeScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedTypeScript,
 						},
 						{
-							Name: "TypeScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedTypeScript,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "TypeScriptPropertyBasedTesting",
+							Name: fuzzers.PropertyBasedTypeScript,
 						},
 						{
 							Name: "not-TypeScriptPropertyBasedTesting",

--- a/probes/fuzzedWithPythonAtheris/impl.go
+++ b/probes/fuzzedWithPythonAtheris/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "PythonAtherisFuzzer")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.PythonAtheris)
 }

--- a/probes/fuzzedWithPythonAtheris/impl_test.go
+++ b/probes/fuzzedWithPythonAtheris/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "PythonAtherisFuzzer",
+							Name: fuzzers.PythonAtheris,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "PythonAtherisFuzzer",
+							Name: fuzzers.PythonAtheris,
 						},
 						{
-							Name: "PythonAtherisFuzzer",
+							Name: fuzzers.PythonAtheris,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "PythonAtherisFuzzer",
+							Name: fuzzers.PythonAtheris,
 						},
 						{
 							Name: "not-PythonAtherisFuzzer",

--- a/probes/fuzzedWithRustCargofuzz/impl.go
+++ b/probes/fuzzedWithRustCargofuzz/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "RustCargoFuzzer")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.RustCargoFuzz)
 }

--- a/probes/fuzzedWithRustCargofuzz/impl_test.go
+++ b/probes/fuzzedWithRustCargofuzz/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "RustCargoFuzzer",
+							Name: fuzzers.RustCargoFuzz,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "RustCargoFuzzer",
+							Name: fuzzers.RustCargoFuzz,
 						},
 						{
-							Name: "RustCargoFuzzer",
+							Name: fuzzers.RustCargoFuzz,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "RustCargoFuzzer",
+							Name: fuzzers.RustCargoFuzz,
 						},
 						{
 							Name: "not-RustCargoFuzzer",

--- a/probes/fuzzedWithSwiftLibFuzzer/impl.go
+++ b/probes/fuzzedWithSwiftLibFuzzer/impl.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/fuzzing"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -35,5 +36,5 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
 	}
 	//nolint:wrapcheck
-	return fuzzing.Run(raw, fs, Probe, "SwiftLibFuzzer")
+	return fuzzing.Run(raw, fs, Probe, fuzzers.SwiftLibFuzzer)
 }

--- a/probes/fuzzedWithSwiftLibFuzzer/impl_test.go
+++ b/probes/fuzzedWithSwiftLibFuzzer/impl_test.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/finding"
+	"github.com/ossf/scorecard/v4/internal/fuzzers"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/test"
 	"github.com/ossf/scorecard/v4/probes/internal/utils/uerror"
 )
@@ -42,7 +43,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "SwiftLibFuzzer",
+							Name: fuzzers.SwiftLibFuzzer,
 						},
 					},
 				},
@@ -57,10 +58,10 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "SwiftLibFuzzer",
+							Name: fuzzers.SwiftLibFuzzer,
 						},
 						{
-							Name: "SwiftLibFuzzer",
+							Name: fuzzers.SwiftLibFuzzer,
 						},
 					},
 				},
@@ -76,7 +77,7 @@ func Test_Run(t *testing.T) {
 				FuzzingResults: checker.FuzzingData{
 					Fuzzers: []checker.Tool{
 						{
-							Name: "SwiftLibFuzzer",
+							Name: fuzzers.SwiftLibFuzzer,
 						},
 						{
 							Name: "not-SwiftLibFuzzer",


### PR DESCRIPTION
#### What kind of change does this PR introduce?

structured result cleanup

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
the constants are defined in multiple places across the code base (raw data and probes)

#### What is the new behavior (if this is a feature change)?**
The constants are defined in one place, and used elsewhere. 

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #3407
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
