### PR TITLE
:seedling: Use git diff instead of external action for changed files

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -38,15 +38,16 @@ jobs:
       uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 #v4.1.1
       with:
         fetch-depth: 2 # needed to diff changed files
-    - id: files
-      name: Get changed files
-      uses: tj-actions/changed-files@90a06d6ba9543371ab4df8eeca0be07ca6054959 #v42.0.2
-      with:
-        files_ignore: '**.md'
     - id: docs_only_check
-      if: steps.files.outputs.any_changed != 'true'
       name: Check for docs-only changes
-      run: echo "docs_only=true" >> $GITHUB_OUTPUT
+      run: |
+        set +e # dont fail based on grep exit code
+        git diff --name-only HEAD~1 | grep --ignore-case --invert-match '.md$'
+        if [ $? -eq 1 ]; then
+            echo "docs_only=true" >> $GITHUB_OUTPUT
+        else
+            echo "docs_only=false" >> $GITHUB_OUTPUT
+        fi
 
   docker_matrix:
     strategy:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,7 @@ jobs:
         set +e # dont fail based on grep exit code
         git diff --name-only HEAD~1 | grep --ignore-case --invert-match '.md$'
         if [ $? -eq 1 ]; then
+            # no grep match (all files end in .md) produces exit code 1
             echo "docs_only=true" >> $GITHUB_OUTPUT
         else
             echo "docs_only=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
#### What kind of change does this PR introduce?

removing dependency

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
we use [tj-actions/changed-files](https://github.com/tj-actions/changed-files) to detect when only markdown files are changed

#### What is the new behavior (if this is a feature change)?**
we use git diff, since the logic we need is simple and this reduces a dependency

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
You can see some example PRs of this working as expected:

* https://github.com/spencerschrock/actions-test/pull/5
  * Confirms it shows non-md files (including `HEAD~1` works as expected on the whole PR and not just the last commit)
* https://github.com/spencerschrock/actions-test/pull/6
  * Confirms it ignores a readme only PR


#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
