### PR TITLE
:seedling: use ValidateTestReturn for SAST tests

### DIFF
--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -46,12 +46,12 @@ func Test_SAST(t *testing.T) {
 		expected      scut.TestReturn
 	}{
 		{
-			name:         "SAST checker should return failed status when no PRs are found",
+			name:         "SAST checker should return min score when no PRs are found",
 			commits:      []clients.Commit{},
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
 			expected: scut.TestReturn{
-				Score:        0,
+				Score:        checker.MinResultScore,
 				NumberOfWarn: 1,
 			},
 		},
@@ -62,7 +62,7 @@ func Test_SAST(t *testing.T) {
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
 			expected: scut.TestReturn{
-				Score: -1,
+				Score: checker.InconclusiveResultScore,
 				Error: sce.ErrScorecardInternal,
 			},
 		},
@@ -86,7 +86,7 @@ func Test_SAST(t *testing.T) {
 				},
 			},
 			expected: scut.TestReturn{
-				Score:         10,
+				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
 				NumberOfDebug: 1,
 			},
@@ -111,7 +111,7 @@ func Test_SAST(t *testing.T) {
 				},
 			},
 			expected: scut.TestReturn{
-				Score:         10,
+				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
 				NumberOfDebug: 1,
 			},
@@ -137,7 +137,7 @@ func Test_SAST(t *testing.T) {
 			},
 			path: "",
 			expected: scut.TestReturn{
-				Score:         10,
+				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
 				NumberOfDebug: 1,
 			},
@@ -162,7 +162,7 @@ func Test_SAST(t *testing.T) {
 				},
 			},
 			expected: scut.TestReturn{
-				Score:         10,
+				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
 				NumberOfDebug: 1,
 			},
@@ -214,7 +214,7 @@ func Test_SAST(t *testing.T) {
 			},
 			path: ".github/workflows/airflow-codeql-workflow.yaml",
 			expected: scut.TestReturn{
-				Score:         10,
+				Score:         checker.MaxResultScore,
 				NumberOfInfo:  2,
 				NumberOfDebug: 1,
 			},
@@ -249,7 +249,7 @@ func Test_SAST(t *testing.T) {
 			},
 			path: ".github/workflows/airflow-codeql-workflow.yaml",
 			expected: scut.TestReturn{
-				Score:         10,
+				Score:         checker.MaxResultScore,
 				NumberOfInfo:  2,
 				NumberOfDebug: 1,
 			},

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ossf/scorecard/v4/checker"
 	"github.com/ossf/scorecard/v4/clients"
 	mockrepo "github.com/ossf/scorecard/v4/clients/mockclients"
+	sce "github.com/ossf/scorecard/v4/errors"
 	scut "github.com/ossf/scorecard/v4/utests"
 )
 
@@ -39,24 +40,31 @@ func Test_SAST(t *testing.T) {
 		searchRequest clients.SearchRequest
 		name          string
 		path          string
-		expected      checker.CheckResult
 		commits       []clients.Commit
 		checkRuns     []clients.CheckRun
 		searchresult  clients.SearchResponse
+		expected      scut.TestReturn
 	}{
 		{
 			name:         "SAST checker should return failed status when no PRs are found",
 			commits:      []clients.Commit{},
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
+			expected: scut.TestReturn{
+				Score:        0,
+				NumberOfWarn: 1,
+			},
 		},
 		{
-			name:         "SAST checker should return failed status when no PRs are found",
+			name:         "SAST checker should return failed status when an error occurs",
 			err:          errors.New("error"),
 			commits:      []clients.Commit{},
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
-			expected:     checker.CheckResult{Score: -1},
+			expected: scut.TestReturn{
+				Score: -1,
+				Error: sce.ErrScorecardInternal,
+			},
 		},
 		{
 			name: "Successful SAST checker should return success status for github-advanced-security",
@@ -77,8 +85,10 @@ func Test_SAST(t *testing.T) {
 					},
 				},
 			},
-			expected: checker.CheckResult{
-				Score: 10,
+			expected: scut.TestReturn{
+				Score:         10,
+				NumberOfInfo:  1,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -100,8 +110,10 @@ func Test_SAST(t *testing.T) {
 					},
 				},
 			},
