### PR TITLE
✨ move to cgr base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,6 +24,6 @@ ARG TARGETOS
 ARG TARGETARCH
 RUN CGO_ENABLED=0 make build-scorecard
 
-FROM gcr.io/distroless/base:nonroot@sha256:53745e95f227cd66e8058d52f64efbbeb6c6af2c193e3c16981137e5083e6a32
+FROM cgr.dev/chainguard/static@sha256:110b6918893ea3df0eec04b2f469f3af07e5439900ed259076c55cefb1ec3965
 COPY --from=build /src/scorecard /
 ENTRYPOINT [ "/scorecard" ]


### PR DESCRIPTION
- Move the static cgr.dev base image as it has less foot print and zero vuln.

cgr.dev 
```
➜  scorecard git:(main) ✗ grype docker.io/library/scorecard
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                    index.docker.io/library/scorecard:latest
 ✔ Parsed image                                                                     sha256:9dc0b3a5edf538cc6e7cb559a037a4076ac68f1fca0010049da9f6111addd339
 ✔ Cataloged contents                                                                      4e28f40763377e1ffe75bfd4400e924ef62cf04db7b5b136338a932569afa3c8
   ├── ✔ Packages                        [121 packages]
   ├── ✔ File digests                    [397 files]
   ├── ✔ File metadata                   [397 locations]
   └── ✔ Executables                     [1 executables]
 ✔ Scanned for vulnerabilities     [0 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 0 medium, 0 low, 0 negligible
   └── by status:   0 fixed, 0 not-fixed, 0 ignored
No vulnerabilities found
```
distroless
```
➜  scorecard git:(main) grype 53597ab312e4
 ✔ Vulnerability DB                [no update available]
 ✔ Loaded image                                                                                                                                53597ab312e4
 ✔ Parsed image                                                                     sha256:53597ab312e4cfc07ed88464de08d020ad23eed32f6b32c8ec3e04449fd67780
 ✔ Cataloged contents                                                                      cf00f3cc9f38cc71a23039d27febd8b68b0aba92a152d8c48f66f9b0f5263065
   ├── ✔ Packages                        [121 packages]
   ├── ✔ File digests                    [1,227 files]
   ├── ✔ File metadata                   [1,227 locations]
   └── ✔ Executables                     [279 executables]
 ✔ Scanned for vulnerabilities     [15 vulnerability matches]
   ├── by severity: 0 critical, 0 high, 3 medium, 0 low, 9 negligible (3 unknown)
   └── by status:   0 fixed, 15 not-fixed, 0 ignored
NAME     INSTALLED         FIXED-IN     TYPE  VULNERABILITY     SEVERITY
libc6    2.36-9+deb12u7                 deb   CVE-2019-9192     Negligible
libc6    2.36-9+deb12u7                 deb   CVE-2019-1010025  Negligible
libc6    2.36-9+deb12u7                 deb   CVE-2019-1010024  Negligible
libc6    2.36-9+deb12u7                 deb   CVE-2019-1010023  Negligible
libc6    2.36-9+deb12u7                 deb   CVE-2019-1010022  Negligible
libc6    2.36-9+deb12u7                 deb   CVE-2018-20796    Negligible
libc6    2.36-9+deb12u7                 deb   CVE-2010-4756     Negligible
libssl3  3.0.11-1~deb12u2  (won't fix)  deb   CVE-2024-0727     Medium
libssl3  3.0.11-1~deb12u2  (won't fix)  deb   CVE-2023-6129     Medium
libssl3  3.0.11-1~deb12u2  (won't fix)  deb   CVE-2023-5678     Medium
libssl3  3.0.11-1~deb12u2               deb   CVE-2010-0928     Negligible
libssl3  3.0.11-1~deb12u2               deb   CVE-2007-6755     Negligible
libssl3  3.0.11-1~deb12u2  (won't fix)  deb   CVE-2024-4603     Unknown
libssl3  3.0.11-1~deb12u2  (won't fix)  deb   CVE-2024-2511     Unknown
libssl3  3.0.11-1~deb12u2  (won't fix)  deb   CVE-2023-6237     Unknown
```

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [ ] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
