### PR TITLE
Update contributor ladder

### DIFF
--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -83,7 +83,7 @@ and software engineering principles.
 
 #### Pre-requisites
 
-- Community Member for at least 3 months
+- Community Member for at least 1 month
 - Helped to triage issues and pull requests
 - Knowledgeable about the codebase
 
@@ -131,7 +131,7 @@ approval is focused on holistic acceptance of a contribution including:
 
 #### Pre-requisites
 
-- Triager for at least 3 months
+- Triager for at least 1 month
 - Reviewed at least 10 substantial PRs to the codebase
 - Reviewed or got at least 30 PRs merged to the codebase
 

--- a/CONTRIBUTOR_LADDER.md
+++ b/CONTRIBUTOR_LADDER.md
@@ -38,7 +38,7 @@ Members are expected to remain active contributors to the community.
 #### Pre-requisites
 
 - Enabled two-factor authentication on their GitHub account
-- Have made multiple contributions to the project or community.
+- Have made multiple contributions to the project or community
   Contributions may include, but are not limited to:
   - Authoring or reviewing PRs on GitHub. At least one PR must be **merged**.
   - Filing or commenting on issues on GitHub


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Reduces duration requirements in contributor ladder

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Triager requires 3 months as a community member 
Maintainer requires 3 months as a triager
#### What is the new behavior (if this is a feature change)?**
Triager will only require 1 month as a community member 
Maintainer will only require 1 month as a triager
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?



<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```NONE

```
