### PR TITLE
:bug: Avoid reading every file searching for sonar configs

### DIFF
--- a/checks/raw/sast.go
+++ b/checks/raw/sast.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"path"
 	"regexp"
 	"strings"
@@ -230,7 +231,8 @@ type sonarConfig struct {
 func getSonarWorkflows(c *checker.CheckRequest) ([]checker.SASTWorkflow, error) {
 	var config []sonarConfig
 	var sastWorkflows []checker.SASTWorkflow
-	err := fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
+	// in the future, we may want to use ListFiles instead, so we don't open every file
+	err := fileparser.OnMatchingFileReaderDo(c.RepoClient, fileparser.PathMatcher{
 		Pattern:       "*",
 		CaseSensitive: false,
 	}, validateSonarConfig, &config)
@@ -255,8 +257,8 @@ func getSonarWorkflows(c *checker.CheckRequest) ([]checker.SASTWorkflow, error) 
 }
 
 // Check file content.
-var validateSonarConfig fileparser.DoWhileTrueOnFileContent = func(pathfn string,
-	content []byte,
+var validateSonarConfig fileparser.DoWhileTrueOnFileReader = func(pathfn string,
+	reader io.Reader,
 	args ...interface{},
 ) (bool, error) {
 	if !strings.EqualFold(path.Base(pathfn), "pom.xml") {
@@ -275,6 +277,10 @@ var validateSonarConfig fileparser.DoWhileTrueOnFileContent = func(pathfn string
 			"validateSonarConfig expects arg[0] of type *[]sonarConfig]: %w", errInvalid)
 	}
 
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return false, fmt.Errorf("read file: %w", err)
+	}
 	regex := regexp.MustCompile(`<sonar\.host\.url>\s*(\S+)\s*<\/sonar\.host\.url>`)
 	match := regex.FindSubmatch(content)
 

--- a/checks/raw/sast.go
+++ b/checks/raw/sast.go
@@ -314,12 +314,11 @@ func findLine(content, data []byte) (uint, error) {
 	r := bytes.NewReader(content)
 	scanner := bufio.NewScanner(r)
 
-	line := 0
-	// https://golang.org/pkg/bufio/#Scanner.Scan
+	var line uint
 	for scanner.Scan() {
 		line++
-		if strings.Contains(scanner.Text(), string(data)) {
-			return uint(line), nil
+		if bytes.Contains(scanner.Bytes(), data) {
+			return line, nil
 		}
 	}
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Every file's whole contents are read. But for any file not called `pom.xml` this is wasted work.

#### What is the new behavior (if this is a feature change)?**
* File content is only read once we know the file is called `pom.xml`
* Changed strings/bytes comparison functions to avoid allocating extra strings. 

- [ ] Tests for the changes have been added (for bug fixes/features)

(should be covered by existing tests)

#### Which issue(s) this PR fixes
Related to #3831 (SAST won't run locally, but this will hopefully save time in the cron)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
