### PR TITLE
:bug: Signed-Releases: dont warn about signatures if provenance present

### DIFF
--- a/checks/evaluation/signed_releases_test.go
+++ b/checks/evaluation/signed_releases_test.go
@@ -111,42 +111,22 @@ func TestSignedReleases(t *testing.T) {
 		},
 
 		{
-			name: "3 releases. One release has one signed, and one release has two provenance.",
+			name: "3 releases. One release has one signed, and one release has provenance.",
 			findings: []finding.Finding{
 				// Release 1:
-				//     Asset 1:
-				signedProbe(release0, asset0, finding.OutcomeFalse),
-				provenanceProbe(release0, asset0, finding.OutcomeFalse),
-				//     Asset 2:
 				signedProbe(release0, asset1, finding.OutcomeTrue),
-				provenanceProbe(release0, asset1, finding.OutcomeFalse),
+				provenanceProbe(release0, asset0, finding.OutcomeFalse),
 				// Release 2
-				//     Asset 1:
 				signedProbe(release1, asset0, finding.OutcomeFalse),
 				provenanceProbe(release1, asset0, finding.OutcomeFalse),
-				// Release 2
-				//     Asset 2:
-				signedProbe(release1, asset1, finding.OutcomeFalse),
-				provenanceProbe(release1, asset1, finding.OutcomeFalse),
-				// Release 2
-				//     Asset 3:
-				signedProbe(release1, asset2, finding.OutcomeFalse),
-				provenanceProbe(release1, asset2, finding.OutcomeFalse),
 				// Release 3
-				//     Asset 1:
 				signedProbe(release2, asset0, finding.OutcomeFalse),
-				provenanceProbe(release2, asset0, finding.OutcomeTrue),
-				//     Asset 2:
-				signedProbe(release2, asset1, finding.OutcomeFalse),
 				provenanceProbe(release2, asset1, finding.OutcomeTrue),
-				//     Asset 3:
-				signedProbe(release2, asset2, finding.OutcomeFalse),
-				provenanceProbe(release2, asset2, finding.OutcomeFalse),
 			},
 			result: scut.TestReturn{
 				Score:         6,
-				NumberOfInfo:  3,
-				NumberOfWarn:  13,
+				NumberOfInfo:  2,
+				NumberOfWarn:  4,
 				NumberOfDebug: 3,
 			},
 		},
@@ -154,56 +134,25 @@ func TestSignedReleases(t *testing.T) {
 			name: "5 releases. Two releases have one signed each, and two releases have one provenance each.",
 			findings: []finding.Finding{
 				// Release 1:
-				// Release 1, Asset 1:
-				signedProbe(release0, asset0, finding.OutcomeFalse),
-				provenanceProbe(release0, asset0, finding.OutcomeFalse),
 				signedProbe(release0, asset1, finding.OutcomeTrue),
 				provenanceProbe(release0, asset1, finding.OutcomeFalse),
 				// Release 2:
-				// Release 2, Asset 1:
-				signedProbe(release1, asset1, finding.OutcomeTrue),
+				signedProbe(release1, asset0, finding.OutcomeTrue),
 				provenanceProbe(release1, asset0, finding.OutcomeFalse),
-				// Release 2, Asset 2:
-				signedProbe(release1, asset1, finding.OutcomeFalse),
-				provenanceProbe(release1, asset1, finding.OutcomeFalse),
-				// Release 2, Asset 3:
-				signedProbe(release1, asset2, finding.OutcomeFalse),
-				provenanceProbe(release1, asset2, finding.OutcomeFalse),
-				// Release 3, Asset 1:
+				// Release 3:
 				signedProbe(release2, asset0, finding.OutcomeFalse),
 				provenanceProbe(release2, asset0, finding.OutcomeTrue),
-				// Release 3, Asset 2:
-				signedProbe(release2, asset1, finding.OutcomeFalse),
-				provenanceProbe(release2, asset1, finding.OutcomeFalse),
-				// Release 3, Asset 3:
-				signedProbe(release2, asset2, finding.OutcomeFalse),
-				provenanceProbe(release2, asset2, finding.OutcomeFalse),
 				// Release 4, Asset 1:
 				signedProbe(release3, asset0, finding.OutcomeFalse),
 				provenanceProbe(release3, asset0, finding.OutcomeTrue),
-				// Release 4, Asset 2:
-				signedProbe(release3, asset1, finding.OutcomeFalse),
-				provenanceProbe(release3, asset1, finding.OutcomeFalse),
-				// Release 4, Asset 3:
-				signedProbe(release3, asset2, finding.OutcomeFalse),
-				provenanceProbe(release3, asset2, finding.OutcomeFalse),
 				// Release 5, Asset 1:
 				signedProbe(release4, asset0, finding.OutcomeFalse),
 				provenanceProbe(release4, asset0, finding.OutcomeFalse),
-				// Release 5, Asset 2:
-				signedProbe(release4, asset1, finding.OutcomeFalse),
-				provenanceProbe(release4, asset1, finding.OutcomeFalse),
-				// Release 5, Asset 3:
-				signedProbe(release4, asset2, finding.OutcomeFalse),
-				provenanceProbe(release4, asset2, finding.OutcomeFalse),
-				// Release 5, Asset 4:
-				signedProbe(release4, asset3, finding.OutcomeFalse),
-				provenanceProbe(release4, asset3, finding.OutcomeFalse),
 			},
 			result: scut.TestReturn{
 				Score:         7,
 				NumberOfInfo:  4,
-				NumberOfWarn:  26,
+				NumberOfWarn:  6,
 				NumberOfDebug: 5,
 			},
 		},
