### PR TITLE
:bug: Branch-Protection: use debug message when unsure if PRs are required

### DIFF
--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -363,9 +363,9 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			expected: scut.TestReturn{
 				Error:         nil,
 				Score:         0,
-				NumberOfWarn:  6,
+				NumberOfWarn:  4,
 				NumberOfInfo:  0,
-				NumberOfDebug: 8,
+				NumberOfDebug: 10,
 			},
 			nonadmin:      true,
 			defaultBranch: main,

--- a/checks/evaluation/branch_protection.go
+++ b/checks/evaluation/branch_protection.go
@@ -407,15 +407,8 @@ func adminReviewProtection(f *finding.Finding, doLogging bool, dl checker.Detail
 	if f.Outcome == finding.OutcomePositive {
 		score++
 	}
-	switch f.Probe {
-	case requiresLastPushApproval.Probe,
-		requiresUpToDateBranches.Probe:
-		logWithDebug(f, doLogging, dl)
-		if f.Outcome != finding.OutcomeNotAvailable {
-			max++
-		}
-	default:
-		logInfoOrWarn(f, doLogging, dl)
+	logWithDebug(f, doLogging, dl)
+	if f.Outcome != finding.OutcomeNotAvailable {
 		max++
 	}
 	return score, max

--- a/checks/evaluation/branch_protection_test.go
+++ b/checks/evaluation/branch_protection_test.go
@@ -731,9 +731,9 @@ func TestBranchProtection(t *testing.T) {
 			},
 			result: scut.TestReturn{
 				Score:         3,
-				NumberOfWarn:  3,
+				NumberOfWarn:  2,
 				NumberOfInfo:  2,
-				NumberOfDebug: 4,
+				NumberOfDebug: 5,
 			},
 		},
 		{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
When run with a non-admin token, if we cant tell if PRs are required, we throw a warning.
> Warn: could not determine whether branch 'main' requires PRs to change code

#### What is the new behavior (if this is a feature change)?**
Since requiring PRs is listed as potentially admin only data, not having the data is now DEBUG, not WARN.

> Debug: could not determine whether branch 'main' requires PRs to change code

https://github.com/ossf/scorecard/blob/90a3708b19883d176d84dc23e3b399b53f1ee1e9/docs/checks.md?plain=1#L113-L115

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
I got rid of the `switch` statement since the function is only called by 3 probes, and all of them want that behavior.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
