### PR TITLE
:sparkles: Recognize scala-steward as dependency update tool

### DIFF
--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -129,7 +129,11 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 		})
 	// https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
 	case ".scala-steward.conf",
-		"scala-steward.conf":
+		"scala-steward.conf",
+		".github/.scala-steward.conf",
+		".github/scala-steward.conf",
+		".config/.scala-steward.conf",
+		".config/scala-steward.conf":
 		*ptools = append(*ptools, checker.Tool{
 			Name: "scala-steward",
 			URL:  asPointer("https://github.com/scala-steward-org/scala-steward"),

--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -127,6 +127,21 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 				},
 			},
 		})
+	// https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
+	case ".scala-steward.conf",
+		"scala-steward.conf":
+		*ptools = append(*ptools, checker.Tool{
+			Name: "scala-steward",
+			URL:  asPointer("https://github.com/scala-steward-org/scala-steward"),
+			Desc: asPointer("Works with Maven, Mill, sbt, and Scala CLI."),
+			Files: []checker.File{
+				{
+					Path:   name,
+					Type:   finding.FileTypeSource,
+					Offset: checker.OffsetDefault,
+				},
+			},
+		})
 	}
 
 	// Continue iterating, even if we have found a tool.

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -106,6 +106,18 @@ func Test_checkDependencyFileExists(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    ".scala-steward.conf",
+			path:    ".scala-steward.conf",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    "scala-steward.conf",
+			path:    "scala-steward.conf",
+			want:    true,
+			wantErr: false,
+		},
+		{
 			name:    ".lift.toml",
 			path:    ".lift.toml",
 			want:    false, // support removed

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -118,6 +118,30 @@ func Test_checkDependencyFileExists(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name:    ".github/.scala-steward.conf",
+			path:    ".github/.scala-steward.conf",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    ".github/scala-steward.conf",
+			path:    ".github/scala-steward.conf",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    ".config/.scala-steward.conf",
+			path:    ".config/.scala-steward.conf",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name:    ".config/scala-steward.conf",
+			path:    ".config/scala-steward.conf",
+			want:    true,
+			wantErr: false,
+		},
+		{
 			name:    ".lift.toml",
 			path:    ".lift.toml",
 			want:    false, // support removed

--- a/docs/checks/dependencyupdatetool/README.md
+++ b/docs/checks/dependencyupdatetool/README.md
@@ -5,6 +5,8 @@
   * Detection is based on the configuration files listed [here](https://docs.renovatebot.com/configuration-options/)
 * [PyUp](https://github.com/pyupio/pyup)
   * Detection based on a `.pyup.yml` file
+* [scala-steward](https://github.com/scala-steward-org/scala-steward)
+  * Detection is based on the configuration files listed [here](https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md)
 
 # Add Support
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Recognize [scala-steward](https://github.com/scala-steward-org/scala-steward) as dependency update tool

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Repositories that are configured to use scala-steward score '0' on the 'Dependency-Update-Tool' check

#### What is the new behavior (if this is a feature change)?**

Repositories that are configured to use scala-steward score '10' on the 'Dependency-Update-Tool' check

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Recognize scala-steward as dependency update tool
```
