### PR TITLE
:bug: Support renamed gradle verification action and callers which pin to hash

### DIFF
--- a/checks/raw/binary_artifact.go
+++ b/checks/raw/binary_artifact.go
@@ -19,11 +19,9 @@ import (
 	"fmt"
 	"io"
 	"path/filepath"
-	"regexp"
 	"strings"
 	"unicode/utf8"
 
-	semver "github.com/Masterminds/semver/v3"
 	"github.com/h2non/filetype"
 	"github.com/h2non/filetype/types"
 	"github.com/rhysd/actionlint"
@@ -35,22 +33,8 @@ import (
 	"github.com/ossf/scorecard/v5/finding"
 )
 
-var (
-	gradleWrapperValidationActionRegex             = regexp.MustCompile(`^gradle\/wrapper-validation-action@v?(.+)$`)
-	gradleWrapperValidationActionVersionConstraint = mustParseConstraint(`>= 1.0.0`)
-)
-
 // how many bytes are considered when determining if a file is text or binary.
 const binaryTestLen = 1024
-
-// mustParseConstraint attempts parse of semver constraint, panics if fail.
-func mustParseConstraint(c string) *semver.Constraints {
-	if c, err := semver.NewConstraint(c); err != nil {
-		panic(fmt.Errorf("failed to parse constraint: %w", err))
-	} else {
-		return c
-	}
-}
 
 // BinaryArtifacts retrieves the raw data for the Binary-Artifacts check.
 func BinaryArtifacts(req *checker.CheckRequest) (checker.BinaryArtifactData, error) {
@@ -266,18 +250,8 @@ func checkWorkflowValidatesGradleWrapper(path string, content []byte, args ...in
 			if ea.Uses == nil {
 				continue
 			}
-			sms := gradleWrapperValidationActionRegex.FindStringSubmatch(ea.Uses.Value)
-			if len(sms) > 1 {
-				v, err := semver.NewVersion(sms[1])
-				if err != nil {
-					// Couldn't parse version, hopefully another step has
-					// a correct one.
-					continue
-				}
-				if !gradleWrapperValidationActionVersionConstraint.Check(v) {
-					// Version out of acceptable range.
-					continue
-				}
+			if strings.HasPrefix(ea.Uses.Value, "gradle/wrapper-validation-action@") ||
+				strings.HasPrefix(ea.Uses.Value, "gradle/actions/wrapper-validation@") {
 				// OK! This is it.
 				*validatingWorkflowFile = filepath.Base(path)
 				return false, nil

--- a/checks/raw/binary_artifact_test.go
+++ b/checks/raw/binary_artifact_test.go
@@ -164,13 +164,26 @@ func TestBinaryArtifacts(t *testing.T) {
 			expect:              1,
 		},
 		{
-			name: "gradle-wrapper.jar with outdated verification action",
+			name: "gradle-wrapper.jar with new verification action",
 			err:  nil,
 			files: [][]string{
 				{"../testdata/binaryartifacts/jars/gradle-wrapper.jar"},
 				{
 					"../testdata/binaryartifacts/workflows/nonverify.yaml",
-					"../testdata/binaryartifacts/workflows/verify-outdated-action.yaml",
+					"../testdata/binaryartifacts/workflows/verify-new-gradle-name.yaml",
+				},
+			},
+			successfulWorkflowRuns: []clients.WorkflowRun{
+				{
+					HeadSHA: strptr("sha-a"),
+				},
+			},
+			commits: []clients.Commit{
+				{
+					SHA: "sha-a",
+				},
+				{
+					SHA: "sha-old",
 				},
 			},
 			getFileContentCount: 3,

--- a/checks/testdata/binaryartifacts/workflows/verify-new-gradle-name.yaml
+++ b/checks/testdata/binaryartifacts/workflows/verify-new-gradle-name.yaml
@@ -6,7 +6,6 @@ jobs:
     name: "GW Validate Job"
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: GW Validate Step
-        # this is a made-up outdated version of the action:
-        uses: gradle/wrapper-validation-action@v0.1.0
+        uses: gradle/actions/wrapper-validation@v3

--- a/go.mod
+++ b/go.mod
@@ -39,7 +39,6 @@ require (
 )
 
 require (
-	github.com/Masterminds/semver/v3 v3.2.1
 	github.com/caarlos0/env/v6 v6.10.0
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-github/v53 v53.2.0

--- a/go.sum
+++ b/go.sum
@@ -89,8 +89,6 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/CycloneDX/cyclonedx-go v0.8.0 h1:FyWVj6x6hoJrui5uRQdYZcSievw3Z32Z88uYzG/0D6M=
 github.com/CycloneDX/cyclonedx-go v0.8.0/go.mod h1:K2bA+324+Og0X84fA8HhN2X066K7Bxz4rpMQ4ZhjtSk=
 github.com/GoogleCloudPlatform/k8s-cloud-provider v0.0.0-20190822182118-27a4ced34534/go.mod h1:iroGtC8B3tQiqtds1l+mgk/BBOrxbqjH+eUfFQYRc14=
-github.com/Masterminds/semver/v3 v3.2.1 h1:RN9w6+7QoMeJVGyfmbcgs28Br8cvmnucEXnY0rYXWg0=
-github.com/Masterminds/semver/v3 v3.2.1/go.mod h1:qvl/7zhW3nngYb5+80sSMF+FG2BjYrf8m9wsX0PNOMQ=
 github.com/Microsoft/go-winio v0.4.14/go.mod h1:qXqCSQ3Xa7+6tgxaGTIe4Kpcdsi+P8jBhyzoq1bpyYA=
 github.com/Microsoft/go-winio v0.5.2/go.mod h1:WpS1mjBmmwHBEWmogvA2mj8546UReBk4v8QkMxJ6pZY=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=


### PR DESCRIPTION
#### What kind of change does this PR introduce?
bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
`gradle/wrapper-validation-action` must be present and pinned to a hash

#### What is the new behavior (if this is a feature change)?**
* detects `gradle/actions/wrapper-validation`
  * From gradle/wrapper-validation-action's readme: "As of v3 this action has been superceded by gradle/actions/wrapper-validation"
* Also support actions pinned to a hash.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #2477
Fixes #2357

Related to https://github.com/ossf/scorecard-action/issues/782#issuecomment-2101915990, but requires a release (which was going to be cut today anyway)

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Binary-Artifacts check now supports the new gradle wrapper validation action, and can be pinned to a hash.
```
