### PR TITLE
:bug: Token-Permissions: use same text for read token details as write token details

### DIFF
--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -29,6 +29,8 @@ import (
 var errNoReleaseFound = errors.New("no release found")
 
 // SignedReleases applies the score policy for the Signed-Releases check.
+//
+//nolint:gocognit // surpressing for now
 func SignedReleases(name string,
 	findings []finding.Finding, dl checker.DetailLogger,
 ) checker.CheckResult {

--- a/probes/internal/utils/permissions/permissions.go
+++ b/probes/internal/utils/permissions/permissions.go
@@ -90,11 +90,13 @@ func ReadTrueLevelFinding(probe string,
 	r checker.TokenPermission,
 	metadata map[string]string,
 ) (*finding.Finding, error) {
-	f, err := finding.NewWith(fs, probe,
-		"found token with 'read' permissions",
-		nil, finding.OutcomeTrue)
+	text, err := createText(r)
 	if err != nil {
-		return nil, fmt.Errorf("%w", err)
+		return nil, err
+	}
+	f, err := finding.NewWith(fs, probe, text, nil, finding.OutcomeTrue)
+	if err != nil {
+		return nil, fmt.Errorf("create finding: %w", err)
 	}
 	if r.File != nil {
 		f = f.WithLocation(r.File.Location())


### PR DESCRIPTION
#### What kind of change does this PR introduce?

 bug fix? This was an unintentional regression from v4.13.1

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The detail used to (v4.13.1) say something like:
```
"topLevel 'pull-requests' permission set to 'read'"
```

But the conversion PR (#3816) replaced the individual scopes with a generic message:
```
"found token with 'read' permissions"
```

#### What is the new behavior (if this is a feature change)?**

Read permissions findings use the same text helper function that write permission findings do, which matches what v4.13.1 did.

```
"topLevel 'pull-requests' permission set to 'read'"
```



- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE (preparing for release)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
