### PR TITLE
:sparkles: dependency-update-tool: detect GitLab Renovate config files

### DIFF
--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -92,9 +92,16 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 			},
 		})
 
-		// https://docs.renovatebot.com/configuration-options/
-	case ".github/renovate.json", ".github/renovate.json5", ".renovaterc.json", "renovate.json",
-		"renovate.json5", ".renovaterc":
+	// https://docs.renovatebot.com/configuration-options/
+	case "renovate.json",
+		"renovate.json5",
+		".github/renovate.json",
+		".github/renovate.json5",
+		".gitlab/renovate.json",
+		".gitlab/renovate.json5",
+		".renovaterc",
+		".renovaterc.json",
+		".renovaterc.json5":
 		*ptools = append(*ptools, checker.Tool{
 			Name: "RenovateBot",
 			URL:  asPointer("https://github.com/renovatebot/renovate"),

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -64,6 +64,18 @@ func Test_checkDependencyFileExists(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    ".gitlab/renovate.json",
+			path:    ".gitlab/renovate.json",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    ".gitlab/renovate.json5",
+			path:    ".gitlab/renovate.json5",
+			want:    true,
+			wantErr: false,
+		},
+		{
 			name:    ".renovaterc.json",
 			path:    ".renovaterc.json",
 			want:    true,


### PR DESCRIPTION

#### What kind of change does this PR introduce?

enhancement/fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
no gitlab config files

#### What is the new behavior (if this is a feature change)?**
gitlab config files added
also organize the list in order of appearance on website. this makes it easier to compare.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Related to #542
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Dependency-Update-Tool now detects Renovate config files in a `.gitlab` folder.
```