@@ -211,61 +160,30 @@ func TestSignedReleases(t *testing.T) {
 			name: "5 releases. All have one signed artifact.",
 			findings: []finding.Finding{
 				// Release 1:
-				// Release 1, Asset 1:
-				signedProbe(release0, asset0, finding.OutcomeFalse),
-				provenanceProbe(release0, asset0, finding.OutcomeFalse),
 				signedProbe(release0, asset1, finding.OutcomeTrue),
 				provenanceProbe(release0, asset1, finding.OutcomeFalse),
 				// Release 2:
-				// Release 2, Asset 1:
 				signedProbe(release1, asset0, finding.OutcomeTrue),
 				provenanceProbe(release1, asset0, finding.OutcomeFalse),
-				// Release 2, Asset 2:
-				signedProbe(release1, asset1, finding.OutcomeFalse),
-				provenanceProbe(release1, asset1, finding.OutcomeFalse),
-				// Release 2, Asset 3:
-				signedProbe(release1, asset2, finding.OutcomeFalse),
-				provenanceProbe(release1, asset2, finding.OutcomeFalse),
-				// Release 3, Asset 1:
+				// Release 3:
 				signedProbe(release2, asset0, finding.OutcomeTrue),
-				provenanceProbe(release2, asset0, finding.OutcomeTrue),
-				// Release 3, Asset 2:
-				signedProbe(release2, asset1, finding.OutcomeFalse),
-				provenanceProbe(release2, asset1, finding.OutcomeFalse),
-				// Release 3, Asset 3:
-				signedProbe(release2, asset2, finding.OutcomeFalse),
-				provenanceProbe(release2, asset2, finding.OutcomeFalse),
-				// Release 4, Asset 1:
+				provenanceProbe(release2, asset0, finding.OutcomeFalse),
+				// Release 4:
 				signedProbe(release3, asset0, finding.OutcomeTrue),
-				provenanceProbe(release3, asset0, finding.OutcomeTrue),
-				// Release 4, Asset 2:
-				signedProbe(release3, asset1, finding.OutcomeFalse),
-				provenanceProbe(release3, asset1, finding.OutcomeFalse),
-				// Release 4, Asset 3:
-				signedProbe(release3, asset2, finding.OutcomeFalse),
-				provenanceProbe(release3, asset2, finding.OutcomeFalse),
-				// Release 5, Asset 1:
+				provenanceProbe(release3, asset0, finding.OutcomeFalse),
+				// Release 5:
 				signedProbe(release4, asset0, finding.OutcomeTrue),
 				provenanceProbe(release4, asset0, finding.OutcomeFalse),
-				// Release 5, Asset 2:
-				signedProbe(release4, asset1, finding.OutcomeFalse),
-				provenanceProbe(release4, asset1, finding.OutcomeFalse),
-				// Release 5, Asset 3:
-				signedProbe(release4, asset2, finding.OutcomeFalse),
-				provenanceProbe(release4, asset2, finding.OutcomeFalse),
-				// Release 5, Asset 4:
-				signedProbe(release4, asset3, finding.OutcomeFalse),
-				provenanceProbe(release4, asset3, finding.OutcomeFalse),
 			},
 			result: scut.TestReturn{
 				Score:         8,
-				NumberOfInfo:  7,
-				NumberOfWarn:  23,
+				NumberOfInfo:  5,
+				NumberOfWarn:  5,
 				NumberOfDebug: 5,
 			},
 		},
 		{
-			name: "too many releases (6 when lookback is 5)",
+			name: "too many releases is an error (6 when lookback is 5)",
 			findings: []finding.Finding{
 				// Release 1:
 				// Release 1, Asset 1:

--- a/checks/evaluation/signed_releases_test.go
+++ b/checks/evaluation/signed_releases_test.go
@@ -105,7 +105,7 @@ func TestSignedReleases(t *testing.T) {
 			result: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
-				NumberOfWarn:  1,
+				NumberOfWarn:  0,
 				NumberOfDebug: 1,
 			},
 		},
@@ -126,7 +126,7 @@ func TestSignedReleases(t *testing.T) {
 			result: scut.TestReturn{
 				Score:         6,
 				NumberOfInfo:  2,
-				NumberOfWarn:  4,
+				NumberOfWarn:  3,
 				NumberOfDebug: 3,
 			},
 		},
@@ -152,7 +152,7 @@ func TestSignedReleases(t *testing.T) {
 			result: scut.TestReturn{
 				Score:         7,
 				NumberOfInfo:  4,
-				NumberOfWarn:  6,
+				NumberOfWarn:  4,
 				NumberOfDebug: 5,
 			},
 		},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix I guess?

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

After the Signed-Releases probe conversion (#3610), we started generating warns for not having a signature file, even though we had a provenance and were scoring a 10/10. This doesn't match what we did in v4.13.1, so correcting before the next release.

For `ossf/scorecard` for example:

```
"Warn: release artifact v4.13.1 not signed: <asset link>",
"Warn: release artifact v4.13.0 not signed: <asset link>",
"Warn: release artifact v4.12.0 not signed: <asset link>",
"Warn: release artifact v4.11.0 not signed: <asset link>",
"Warn: release artifact v4.10.5 not signed: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>"
```

#### What is the new behavior (if this is a feature change)?**

Suppress warnings for not having a signed release artifact if the same release has provenance. 

```
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>",
"Info: provenance for release artifact: multiple.intoto.jsonl: <asset link>"
```

I also simplified the existing tests in 6d18776774c086992edb14f9824e27d3100ce9da first because they didnt represent how many findings get generated, and it caused so many infos/warns it was hard to reason about the tests.

So when you look at the test diff for the second commit (b9d51bbb805df20d5595767c3f3dda761c9494c3), the reduction in Warn messages corresponds to the number of releases which have provenance but dont have a signature file.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE (preparing for release)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
