### PR TITLE
:seedling: Bump CodeQL Action version to 3.24.10 and remove whitespace

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # v1
+      uses: github/codeql-action/init@83a02f7883b12e0e4e1a146174f5e2292a01e601 # v2.16.4
       with:
         languages: ${{ matrix.language }}
         queries: +security-extended
@@ -85,7 +85,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@cdcdbb579706841c47f7063dda365e292e5cad7a # v1
+      uses: github/codeql-action/autobuild@83a02f7883b12e0e4e1a146174f5e2292a01e601 # v2.16.4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -99,4 +99,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@cdcdbb579706841c47f7063dda365e292e5cad7a # v1
+      uses: github/codeql-action/analyze@83a02f7883b12e0e4e1a146174f5e2292a01e601 # v2.16.4

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,6 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-
       uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # v1
       with:
         languages: ${{ matrix.language }}

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@423a04bb2cb7cd2643007122588f1387778f14d0 # v3.24.8
+      uses: github/codeql-action/init@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
       with:
         languages: ${{ matrix.language }}
         queries: +security-extended
@@ -85,7 +85,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@423a04bb2cb7cd2643007122588f1387778f14d0 # v3.24.8
+      uses: github/codeql-action/autobuild@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -99,4 +99,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@423a04bb2cb7cd2643007122588f1387778f14d0 # v3.24.8
+      uses: github/codeql-action/analyze@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -73,7 +73,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@83a02f7883b12e0e4e1a146174f5e2292a01e601 # v2.16.4
+      uses: github/codeql-action/init@423a04bb2cb7cd2643007122588f1387778f14d0 # v3.24.8
       with:
         languages: ${{ matrix.language }}
         queries: +security-extended
@@ -85,7 +85,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@83a02f7883b12e0e4e1a146174f5e2292a01e601 # v2.16.4
+      uses: github/codeql-action/autobuild@423a04bb2cb7cd2643007122588f1387778f14d0 # v3.24.8
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -99,4 +99,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@83a02f7883b12e0e4e1a146174f5e2292a01e601 # v2.16.4
+      uses: github/codeql-action/analyze@423a04bb2cb7cd2643007122588f1387778f14d0 # v3.24.8

--- a/.github/workflows/scorecard-analysis.yml
+++ b/.github/workflows/scorecard-analysis.yml
@@ -51,6 +51,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.16.4
+        uses: github/codeql-action/upload-sarif@4355270be187e1b672a7a1c7c7bae5afdc1ab94a # v3.24.10
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

I don't see Dependabot updating the `github/codeql` action in this particular action workflow, though it's updating a) other actions in this workflow and b) `github/codeql` in other actions.

Just a while speculation, but this is the only one with the whitespace between the actual name key and the uses? Just in case, firing this to see if the next Dependabot scan will start patching the codeql action in this file also. (and if so, it may infer a minor text checking bug in the upstream Dependabot algorithm?)

#### What is the new behavior (if this is a feature change)?**

Should allow Dependabot to bump the codeql action in this file.

While here, I also bumped the actions manually to the latest v3.x series (which also includes Node 20, which should help eliminate any actions warnings about Node deprecations).

Note the only other call is this in a different workflow:

https://github.com/ossf/scorecard/blob/e780e089f512f12cd1fc3d090a2424f186ac1a78/.github/workflows/scorecard-analysis.yml#L53-L54

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

An attempt to help dig more into https://github.com/ossf/scorecard-action/pull/1354.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
