### PR TITLE
:warning: ProjectPackageClient: pass client to RunScorecard

### DIFF
--- a/attestor/command/check.go
+++ b/attestor/command/check.go
@@ -77,7 +77,7 @@ func RunCheckWithParams(repoURL, commitSHA, policyPath string) (policy.PolicyRes
 		}
 	}
 
-	repo, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, err := checker.GetClients(
+	repo, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, projectClient, err := checker.GetClients(
 		ctx, repoURL, "", logger)
 	if err != nil {
 		return policy.Fail, fmt.Errorf("couldn't set up clients: %w", err)
@@ -117,6 +117,7 @@ func RunCheckWithParams(repoURL, commitSHA, policyPath string) (policy.PolicyRes
 		ossFuzzRepoClient,
 		ciiClient,
 		vulnsClient,
+		projectClient,
 	)
 	if err != nil {
 		return policy.Fail, fmt.Errorf("RunScorecard: %w", err)

--- a/checker/check_request.go
+++ b/checker/check_request.go
@@ -18,6 +18,7 @@ import (
 	"context"
 
 	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/internal/packageclient"
 )
 
 // CheckRequest struct encapsulates all data to be passed into a CheckFn.
@@ -29,6 +30,7 @@ type CheckRequest struct {
 	Dlogger               DetailLogger
 	Repo                  clients.Repo
 	VulnerabilitiesClient clients.VulnerabilitiesClient
+	ProjectClient         packageclient.ProjectPackageClient
 	// UPGRADEv6: return raw results instead of scores.
 	RawResults    *RawResults
 	RequiredTypes []RequestType

--- a/checker/client.go
+++ b/checker/client.go
@@ -23,6 +23,7 @@ import (
 	glrepo "github.com/ossf/scorecard/v5/clients/gitlabrepo"
 	"github.com/ossf/scorecard/v5/clients/localdir"
 	"github.com/ossf/scorecard/v5/clients/ossfuzz"
+	"github.com/ossf/scorecard/v5/internal/packageclient"
 	"github.com/ossf/scorecard/v5/log"
 )
 
@@ -34,6 +35,7 @@ func GetClients(ctx context.Context, repoURI, localURI string, logger *log.Logge
 	clients.RepoClient, // ossFuzzClient
 	clients.CIIBestPracticesClient, // ciiClient
 	clients.VulnerabilitiesClient, // vulnClient
+	packageclient.ProjectPackageClient, // projectClient
 	error,
 ) {
 	var repo clients.Repo
@@ -50,6 +52,7 @@ func GetClients(ctx context.Context, repoURI, localURI string, logger *log.Logge
 			nil, /*ossFuzzClient*/
 			nil, /*ciiClient*/
 			clients.DefaultVulnerabilitiesClient(), /*vulnClient*/
+			nil,
 			retErr
 	}
 
@@ -68,6 +71,7 @@ func GetClients(ctx context.Context, repoURI, localURI string, logger *log.Logge
 				nil,
 				nil,
 				nil,
+				packageclient.CreateDepsDevClient(),
 				fmt.Errorf("error making github repo: %w", makeRepoError)
 		}
 		repoClient = ghrepo.CreateGithubRepoClient(ctx, logger)
@@ -78,5 +82,6 @@ func GetClients(ctx context.Context, repoURI, localURI string, logger *log.Logge
 		ossfuzz.CreateOSSFuzzClient(ossfuzz.StatusURL), /*ossFuzzClient*/
 		clients.DefaultCIIBestPracticesClient(), /*ciiClient*/
 		clients.DefaultVulnerabilitiesClient(), /*vulnClient*/
+		packageclient.CreateDepsDevClient(),
 		nil
 }

--- a/checker/client_test.go
+++ b/checker/client_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ossf/scorecard/v5/log"
 )
 
+//nolint:gocognit
 func TestGetClients(t *testing.T) {
 	type args struct { //nolint:govet
 		ctx      context.Context
@@ -28,16 +29,17 @@ func TestGetClients(t *testing.T) {
 		logger   *log.Logger
 	}
 	tests := []struct { //nolint:govet
-		name                  string
-		args                  args
-		shouldOSSFuzzBeNil    bool
-		shouldRepoClientBeNil bool
-		shouldVulnClientBeNil bool
-		shouldRepoBeNil       bool
-		shouldCIIBeNil        bool
-		wantErr               bool
-		experimental          bool
-		isGhHost              bool
+		name                     string
+		args                     args
+		shouldOSSFuzzBeNil       bool
+		shouldRepoClientBeNil    bool
+		shouldVulnClientBeNil    bool
+		shouldRepoBeNil          bool
+		shouldCIIBeNil           bool
+		shouldProjectClientBeNil bool
+		wantErr                  bool
+		experimental             bool
+		isGhHost                 bool
 	}{
 		{
 			name: "localURI is not empty",
@@ -105,7 +107,7 @@ func TestGetClients(t *testing.T) {
 				t.Setenv("GH_HOST", "github.corp.com")
 				t.Setenv("GH_TOKEN", "PAT")
 			}
-			got, repoClient, ossFuzzClient, ciiClient, vulnsClient, err := GetClients(tt.args.ctx, tt.args.repoURI, tt.args.localURI, tt.args.logger)
+			got, repoClient, ossFuzzClient, ciiClient, vulnsClient, projectClient, err := GetClients(tt.args.ctx, tt.args.repoURI, tt.args.localURI, tt.args.logger)
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("GetClients() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -123,6 +125,9 @@ func TestGetClients(t *testing.T) {
 			}
 			if vulnsClient != nil && tt.shouldVulnClientBeNil {
 				t.Errorf("GetClients() vulnsClient = %v", vulnsClient)
+			}
+			if projectClient != nil && tt.shouldProjectClientBeNil {
+				t.Errorf("GetClients() projectClient = %v", projectClient)
 			}
 		})
 	}

--- a/cmd/internal/scdiff/app/runner/runner.go
+++ b/cmd/internal/scdiff/app/runner/runner.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ossf/scorecard/v5/clients/gitlabrepo"
 	"github.com/ossf/scorecard/v5/clients/ossfuzz"
 	sce "github.com/ossf/scorecard/v5/errors"
+	"github.com/ossf/scorecard/v5/internal/packageclient"
 	"github.com/ossf/scorecard/v5/log"
 	"github.com/ossf/scorecard/v5/pkg"
 )
@@ -45,6 +46,7 @@ type Runner struct {
 	ossFuzz       clients.RepoClient
 	cii           clients.CIIBestPracticesClient
 	vuln          clients.VulnerabilitiesClient
+	deps          packageclient.ProjectPackageClient
 }
 
 // Creates a Runner which will run the listed checks. If no checks are provided, all will run.
@@ -79,7 +81,9 @@ func (r *Runner) Run(repoURI string) (pkg.ScorecardResult, error) {
 	if err != nil {
 		return pkg.ScorecardResult{}, err
 	}
-	return pkg.RunScorecard(r.ctx, repo, commit, commitDepth, r.enabledChecks, repoClient, r.ossFuzz, r.cii, r.vuln)
+	return pkg.RunScorecard(
+		r.ctx, repo, commit, commitDepth, r.enabledChecks, repoClient, r.ossFuzz, r.cii, r.vuln, r.deps,
+	)
 }
 
 // logs only if logger is set.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -93,7 +93,7 @@ func rootCmd(o *options.Options) error {
 
 	ctx := context.Background()
 	logger := sclog.NewLogger(sclog.ParseLevel(o.LogLevel))
-	repoURI, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, err := checker.GetClients(
+	repoURI, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, projectClient, err := checker.GetClients(
 		ctx, o.Repo, o.Local, logger) // MODIFIED
 	if err != nil {
 		return fmt.Errorf("GetClients: %w", err)
@@ -142,6 +142,7 @@ func rootCmd(o *options.Options) error {
 		ossFuzzRepoClient,
 		ciiClient,
 		vulnsClient,
+		projectClient,
 	)
 	if err != nil {
 		return fmt.Errorf("RunScorecard: %w", err)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ossf/scorecard/v5/clients"
 	"github.com/ossf/scorecard/v5/clients/githubrepo"
 	"github.com/ossf/scorecard/v5/clients/ossfuzz"
+	"github.com/ossf/scorecard/v5/internal/packageclient"
 	"github.com/ossf/scorecard/v5/log"
 	"github.com/ossf/scorecard/v5/options"
 	"github.com/ossf/scorecard/v5/pkg"
@@ -69,10 +70,11 @@ func serveCmd(o *options.Options) *cobra.Command {
 				}
 				defer ossFuzzRepoClient.Close()
 				ciiClient := clients.DefaultCIIBestPracticesClient()
+				projectClient := packageclient.CreateDepsDevClient()
 				checksToRun := checks.GetAll()
 				repoResult, err := pkg.RunScorecard(
 					ctx, repo, clients.HeadSHA /*commitSHA*/, o.CommitDepth, checksToRun, repoClient,
-					ossFuzzRepoClient, ciiClient, vulnsClient)
+					ossFuzzRepoClient, ciiClient, vulnsClient, projectClient)
 				if err != nil {
 					logger.Error(err, "running enabled scorecard checks on repo")
 					rw.WriteHeader(http.StatusInternalServerError)

--- a/e2e/attestor_policy_test.go
+++ b/e2e/attestor_policy_test.go
@@ -242,11 +242,11 @@ func getScorecardResult(repoURL string) (pkg.ScorecardResult, error) {
 			Fn: checks.PinningDependencies,
 		},
 	}
-	repo, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, err := checker.GetClients(
+	repo, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, projectClient, err := checker.GetClients(
 		ctx, repoURL, "", logger)
 	if err != nil {
 		return pkg.ScorecardResult{}, fmt.Errorf("couldn't set up clients: %w", err)
 	}
 
-	return pkg.RunScorecard(ctx, repo, clients.HeadSHA, 0, enabledChecks, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient)
+	return pkg.RunScorecard(ctx, repo, clients.HeadSHA, 0, enabledChecks, repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, projectClient)
 }

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -31,6 +31,7 @@ import (
 	"github.com/ossf/scorecard/v5/config"
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/packageclient"
 	proberegistration "github.com/ossf/scorecard/v5/internal/probes"
 	sclog "github.com/ossf/scorecard/v5/log"
 	"github.com/ossf/scorecard/v5/options"
@@ -91,6 +92,7 @@ func runScorecard(ctx context.Context,
 	ossFuzzRepoClient clients.RepoClient,
 	ciiClient clients.CIIBestPracticesClient,
 	vulnsClient clients.VulnerabilitiesClient,
+	projectClient packageclient.ProjectPackageClient,
 ) (ScorecardResult, error) {
 	if err := repoClient.InitRepo(repo, commitSHA, commitDepth); err != nil {
 		// No need to call sce.WithMessage() since InitRepo will do that for us.
@@ -232,6 +234,7 @@ func RunScorecard(ctx context.Context,
 	ossFuzzRepoClient clients.RepoClient,
 	ciiClient clients.CIIBestPracticesClient,
 	vulnsClient clients.VulnerabilitiesClient,
+	projectClient packageclient.ProjectPackageClient,
 ) (ScorecardResult, error) {
 	return runScorecard(ctx,
 		repo,
@@ -243,6 +246,7 @@ func RunScorecard(ctx context.Context,
 		ossFuzzRepoClient,
 		ciiClient,
 		vulnsClient,
+		projectClient,
 	)
 }
 
@@ -257,6 +261,7 @@ func ExperimentalRunProbes(ctx context.Context,
 	ossFuzzRepoClient clients.RepoClient,
 	ciiClient clients.CIIBestPracticesClient,
 	vulnsClient clients.VulnerabilitiesClient,
+	projectClient packageclient.ProjectPackageClient,
 ) (ScorecardResult, error) {
 	return runScorecard(ctx,
 		repo,
@@ -268,5 +273,6 @@ func ExperimentalRunProbes(ctx context.Context,
 		ossFuzzRepoClient,
 		ciiClient,
 		vulnsClient,
+		projectClient,
 	)
 }

--- a/pkg/scorecard_e2e_test.go
+++ b/pkg/scorecard_e2e_test.go
@@ -108,20 +108,20 @@ var _ = Describe("E2E TEST: RunScorecard with re-used repoClient", func() {
 
 			isolatedLogger := sclog.NewLogger(sclog.DebugLevel)
 			lastRepo := repos[len(repos)-1]
-			repo, rc, ofrc, cc, vc, err := checker.GetClients(ctx, lastRepo, "", isolatedLogger)
+			repo, rc, ofrc, cc, vc, dc, err := checker.GetClients(ctx, lastRepo, "", isolatedLogger)
 			Expect(err).Should(BeNil())
-			isolatedResult, err := RunScorecard(ctx, repo, clients.HeadSHA, 0, allChecks, rc, ofrc, cc, vc)
+			isolatedResult, err := RunScorecard(ctx, repo, clients.HeadSHA, 0, allChecks, rc, ofrc, cc, vc, dc)
 			Expect(err).Should(BeNil())
 
 			logger := sclog.NewLogger(sclog.DebugLevel)
-			_, rc2, ofrc2, cc2, vc2, err := checker.GetClients(ctx, repos[0], "", logger)
+			_, rc2, ofrc2, cc2, vc2, dc2, err := checker.GetClients(ctx, repos[0], "", logger)
 			Expect(err).Should(BeNil())
 
 			var sharedResult ScorecardResult
 			for i := range repos {
 				repo, err = githubrepo.MakeGithubRepo(repos[i])
 				Expect(err).Should(BeNil())
-				sharedResult, err = RunScorecard(ctx, repo, clients.HeadSHA, 0, allChecks, rc2, ofrc2, cc2, vc2)
+				sharedResult, err = RunScorecard(ctx, repo, clients.HeadSHA, 0, allChecks, rc2, ofrc2, cc2, vc2, dc2)
 				Expect(err).Should(BeNil())
 			}
 

--- a/pkg/scorecard_test.go
+++ b/pkg/scorecard_test.go
@@ -179,7 +179,7 @@ func TestRunScorecard(t *testing.T) {
 				}, nil
 			})
 			defer ctrl.Finish()
-			got, err := RunScorecard(context.Background(), repo, tt.args.commitSHA, 0, nil, mockRepoClient, nil, nil, nil)
+			got, err := RunScorecard(context.Background(), repo, tt.args.commitSHA, 0, nil, mockRepoClient, nil, nil, nil, nil)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RunScorecard() error = %v, wantErr %v", err, tt.wantErr)
 				return
@@ -315,7 +315,9 @@ func TestExperimentalRunProbes(t *testing.T) {
 				mockRepoClient,
 				nil,
 				nil,
-				nil)
+				nil,
+				nil,
+			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RunScorecard() error = %v, wantErr %v", err, tt.wantErr)
 				return


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Pass ProjectPackageClient to `RunScorecard`. This will allow raw data collection/probes to make use of the new interface.