### PR TITLE
:seedling: polish scorecard workflow for use as example workflow

### DIFF
--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -7,8 +7,6 @@ on:
   schedule:
     # Weekly on Saturdays.
     - cron:  '30 1 * * 6'
-#   pull_request:
-#     branches: [main]
 
 permissions: read-all
 
@@ -17,19 +15,22 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      # Needed for Code scanning upload
       security-events: write
+      # Needed for GitHub OIDC token if publish_results is true
       id-token: write
 
     steps:
       - name: "Checkout code"
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          persist-credentials: false
 
       - name: "Run analysis"
         uses: ossf/scorecard-action@0864cf19026789058feabb7e87baa5f140aac736 # v2.3.1
         with:
           results_file: results.sarif
           results_format: sarif
-          repo_token: ${{ secrets.GITHUB_TOKEN }}
           # Scorecard team runs a weekly scan of public GitHub repos,
           # see https://github.com/ossf/scorecard#public-data.
           # Setting `publish_results: true` helps us scale by leveraging your workflow to
@@ -37,16 +38,19 @@ jobs:
           # And it's free for you!
           publish_results: true
 
+      # Upload the results as artifacts (optional). Commenting out will disable
+      # uploads of run results in SARIF format to the repository Actions tab.
       # https://docs.github.com/en/actions/advanced-guides/storing-workflow-data-as-artifacts
-      # Optional.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v3
+        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
         with:
           name: SARIF file
           path: results.sarif
           retention-days: 5
 
-      - name: "Upload SARIF results"
-        uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v1
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@83a02f7883b12e0e4e1a146174f5e2292a01e601 # v2.16.4
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
#### What kind of change does this PR introduce?

workflow update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Some version comments are out of date. 
One actions is out of date

#### What is the new behavior (if this is a feature change)?**
* Adds version comments
* adds some explanatory comments
* deleted `repo_token` arg since it will use the GitHub token by default anyway
* Updates `github/codeql-action/upload-sarif` to the latest release, not sure why dependabot hasn't updated it.

The intent is to use this file as an example for the Scorecard Action repo (see https://github.com/ossf/scorecard-action/pull/1352) so it remains up-to-date through dependabot. Currently the workflow example from the Scorecard Action readme is out of date (see #3968) .

Where possible I tried to make the workflow match our [example](https://github.com/ossf/scorecard-action/blob/5fc43dc5154fb0ce7cc74b6264142ac8621bda1d/README.md#workflow-example), in terms of comments.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Related to #3968 and https://github.com/ossf/scorecard-action/issues/1287
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
