### PR TITLE
📖docs: Add `.sigstore` bundles to Signed-Releases

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -594,7 +594,7 @@ Signed releases attest to the provenance of the artifact.
 This check looks for the following filenames in the project's last five
 [release assets](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases):
 [*.minisig](https://github.com/jedisct1/minisign), *.asc (pgp),
-*.sig, *.sign, [*.intoto.jsonl](https://slsa.dev).
+*.sig, *.sign, *.sigstore, [*.intoto.jsonl](https://slsa.dev).
 
 If a signature is found in the assets for each release, a score of 8 is given.
 If a [SLSA provenance file](https://slsa.dev/spec/v0.1/index) is found in the assets for each release (*.intoto.jsonl), the maximum score of 10 is given.

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -626,7 +626,7 @@ checks:
       This check looks for the following filenames in the project's last five
       [release assets](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases):
       [*.minisig](https://github.com/jedisct1/minisign), *.asc (pgp),
-      *.sig, *.sign, [*.intoto.jsonl](https://slsa.dev).
+      *.sig, *.sign, *.sigstore, [*.intoto.jsonl](https://slsa.dev).
 
       If a signature is found in the assets for each release, a score of 8 is given.
       If a [SLSA provenance file](https://slsa.dev/spec/v0.1/index) is found in the assets for each release (*.intoto.jsonl), the maximum score of 10 is given.


### PR DESCRIPTION
#### What kind of change does this PR introduce?

docs

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`.sigstore` bundles were added to Signed-Releases check by #3772 but docs weren't updated

#### What is the new behavior (if this is a feature change)?**

Docs will reflect checks as they presently are in `main`

NA - [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #3914

#### Special notes for your reviewer

`checks.yaml` was edited and then `checks.md` was generated with `make generate-docs`, but as it's a trivial change there's no obvious evidence of the docs generation process (which is probably as things should be).

#### Does this PR introduce a user-facing change?

Yes:

```release-note
Document that `.sigstore` bundles are part of check for Signed-Releases
```
