### PR TITLE
:sparkles: allow probes to collect their own data from repo clients

### DIFF
--- a/internal/probes/probes_test.go
+++ b/internal/probes/probes_test.go
@@ -27,6 +27,10 @@ func emptyImpl(r *checker.RawResults) ([]finding.Finding, string, error) {
 	return nil, "", nil
 }
 
+func emptyIndependentImpl(c *checker.CheckRequest) ([]finding.Finding, string, error) {
+	return nil, "", nil
+}
+
 var (
 	p1 = Probe{
 		Name:            "someProbe1",
@@ -81,6 +85,14 @@ func Test_register(t *testing.T) {
 				Name:            "foo",
 				Implementation:  emptyImpl,
 				RequiredRawData: []CheckName{BinaryArtifacts},
+			},
+			wantErr: false,
+		},
+		{
+			name: "independent probe registration",
+			probe: Probe{
+				Name:                      "bar",
+				IndependentImplementation: emptyIndependentImpl,
 			},
 			wantErr: false,
 		},

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -207,7 +207,12 @@ func runEnabledProbes(request *checker.CheckRequest,
 			return fmt.Errorf("getting probe %q: %w", probeName, err)
 		}
 		// Run probe
-		findings, _, err := probe.Implementation(&ret.RawResults)
+		var findings []finding.Finding
+		if probe.IndependentImplementation != nil {
+			findings, _, err = probe.IndependentImplementation(request)
+		} else {
+			findings, _, err = probe.Implementation(&ret.RawResults)
+		}
 		if err != nil {
 			return sce.WithMessage(sce.ErrScorecardInternal, "ending run")
 		}

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -66,6 +66,9 @@ import (
 // ProbeImpl is the implementation of a probe.
 type ProbeImpl func(*checker.RawResults) ([]finding.Finding, string, error)
 
+// IndependentProbeImpl is the implementation of an independent probe.
+type IndependentProbeImpl func(*checker.CheckRequest) ([]finding.Finding, string, error)
+
 var (
 	// All represents all the probes.
 	All []ProbeImpl
@@ -160,6 +163,9 @@ var (
 		codeReviewOneReviewers.Run,
 		hasBinaryArtifacts.Run,
 	}
+
+	// Probes which don't use pre-computed raw data but rather collect it themselves.
+	Independent = []IndependentProbeImpl{}
 )
 
 //nolint:gochecknoinits


### PR DESCRIPTION
#### What kind of change does this PR introduce?

feature

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
probes must have the data they rely on in some check's raw result

#### What is the new behavior (if this is a feature change)?**
* introduce "independent" probes which fetch data directly from the repo client
* Allow these probes to run when specified via `--probe`
  * since this is only for probes which don't belong to checks, the logic around running probes from the various `check/*.go` functions doesn't need modified

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #3235

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
