### PR TITLE
:bug: Code-Review: change phabricator regex to allow URLs

### DIFF
--- a/checks/code_review_test.go
+++ b/checks/code_review_test.go
@@ -206,7 +206,7 @@ func TestCodereview(t *testing.T) {
 					Committer: clients.User{
 						Login: "bob",
 					},
-					Message: "Title\nReviewed By: alice\nDifferential Revision: PHAB234",
+					Message: "Title\nReviewed By: alice\nDifferential Revision: D234",
 				},
 			},
 			expected: scut.TestReturn{
@@ -236,7 +236,7 @@ func TestCodereview(t *testing.T) {
 					Committer: clients.User{
 						Login: "bob",
 					},
-					Message: "Title\nDifferential Revision: PHAB234",
+					Message: "Title\nDifferential Revision: D234",
 				},
 			},
 			expected: scut.TestReturn{

--- a/checks/raw/code_review.go
+++ b/checks/raw/code_review.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	rePhabricatorRevID = regexp.MustCompile(`Differential Revision:\s*(\w+)`)
+	rePhabricatorRevID = regexp.MustCompile(`Differential Revision:[^\r\n]*(D\d+)`)
 	rePiperRevID       = regexp.MustCompile(`PiperOrigin-RevId:\s*(\d{3,})`)
 )
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The old regex used `\w` which only allowed `[0-9A-Za-z_]`, however most projects use full URLs with phabricator (e.g.
`https://reviews.foo.org/D###`). This led to errors parsing the revisions, where `https` was seen as the revision (the portion which matched `\w`), leading to an underreporting of code review practices as everything was considered 1 changeset.

```
go run main.go --repo freebsd/freebsd-src --checks Code-Review --format json --show-details | jq
{
  "date": "2024-05-06T14:23:32-07:00",
  "repo": {
    "name": "github.com/freebsd/freebsd-src",
    "commit": "a7db82cfd940431037e748280825931a46ed2d12"
  },
  "scorecard": {
    "version": "devel",
    "commit": "unknown"
  },
  "score": 0.0,
  "checks": [
    {
      "details": null,
      "score": 0,
      "reason": "Found 1/14 approved changesets -- score normalized to 0",
      "name": "Code-Review",
      "documentation": {
        "url": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review",
        "short": "Determines if the project requires human code review before pull requests (aka merge requests) are merged."
      }
    }
  ],
  "metadata": null
}
```

#### What is the new behavior (if this is a feature change)?**
The new regex focuses on matching `D####` which is on the same line as "Differential Revision" . This regex does force the **D** prefix for a revision.

```shell
go run main.go --repo freebsd/freebsd-src --checks Code-Review --format json --show-details | jq
{
  "date": "2024-05-06T14:23:12-07:00",
  "repo": {
    "name": "github.com/freebsd/freebsd-src",
    "commit": "a7db82cfd940431037e748280825931a46ed2d12"
  },
  "scorecard": {
    "version": "devel",
    "commit": "unknown"
  },
  "score": 5.0,
  "checks": [
    {
      "details": null,
      "score": 5,
      "reason": "Found 17/30 approved changesets -- score normalized to 5",
      "name": "Code-Review",
      "documentation": {
        "url": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#code-review",
        "short": "Determines if the project requires human code review before pull requests (aka merge requests) are merged."
      }
    }
  ],
  "metadata": null
}
```

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #4038
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
I also made use of subtests in the corresponding test because it helps isolate the test failures better.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Fixed an issue where Phabricator reviews weren't being parsed properly.
```
