### PR TITLE
:warning: Switch `Outcome` type to string

### DIFF
--- a/finding/finding.go
+++ b/finding/finding.go
@@ -54,43 +54,25 @@ type Location struct {
 }
 
 // Outcome is the result of a finding.
-type Outcome int
+type Outcome string
 
 // TODO(#2928): re-visit the finding definitions.
 const (
-	// NOTE: The additional '_' are intended for future use.
-	// This allows adding outcomes without breaking the values
-	// of existing outcomes.
 	// OutcomeNegative indicates a negative outcome.
-	OutcomeNegative Outcome = iota
-	_
-	_
-	_
+	OutcomeNegative Outcome = "Negative"
 	// OutcomeNotAvailable indicates an unavailable outcome,
 	// typically because an API call did not return an answer.
-	OutcomeNotAvailable
-	_
-	_
-	_
+	OutcomeNotAvailable Outcome = "NotAvailable"
 	// OutcomeError indicates an errors while running.
 	// The results could not be determined.
-	OutcomeError
-	_
-	_
-	_
+	OutcomeError Outcome = "Error"
 	// OutcomePositive indicates a positive outcome.
-	OutcomePositive
-	_
-	_
-	_
+	OutcomePositive Outcome = "Positive"
 	// OutcomeNotSupported indicates a non-supported outcome.
-	OutcomeNotSupported
-	_
-	_
-	_
+	OutcomeNotSupported Outcome = "NotSupported"
 	// OutcomeNotApplicable indicates if a finding should not
 	// be considered in evaluation.
-	OutcomeNotApplicable
+	OutcomeNotApplicable Outcome = "NotApplicable"
 )
 
 // Finding represents a finding.

--- a/pkg/scorecard_test.go
+++ b/pkg/scorecard_test.go
@@ -235,6 +235,7 @@ func TestExperimentalRunProbes(t *testing.T) {
 				Findings: []finding.Finding{
 					{
 						Probe:   fuzzed.Probe,
+						Outcome: finding.OutcomeNegative,
 						Message: "no fuzzer integrations found",
 						Remediation: &probe.Remediation{
 							Effort: probe.RemediationEffortHigh,

--- a/pkg/testdata/probe1.json
+++ b/pkg/testdata/probe1.json
@@ -16,12 +16,12 @@
             },
             "probe": "check for X",
             "message": "found X",
-            "outcome": 12
+            "outcome": "Positive"
         },
         {
             "probe": "check for Y",
             "message": "did not find Y",
-            "outcome": 0
+            "outcome": "Negative"
         }
     ]
 }

--- a/probes/sastToolRunsOnAllCommits/impl_test.go
+++ b/probes/sastToolRunsOnAllCommits/impl_test.go
@@ -36,7 +36,7 @@ func Test_Run(t *testing.T) {
 		expectedFindings []finding.Finding
 	}{
 		{
-			name: "sonar present",
+			name: "any unchecked commits leads to negative outcome",
 			err:  nil,
 			raw: &checker.RawResults{
 				SASTResults: checker.SASTData{
@@ -57,6 +57,7 @@ func Test_Run(t *testing.T) {
 				{
 					Probe:   Probe,
 					Message: "1 commits out of 2 are checked with a SAST tool",
+					Outcome: finding.OutcomeNegative,
 					Values: map[string]string{
 						AnalyzedPRsKey: "1",
 						TotalPRsKey:    "2",
@@ -65,7 +66,7 @@ func Test_Run(t *testing.T) {
 			},
 		},
 		{
-			name: "sonar present",
+			name: "all commits checked is positive outcome",
 			err:  nil,
 			raw: &checker.RawResults{
 				SASTResults: checker.SASTData{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

structured result cleanup which is technically a breaking change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Outcome is an int based type

#### What is the new behavior (if this is a feature change)?**
Outcome is a string based type, which leads to better output format

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Related to https://github.com/ossf/scorecard/issues/2928#issuecomment-2040433089
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
