### PR TITLE
:book: revert PAT scope change and document Go resources

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,7 @@ project. This document describes the contribution guidelines for the project.
 * [Contributing code](#contributing-code)
   * [Getting started](#getting-started)
   * [Environment Setup](#environment-setup)
+  * [New to Go?](#new-to-go)
 * [Contributing steps](#contributing-steps)
 * [How to build scorecard locally](#how-to-build-scorecard-locally)
 * [PR Process](#pr-process)
@@ -61,6 +62,15 @@ You must install these tools:
 You may need these tools for some tasks:
 
 1.  [`docker`](https://docs.docker.com/engine/install/): `v18.9` or higher.
+
+### New to Go?
+
+If you're unfamiliar with the language, there are plenty of articles, resources, and books.
+We recommend starting with several resources from the official Go website:
+
+* [How to Write Go Code](https://go.dev/doc/code)
+* [A Tour of Go](https://go.dev/tour/)
+* [Effective Go](https://go.dev/doc/effective_go)
 
 ## Contributing steps
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -180,7 +180,9 @@ make fix-linter
 
 ## Permission for GitHub personal access tokens
 
-For public repos, classic personal access tokens do not need any scopes.
+For public repos, classic personal access tokens need the following scopes:
+
+- `public_repo` - Read/write access to public repositories. Needed for branch protection
 
 ## Where the CI Tests are configured
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

docs. 

reverts part of #4002. it turns out `public_repo` scope is needed for branch protection after all.

A few basic Go resources added for contributors unfamiliar with the language

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
