### PR TITLE
:sparkles: Add experimental local OSV mode for cron releasetest worker

### DIFF
--- a/clients/osv.go
+++ b/clients/osv.go
@@ -26,7 +26,9 @@ import (
 
 var _ VulnerabilitiesClient = osvClient{}
 
-type osvClient struct{}
+type osvClient struct {
+	local bool
+}
 
 // ListUnfixedVulnerabilities implements VulnerabilityClient.ListUnfixedVulnerabilities.
 func (v osvClient) ListUnfixedVulnerabilities(
@@ -52,6 +54,9 @@ func (v osvClient) ListUnfixedVulnerabilities(
 		SkipGit:        true,
 		Recursive:      true,
 		GitCommits:     gitCommits,
+		ExperimentalScannerActions: osvscanner.ExperimentalScannerActions{
+			CompareLocally: v.local,
+		},
 	}, nil) // TODO: Do logging?
 
 	response := VulnerabilitiesResponse{}

--- a/clients/vulnerabilities.go
+++ b/clients/vulnerabilities.go
@@ -29,7 +29,17 @@ type VulnerabilitiesClient interface {
 
 // DefaultVulnerabilitiesClient returns a new OSV Vulnerabilities client.
 func DefaultVulnerabilitiesClient() VulnerabilitiesClient {
-	return osvClient{}
+	return osvClient{local: false}
+}
+
+// ExperimentalLocalOSVClient returns an OSV Vulnerabilities client which
+// takes advantage of their experimental local database option. As the
+// osv-scanner feature is experimental, so is our usage of it. This function
+// may be removed without warning.
+//
+// https://google.github.io/osv-scanner/experimental/offline-mode/#local-database-option
+func ExperimentalLocalOSVClient() VulnerabilitiesClient {
+	return osvClient{local: true}
 }
 
 // VulnerabilitiesResponse is the response from the vuln DB.

--- a/cron/internal/worker/main.go
+++ b/cron/internal/worker/main.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"net/http"
 	_ "net/http/pprof" //nolint:gosec
+	"os"
 
 	"go.opencensus.io/stats/view"
 
@@ -129,7 +130,11 @@ func newScorecardWorker() (*ScorecardWorker, error) {
 		return nil, fmt.Errorf("ossfuzz.CreateOSSFuzzClientEager: %w", err)
 	}
 
-	sw.vulnsClient = clients.DefaultVulnerabilitiesClient()
+	if _, enabled := os.LookupEnv("SCORECARD_LOCAL_OSV"); enabled {
+		sw.vulnsClient = clients.ExperimentalLocalOSVClient()
+	} else {
+		sw.vulnsClient = clients.DefaultVulnerabilitiesClient()
+	}
 
 	if sw.exporter, err = startMetricsExporter(); err != nil {
 		return nil, fmt.Errorf("startMetricsExporter: %w", err)

--- a/cron/k8s/worker.release.yaml
+++ b/cron/k8s/worker.release.yaml
@@ -59,6 +59,8 @@ spec:
                   key: auth_token
             - name: "SCORECARD_API_RESULTS_BUCKET_URL"
               value: "gs://ossf-scorecard-cron-releasetest-results"
+            - name: SCORECARD_LOCAL_OSV
+              value: "1"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/scorecard


### PR DESCRIPTION
#### What kind of change does this PR introduce?

cron feature

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
All vuln requests go to osv.dev, which takes time. The vulnerabilities check is a bottleneck for our processing, and the cron has been struggling to complete recently.

#### What is the new behavior (if this is a feature change)?**
the release test cron worker will try using the local DB option for osv-scanner, which you can read about here:
https://github.com/google/osv-scanner/blob/5151082e73f912d203776c0618f50ccef7866219/docs/offline-mode.md#local-database-option

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
