### PR TITLE
:seedling: cron: don't write any bestpractices data for projects without repo URL

### DIFF
--- a/cron/internal/cii/main.go
+++ b/cron/internal/cii/main.go
@@ -42,6 +42,9 @@ func writeToCIIDataBucket(ctx context.Context, pageResp []ciiPageResp, bucketURL
 	for _, project := range pageResp {
 		projectURL := strings.TrimPrefix(project.RepoURL, "https://")
 		projectURL = strings.TrimPrefix(projectURL, "http://")
+		if projectURL == "" {
+			continue
+		}
 		jsonData, err := clients.BadgeResponse{
 			BadgeLevel: project.BadgeLevel,
 		}.AsJSON()


### PR DESCRIPTION
#### What kind of change does this PR introduce?

cron fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
We still run into the 429 GCS responses due to the lower limits on writes to the same object. All of the projects without a `repo_url` are being mapped to the same object `/result.json` and leading to rate limiting.

"Maximum rate of writes to the same object name: One write per second"
https://cloud.google.com/storage/quotas#objects

#### What is the new behavior (if this is a feature change)?**
We don't try to write anything for projects without an associated `repo_url`

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Follow up of #4090 , related to #4037
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
