### PR TITLE
:bug: fix signed-releases lookback limit precedence

### DIFF
--- a/probes/releasesAreSigned/impl.go
+++ b/probes/releasesAreSigned/impl.go
@@ -53,12 +53,12 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 
 	totalReleases := 0
 	for releaseIndex, release := range releases {
-		if len(release.Assets) == 0 {
-			continue
-		}
-
 		if releaseIndex == releaseLookBack {
 			break
+		}
+
+		if len(release.Assets) == 0 {
+			continue
 		}
 
 		totalReleases++

--- a/probes/releasesAreSigned/impl.go
+++ b/probes/releasesAreSigned/impl.go
@@ -53,7 +53,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 
 	totalReleases := 0
 	for releaseIndex, release := range releases {
-		if releaseIndex == releaseLookBack {
+		if releaseIndex >= releaseLookBack {
 			break
 		}
 

--- a/probes/releasesAreSigned/impl_test.go
+++ b/probes/releasesAreSigned/impl_test.go
@@ -189,6 +189,30 @@ func Test_Run(t *testing.T) {
 				finding.OutcomeTrue,
 			},
 		},
+		{
+			// https://github.com/ossf/scorecard/issues/4059
+			name: "lookback cutoff not skipped if 6th release has no assets",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						release("v0.8.5"),
+						release("v0.8.4"),
+						release("v0.8.3"),
+						release("v0.8.2"),
+						release("v0.8.1"),
+						releaseNoAssets("v0.8.0"),
+						release("v0.7.0"),
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below
@@ -249,5 +273,14 @@ func release(version string) clients.Release {
 				URL:  fmt.Sprintf("https://github.com/test/repo/releases/%s/%s_windows_x86_64.tar.gz", version, version),
 			},
 		},
+	}
+}
+
+func releaseNoAssets(version string) clients.Release {
+	return clients.Release{
+		TagName:         version,
+		URL:             fmt.Sprintf("https://github.com/test/test_artifact/releases/tag/%s", version),
+		TargetCommitish: "master",
+		Assets:          []clients.ReleaseAsset{},
 	}
 }

--- a/probes/releasesHaveProvenance/impl.go
+++ b/probes/releasesHaveProvenance/impl.go
@@ -56,11 +56,11 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 
 	for i := range releases {
 		release := releases[i]
-		if len(release.Assets) == 0 {
-			continue
-		}
 		if i == releaseLookBack {
 			break
+		}
+		if len(release.Assets) == 0 {
+			continue
 		}
 		totalReleases++
 		hasProvenance := false

--- a/probes/releasesHaveProvenance/impl.go
+++ b/probes/releasesHaveProvenance/impl.go
@@ -56,7 +56,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 
 	for i := range releases {
 		release := releases[i]
-		if i == releaseLookBack {
+		if i >= releaseLookBack {
 			break
 		}
 		if len(release.Assets) == 0 {

--- a/probes/releasesHaveProvenance/impl_test.go
+++ b/probes/releasesHaveProvenance/impl_test.go
@@ -217,6 +217,75 @@ func Test_Run(t *testing.T) {
 				finding.OutcomeTrue,
 			},
 		},
+		{
+			// https://github.com/ossf/scorecard/issues/4059
+			name: "lookback cutoff not skipped if 6th release has no assets",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						{
+							TagName: "v7.0",
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+								{Name: "binary.tar.gz.sig"},
+								{Name: "binary.tar.gz.intoto.jsonl"},
+							},
+						},
+						{
+							TagName: "v6.0",
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+								{Name: "binary.tar.gz.sig"},
+								{Name: "binary.tar.gz.intoto.jsonl"},
+							},
+						},
+						{
+							TagName: "v5.0",
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+								{Name: "binary.tar.gz.sig"},
+								{Name: "binary.tar.gz.intoto.jsonl"},
+							},
+						},
+						{
+							TagName: "v4.0",
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+								{Name: "binary.tar.gz.sig"},
+								{Name: "binary.tar.gz.intoto.jsonl"},
+							},
+						},
+						{
+							TagName: "v3.0",
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+								{Name: "binary.tar.gz.sig"},
+								{Name: "binary.tar.gz.intoto.jsonl"},
+							},
+						},
+						{
+							TagName: "v2.0",
+							Assets:  []clients.ReleaseAsset{},
+						},
+						{
+							TagName: "v1.0",
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+								{Name: "binary.tar.gz.sig"},
+								{Name: "binary.tar.gz.intoto.jsonl"},
+							},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+			},
+		},
 	}
 	for _, tt := range tests {
 		tt := tt // Re-initializing variable so it is not changed while executing the closure below


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
if the 6th release had no assets, the lookback limit exit condition was being skipped. This led to scenarios where too many releases were being considered by the Signed-Releases check.

#### What is the new behavior (if this is a feature change)?**
The lookback exit condition is now the first thing performed.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #4059

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Fixed a Signed-Releases bug where more releases were being analyzed than intended.
```
