### PR TITLE
🌱  Update Binary-Artifacts and License checks

### DIFF
--- a/checks/binary_artifact_test.go
+++ b/checks/binary_artifact_test.go
@@ -16,15 +16,14 @@ package checks
 
 import (
 	"context"
-	"errors"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 
 	"github.com/ossf/scorecard/v5/checker"
-	"github.com/ossf/scorecard/v5/clients"
-	"github.com/ossf/scorecard/v5/clients/localdir"
-	"github.com/ossf/scorecard/v5/log"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
 	scut "github.com/ossf/scorecard/v5/utests"
 )
 
@@ -58,28 +57,36 @@ func TestBinaryArtifacts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := log.NewLogger(log.DebugLevel)
+			// logger := log.NewLogger(log.DebugLevel)
 
 			// TODO: Use gMock instead of Localdir here.
 			ctrl := gomock.NewController(t)
-			repo, err := localdir.MakeLocalDirRepo(tt.inputFolder)
 
-			if !errors.Is(err, tt.err) {
-				t.Errorf("MakeLocalDirRepo: %v, expected %v", err, tt.err)
-			}
+			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+			mockRepoClient.EXPECT().ListFiles(gomock.Any()).DoAndReturn(func(predicate func(string) (bool, error)) ([]string, error) {
+				var files []string
+				dirFiles, err := os.ReadDir(tt.inputFolder)
+				if err == nil {
+					for _, file := range dirFiles {
+						files = append(files, file.Name())
+					}
+					print(files)
+				}
+				return files, err
+			}).AnyTimes()
+
+			mockRepoClient.EXPECT().GetFileReader(gomock.Any()).DoAndReturn(func(file string) (io.ReadCloser, error) {
+				return os.Open("./" + tt.inputFolder + "/" + file)
+			}).AnyTimes()
 
 			ctx := context.Background()
-
-			client := localdir.CreateLocalDirClient(ctx, logger)
-			if err := client.InitRepo(repo, clients.HeadSHA, 0); err != nil {
-				t.Errorf("InitRepo: %v", err)
-			}
 
 			dl := scut.TestDetailLogger{}
 
 			req := checker.CheckRequest{
 				Ctx:        ctx,
-				RepoClient: client,
+				RepoClient: mockRepoClient,
 				Dlogger:    &dl,
 			}
 

--- a/checks/binary_artifact_test.go
+++ b/checks/binary_artifact_test.go
@@ -33,22 +33,26 @@ func TestBinaryArtifacts(t *testing.T) {
 		name        string
 		inputFolder string
 		err         error
-		expected    checker.CheckResult
+		expected    scut.TestReturn
 	}{
 		{
 			name:        "Jar file",
 			inputFolder: "testdata/binaryartifacts/jars",
 			err:         nil,
-			expected: checker.CheckResult{
-				Score: 8,
+			expected: scut.TestReturn{
+				Score:        8,
+				NumberOfInfo: 0,
+				NumberOfWarn: 2,
 			},
 		},
 		{
 			name:        "non binary file",
 			inputFolder: "testdata/licensedir/withlicense",
 			err:         nil,
-			expected: checker.CheckResult{
-				Score: 10,
+			expected: scut.TestReturn{
+				Score:        checker.MaxResultScore,
+				NumberOfInfo: 0,
+				NumberOfWarn: 0,
 			},
 		},
 	}
@@ -57,9 +61,6 @@ func TestBinaryArtifacts(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			// logger := log.NewLogger(log.DebugLevel)
-
-			// TODO: Use gMock instead of Localdir here.
 			ctrl := gomock.NewController(t)
 
 			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
@@ -91,9 +92,8 @@ func TestBinaryArtifacts(t *testing.T) {
 			}
 
 			result := BinaryArtifacts(&req)
-			if result.Score != tt.expected.Score {
-				t.Errorf("BinaryArtifacts: %v, expected %v for tests %v", result.Score, tt.expected.Score, tt.name)
-			}
+
+			scut.ValidateTestReturn(t, tt.name, &tt.expected, &result, &dl)
 
 			ctrl.Finish()
 		})

--- a/checks/license_test.go
+++ b/checks/license_test.go
@@ -86,7 +86,7 @@ func TestLicenseFileSubdirectory(t *testing.T) {
 				return os.Open("./" + tt.inputFolder + "/" + file)
 			}).AnyTimes()
 