-			expected: checker.CheckResult{
-				Score: 10,
+			expected: scut.TestReturn{
+				Score:         10,
+				NumberOfInfo:  1,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -124,8 +136,10 @@ func Test_SAST(t *testing.T) {
 				},
 			},
 			path: "",
-			expected: checker.CheckResult{
-				Score: 10,
+			expected: scut.TestReturn{
+				Score:         10,
+				NumberOfInfo:  1,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -147,8 +161,10 @@ func Test_SAST(t *testing.T) {
 					},
 				},
 			},
-			expected: checker.CheckResult{
-				Score: 10,
+			expected: scut.TestReturn{
+				Score:         10,
+				NumberOfInfo:  1,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -163,8 +179,10 @@ func Test_SAST(t *testing.T) {
 			},
 			searchresult: clients.SearchResponse{},
 			path:         ".github/workflows/airflow-codeql-workflow.yaml",
-			expected: checker.CheckResult{
-				Score: 7,
+			expected: scut.TestReturn{
+				Score:        7,
+				NumberOfWarn: 1,
+				NumberOfInfo: 1,
 			},
 		},
 		{
@@ -195,8 +213,10 @@ func Test_SAST(t *testing.T) {
 				},
 			},
 			path: ".github/workflows/airflow-codeql-workflow.yaml",
-			expected: checker.CheckResult{
-				Score: 10,
+			expected: scut.TestReturn{
+				Score:         10,
+				NumberOfInfo:  2,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -228,8 +248,10 @@ func Test_SAST(t *testing.T) {
 				},
 			},
 			path: ".github/workflows/airflow-codeql-workflow.yaml",
-			expected: checker.CheckResult{
-				Score: 10,
+			expected: scut.TestReturn{
+				Score:         10,
+				NumberOfInfo:  2,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -266,8 +288,10 @@ func Test_SAST(t *testing.T) {
 				},
 			},
 			path: ".github/workflows/airflow-codeql-workflow.yaml",
-			expected: checker.CheckResult{
-				Score: 7,
+			expected: scut.TestReturn{
+				Score:        7,
+				NumberOfWarn: 1,
+				NumberOfInfo: 1,
 			},
 		},
 	}
@@ -315,10 +339,7 @@ func Test_SAST(t *testing.T) {
 			}
 			res := SAST(&req)
 
-			if res.Score != tt.expected.Score {
-				t.Errorf("Expected score %d, got %d for %v", tt.expected.Score, res.Score, tt.name)
-			}
-			ctrl.Finish()
+			scut.ValidateTestReturn(t, tt.name, &tt.expected, &res, &dl)
 		})
 	}
 }


### PR DESCRIPTION

#### What kind of change does this PR introduce?

test cleanup

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
we only checked the result score, which produces test failures without clear actionable feedback.
I discovered this during another refactor and it was hard to figure out what the issue was.

```
--- FAIL: Test_SAST (0.00s)
    --- FAIL: Test_SAST/SAST_checker_should_return_failed_status_when_no_PRs_are_found (0.00s)
        ~/checks/sast_test.go:319: Expected score 0, got -1 for SAST checker should return failed status when no PRs are found
    --- FAIL: Test_SAST/Successful_SAST_checker_should_return_success_status_for_sonarcloud (0.00s)
        ~/checks/sast_test.go:319: Expected score 10, got -1 for Successful SAST checker should return success status for sonarcloud
```

#### What is the new behavior (if this is a feature change)?**
We use our test helper: `ValidateTestReturn`, which provides much more actionable feedback when tests fail:
```
--- FAIL: Test_SAST (0.00s)
    --- FAIL: Test_SAST/SAST_checker_should_return_failed_status_when_no_PRs_are_found (0.00s)
        ~/checks/sast_test.go:342: SAST checker should return failed status when no PRs are found: (-expected +actual)  utests.TestReturn{
            - 	Error:         nil,
            + 	Error:         e"internal error: probe run failure: [create finding: finding.New: invalid: ID: read '', expected 'sastToolConfigured']",
            - 	Score:         0,
            + 	Score:         -1,
            - 	NumberOfWarn:  1,
            + 	NumberOfWarn:  0,
              	NumberOfInfo:  0,
              	NumberOfDebug: 0,
              }
```

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
The warn/info/debug counts were just taken as-is from the current state of `main` branch.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
