### PR TITLE
:warning: remove experimental gate from `probe` format

### DIFF
--- a/options/options.go
+++ b/options/options.go
@@ -79,13 +79,8 @@ const (
 	// Formats.
 	// FormatJSON specifies that results should be output in JSON format.
 	FormatJSON = "json"
-	// FormatFJSON specifies that results should be output in JSON format,
-	// but with structured findings.
-	FormatFJSON = "finding"
-	// FormatPJSON specifies that results should be output in probe JSON format.
-	FormatPJSON = "probe"
-	// FormatSJSON specifies that results should be output in structured JSON format.
-	FormatSJSON = "structured"
+	// FormatProbe specifies that results should be output in probe JSON format.
+	FormatProbe = "probe"
 	// FormatSarif specifies that results should be output in SARIF format.
 	FormatSarif = "sarif"
 	// FormatDefault specifies that results should be output in default format.
@@ -161,17 +156,6 @@ func (o *Options) Validate() error {
 			errs = append(
 				errs,
 				errRawOptionNotSupported,
-			)
-		}
-	}
-
-	if !o.isExperimentalEnabled() {
-		if o.Format == FormatSJSON ||
-			o.Format == FormatFJSON ||
-			o.Format == FormatPJSON {
-			errs = append(
-				errs,
-				errFormatSupportedWithExperimental,
 			)
 		}
 	}
@@ -269,8 +253,7 @@ func (o *Options) isV6Enabled() bool {
 
 func validateFormat(format string) bool {
 	switch format {
-	case FormatJSON, FormatSJSON, FormatFJSON,
-		FormatPJSON, FormatSarif, FormatDefault, FormatRaw:
+	case FormatJSON, FormatProbe, FormatSarif, FormatDefault, FormatRaw:
 		return true
 	default:
 		return false

--- a/options/options.go
+++ b/options/options.go
@@ -104,12 +104,11 @@ var (
 	// DefaultLogLevel retrieves the default log level.
 	DefaultLogLevel = sclog.DefaultLevel.String()
 
-	errCommitIsEmpty                   = errors.New("commit should be non-empty")
-	errFormatNotSupported              = errors.New("unsupported format")
-	errFormatSupportedWithExperimental = errors.New("format supported only with SCORECARD_EXPERIMENTAL=1")
-	errPolicyFileNotSupported          = errors.New("policy file is not supported yet")
-	errRawOptionNotSupported           = errors.New("raw option is not supported yet")
-	errRepoOptionMustBeSet             = errors.New(
+	errCommitIsEmpty          = errors.New("commit should be non-empty")
+	errFormatNotSupported     = errors.New("unsupported format")
+	errPolicyFileNotSupported = errors.New("policy file is not supported yet")
+	errRawOptionNotSupported  = errors.New("raw option is not supported yet")
+	errRepoOptionMustBeSet    = errors.New(
 		"exactly one of `repo`, `npm`, `pypi`, `rubygems`, `nuget` or `local` must be set",
 	)
 	errSARIFNotSupported = errors.New("SARIF format is not supported yet")
@@ -227,13 +226,6 @@ func (o *Options) Checks() []string {
 
 func (o *Options) Probes() []string {
 	return o.ProbesToRun
-}
-
-// isExperimentalEnabled returns true if experimental features were enabled via
-// environment variable.
-func (o *Options) isExperimentalEnabled() bool {
-	value, _ := os.LookupEnv(EnvVarScorecardExperimental)
-	return value == "1"
 }
 
 // isSarifEnabled returns true if SARIF format was specified in options or via

--- a/pkg/probe.go
+++ b/pkg/probe.go
@@ -37,9 +37,9 @@ type ProbeResultOption struct {
 	Indent string
 }
 
-// AsPJSON writes results as JSON for flat findings without checks.
+// AsProbe writes results as JSON for flat findings without checks.
 // It accepts an optional argument to configure the output.
-func (r *ScorecardResult) AsPJSON(writer io.Writer, o *ProbeResultOption) error {
+func (r *ScorecardResult) AsProbe(writer io.Writer, o *ProbeResultOption) error {
 	encoder := json.NewEncoder(writer)
 	out := JSONScorecardProbeResult{
 		Repo: jsonRepoV2{

--- a/pkg/probe_test.go
+++ b/pkg/probe_test.go
@@ -25,7 +25,7 @@ import (
 	"github.com/ossf/scorecard/v4/finding"
 )
 
-func Test_AsPJSON(t *testing.T) {
+func TestAsProbe(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name     string
@@ -76,8 +76,8 @@ func Test_AsPJSON(t *testing.T) {
 			}
 
 			var result bytes.Buffer
-			if err = tt.result.AsPJSON(&result, opt); err != nil {
-				t.Fatalf("AsPJSON: %v", err)
+			if err = tt.result.AsProbe(&result, opt); err != nil {
+				t.Fatalf("AsProbe: %v", err)
 			}
 
 			if diff := cmp.Diff(expected, result.Bytes()); diff != "" {

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -31,7 +30,6 @@ import (
 	sce "github.com/ossf/scorecard/v4/errors"
 	"github.com/ossf/scorecard/v4/finding"
 	proberegistration "github.com/ossf/scorecard/v4/internal/probes"
-	"github.com/ossf/scorecard/v4/options"
 )
 
 // errEmptyRepository indicates the repository is empty.
@@ -162,13 +160,9 @@ func runScorecard(ctx context.Context,
 	// If the user runs checks
 	go runEnabledChecks(ctx, repo, request, checksToRun, resultsCh)
 
-	exposeFindings := os.Getenv(options.EnvVarScorecardExperimental) == "1"
 	for result := range resultsCh {
 		ret.Checks = append(ret.Checks, result)
-
-		if exposeFindings {
-			ret.Findings = append(ret.Findings, result.Findings...)
-		}
+		ret.Findings = append(ret.Findings, result.Findings...)
 	}
 	return ret, nil
 }

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -137,7 +137,7 @@ func FormatResults(
 		err = results.AsJSON2(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, output)
 	case options.FormatProbe:
 		var opts *ProbeResultOption
-		err = results.AsPJSON(output, opts)
+		err = results.AsProbe(output, opts)
 	case options.FormatRaw:
 		err = results.AsRawJSON(output)
 	default:

--- a/pkg/scorecard_result.go
+++ b/pkg/scorecard_result.go
@@ -135,9 +135,7 @@ func FormatResults(
 		err = results.AsSARIF(opts.ShowDetails, log.ParseLevel(opts.LogLevel), output, doc, policy, opts)
 	case options.FormatJSON:
 		err = results.AsJSON2(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, output)
-	case options.FormatFJSON:
-		err = results.AsFJSON(opts.ShowDetails, log.ParseLevel(opts.LogLevel), doc, output)
-	case options.FormatPJSON:
+	case options.FormatProbe:
 		var opts *ProbeResultOption
 		err = results.AsPJSON(output, opts)
 	case options.FormatRaw:


### PR DESCRIPTION

#### What kind of change does this PR introduce?

feature and breaking change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
`--format probe` is  gated behind `SCORECARD_EXPERIMENTAL=1`

#### What is the new behavior (if this is a feature change)?**

- `--format probe` is no longer gated behind `SCORECARD_EXPERIMENTAL=1`
- Also delete finding and structured results formats as they weren't used

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE (prepping for release)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
A new --format option "probe" is available.
```