-			//Currently the check itself handles this error gracefully,
+			// Currently the check itself handles this error gracefully,
 			//     searching through the directory to find the license file(s)
 			//     if that functionality is ever changed, this mock needs to be updated accordingly
 			mockRepoClient.EXPECT().ListLicenses().Return(nil, fmt.Errorf("ListLicenses: %w", clients.ErrUnsupportedFeature)).AnyTimes()

--- a/checks/license_test.go
+++ b/checks/license_test.go
@@ -86,7 +86,9 @@ func TestLicenseFileSubdirectory(t *testing.T) {
 				return os.Open("./" + tt.inputFolder + "/" + file)
 			}).AnyTimes()
 
-			// mock based on localDir
+			//Currently the check itself handles this error gracefully,
+			//     searching through the directory to find the license file(s)
+			//     if that functionality is ever changed, this mock needs to be updated accordingly
 			mockRepoClient.EXPECT().ListLicenses().Return(nil, fmt.Errorf("ListLicenses: %w", clients.ErrUnsupportedFeature)).AnyTimes()
 
 			ctx := context.Background()

--- a/checks/license_test.go
+++ b/checks/license_test.go
@@ -16,15 +16,16 @@ package checks
 
 import (
 	"context"
-	"errors"
+	"fmt"
+	"io"
+	"os"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 
 	"github.com/ossf/scorecard/v5/checker"
-	"github.com/ossf/scorecard/v5/clients"
-	"github.com/ossf/scorecard/v5/clients/localdir"
-	"github.com/ossf/scorecard/v5/log"
+	clients "github.com/ossf/scorecard/v5/clients"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
 	scut "github.com/ossf/scorecard/v5/utests"
 )
 
@@ -66,28 +67,35 @@ func TestLicenseFileSubdirectory(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			logger := log.NewLogger(log.DebugLevel)
-
-			// TODO: Use gMock instead of Localdir here.
 			ctrl := gomock.NewController(t)
-			repo, err := localdir.MakeLocalDirRepo(tt.inputFolder)
+			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
 
-			if !errors.Is(err, tt.err) {
-				t.Errorf("MakeLocalDirRepo: %v, expected %v", err, tt.err)
-			}
+			mockRepoClient.EXPECT().ListFiles(gomock.Any()).DoAndReturn(func(predicate func(string) (bool, error)) ([]string, error) {
+				var files []string
+				dirFiles, err := os.ReadDir(tt.inputFolder)
+				if err == nil {
+					for _, file := range dirFiles {
+						files = append(files, file.Name())
+					}
+					print(files)
+				}
+				return files, err
+			}).AnyTimes()
+
+			mockRepoClient.EXPECT().GetFileReader(gomock.Any()).DoAndReturn(func(file string) (io.ReadCloser, error) {
+				return os.Open("./" + tt.inputFolder + "/" + file)
+			}).AnyTimes()
+
+			// mock based on localDir
+			mockRepoClient.EXPECT().ListLicenses().Return(nil, fmt.Errorf("ListLicenses: %w", clients.ErrUnsupportedFeature)).AnyTimes()
 
 			ctx := context.Background()
-
-			client := localdir.CreateLocalDirClient(ctx, logger)
-			if err := client.InitRepo(repo, clients.HeadSHA, 0); err != nil {
-				t.Errorf("InitRepo: %v", err)
-			}
 
 			dl := scut.TestDetailLogger{}
 
 			req := checker.CheckRequest{
 				Ctx:        ctx,
-				RepoClient: client,
+				RepoClient: mockRepoClient,
 				Dlogger:    &dl,
 			}
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Updates tests to follow best practices (and corrects previous PR #4078 )


#### What is the current behavior?
binary_analysis and license check tests currently use localDirRepo instead of gomock
binary_analysis does not utilize scut (license test already uses scut and does not need modification)

#### What is the new behavior (if this is a feature change)?**
 - No behavior change anticipated
 - binary_analysis and license check tests updated to use gomock
   - ListFiles and GetFileReader mocked for both
   - ListLicenses mocked for license check (replicates localDirRepo by throwing Unsupported Feature error)
 - binary_analysis updated to use scut
   - test cases modified to include some logging information

#### Which issue(s) this PR fixes
Fixes #4032 
