### PR TITLE
:seedling: Enable dependabot multi-directory updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,15 +1,9 @@
 version: 2
 updates:
 - package-ecosystem: gomod
-  directory: "/"
-  schedule:
-    interval: daily
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-  open-pull-requests-limit: 3
-- package-ecosystem: gomod
-  directory: "/tools"
+  directories:
+    - "/"
+    - "/tools"
   schedule:
     interval: daily
   rebase-strategy: disabled

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -27,58 +27,15 @@ updates:
         - "arduino/setup-protoc"
         - "goreleaser/goreleaser-action"
 - package-ecosystem: docker
-  directory: "/"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-  open-pull-requests-limit: 3
-- package-ecosystem: docker
-  directory: "/cron/internal/bq"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-  open-pull-requests-limit: 3
-- package-ecosystem: docker
-  directory: "/cron/internal/worker"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/cron/internal/webhook"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/cron/internal/controller"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/cron/internal/cii"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/clients/githubrepo/roundtripper/tokens/server"
-  schedule:
-    interval: weekly
-  rebase-strategy: disabled
-  commit-message:
-      prefix: ":seedling:"
-- package-ecosystem: docker
-  directory: "/attestor"
+  directories:
+    - "/"
+    - "/cron/internal/bq"
+    - "/cron/internal/worker"
+    - "/cron/internal/webhook"
+    - "/cron/internal/controller"
+    - "/cron/internal/cii"
+    - "/clients/githubrepo/roundtripper/tokens/server"
+    - "/attestor"
   schedule:
     interval: weekly
   rebase-strategy: disabled


### PR DESCRIPTION
#### What kind of change does this PR introduce?

ci update

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- We get multiple PRs for the same update, across multiple PRs
  - Go example:
    - #4056
    - #4058 
  - Docker example:
    - #4007
    -  #4008
    -  #4009
    -  #4010
    -  #4011
    - #4012
    -  #4013
    -  #4014

#### What is the new behavior (if this is a feature change)?**

We use dependabot's new beta feature: 
https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/

this does not group all Go updates, or all Docker updates. But for any single updates to these dependencies that exist in multiple lockfiles, they will all be updated in 1 PR.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
