### PR TITLE
:bug: Limit Binary Artifact file reads to first 1024 bytes

### DIFF
--- a/checks/fileparser/listing.go
+++ b/checks/fileparser/listing.go
@@ -64,6 +64,21 @@ type PathMatcher struct {
 	CaseSensitive bool
 }
 
+// DoWhileTrueOnFileReader takes a filepath, its reader and
+// optional variadic args. It returns a boolean indicating whether
+// iterating over next files should continue.
+type DoWhileTrueOnFileReader func(path string, reader io.Reader, args ...interface{}) (bool, error)
+
+// OnMatchingFileReaderDo matches all files listed by `repoClient` against `matchPathTo`
+// and on every successful match, runs onFileReader fn on the file's reader.
+// Continues iterating along the matched files until onFileReader returns
+// either a false value or an error.
+func OnMatchingFileReaderDo(repoClient clients.RepoClient, matchPathTo PathMatcher,
+	onFileReader DoWhileTrueOnFileReader, args ...interface{},
+) error {
+	return onMatchingFileDo(repoClient, matchPathTo, onFileReader, args...)
+}
+
 // DoWhileTrueOnFileContent takes a filepath, its content and
 // optional variadic args. It returns a boolean indicating whether
 // iterating over next files should continue.
@@ -75,6 +90,12 @@ type DoWhileTrueOnFileContent func(path string, content []byte, args ...interfac
 // either a false value or an error.
 func OnMatchingFileContentDo(repoClient clients.RepoClient, matchPathTo PathMatcher,
 	onFileContent DoWhileTrueOnFileContent, args ...interface{},
+) error {
+	return onMatchingFileDo(repoClient, matchPathTo, onFileContent, args...)
+}
+
+func onMatchingFileDo(repoClient clients.RepoClient, matchPathTo PathMatcher,
+	onFile any, args ...interface{},
 ) error {
 	predicate := func(filepath string) (bool, error) {
 		// Filter out test files.
@@ -95,17 +116,28 @@ func OnMatchingFileContentDo(repoClient clients.RepoClient, matchPathTo PathMatc
 	}
 
 	for _, file := range matchedFiles {
-		rc, err := repoClient.GetFileReader(file)
+		reader, err := repoClient.GetFileReader(file)
 		if err != nil {
 			return fmt.Errorf("error during GetFileReader: %w", err)
 		}
-		content, err := io.ReadAll(rc)
-		rc.Close()
-		if err != nil {
-			return fmt.Errorf("reading from file: %w", err)
-		}
 
-		continueIter, err := onFileContent(file, content, args...)
+		var continueIter bool
+		switch f := onFile.(type) {
+		case DoWhileTrueOnFileReader:
+			continueIter, err = f(file, reader, args...)
+			reader.Close()
+		case DoWhileTrueOnFileContent:
+			var content []byte
+			content, err = io.ReadAll(reader)
+			reader.Close()
+			if err != nil {
+				return fmt.Errorf("reading from file: %w", err)
+			}
+			continueIter, err = f(file, content, args...)
+		default:
+			msg := fmt.Sprintf("invalid type (%T) passed to onMatchingFileDo", f)
+			return sce.WithMessage(sce.ErrScorecardInternal, msg)
+		}
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The whole file is read, even though we only use 1024 bytes when determining if a file is text or binary

#### What is the new behavior (if this is a feature change)?**
Only up to the first 1024 bytes are read.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Part 1 of 2 to address #3831
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
