### PR TITLE
:bug: fix Docker remediations for unpinned GHA dependencies

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -230,7 +230,7 @@ func collectDockerfilePinning(c *checker.CheckRequest, r *checker.PinningDepende
 
 	for i := range r.Dependencies {
 		rr := &r.Dependencies[i]
-		if !*rr.Pinned {
+		if rr.Type == checker.DependencyUseTypeDockerfileContainerImage && !*rr.Pinned {
 			remediate := remediation.CreateDockerfilePinningRemediation(rr, remediation.CraneDigester{})
 			rr.Remediation = remediate
 		}
@@ -485,7 +485,7 @@ func collectGitHubActionsWorkflowPinning(c *checker.CheckRequest, r *checker.Pin
 
 	for i := range r.Dependencies {
 		rr := &r.Dependencies[i]
-		if !*rr.Pinned {
+		if rr.Type == checker.DependencyUseTypeGHAction && !*rr.Pinned {
 			remediate := remediationMetadata.CreateWorkflowPinningRemediation(rr.Location.Path)
 			rr.Remediation = remediate
 		}

--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -228,14 +228,18 @@ func collectDockerfilePinning(c *checker.CheckRequest, r *checker.PinningDepende
 		return err
 	}
 
-	for i := range r.Dependencies {
-		rr := &r.Dependencies[i]
+	applyDockerfilePinningRemediations(r.Dependencies)
+	return nil
+}
+
+func applyDockerfilePinningRemediations(d []checker.Dependency) {
+	for i := range d {
+		rr := &d[i]
 		if rr.Type == checker.DependencyUseTypeDockerfileContainerImage && !*rr.Pinned {
 			remediate := remediation.CreateDockerfilePinningRemediation(rr, remediation.CraneDigester{})
 			rr.Remediation = remediate
 		}
 	}
-	return nil
 }
 
 var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
@@ -483,14 +487,18 @@ func collectGitHubActionsWorkflowPinning(c *checker.CheckRequest, r *checker.Pin
 	//nolint:errcheck
 	remediationMetadata, _ := remediation.New(c)
 
-	for i := range r.Dependencies {
-		rr := &r.Dependencies[i]
+	applyWorkflowPinningRemediations(remediationMetadata, r.Dependencies)
+	return nil
+}
+
+func applyWorkflowPinningRemediations(rm *remediation.RemediationMetadata, d []checker.Dependency) {
+	for i := range d {
+		rr := &d[i]
 		if rr.Type == checker.DependencyUseTypeGHAction && !*rr.Pinned {
-			remediate := remediationMetadata.CreateWorkflowPinningRemediation(rr.Location.Path)
+			remediate := rm.CreateWorkflowPinningRemediation(rr.Location.Path)
 			rr.Remediation = remediate
 		}
 	}
-	return nil
 }
 
 // validateGitHubActionWorkflow checks if the workflow file contains unpinned actions. Returns true if the check

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/ossf/scorecard/v5/checker"
 	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/remediation"
 	scut "github.com/ossf/scorecard/v5/utests"
 )
 
@@ -412,6 +413,75 @@ func TestDockerfilePinning(t *testing.T) {
 				t.Errorf("expected %v. Got %v", tt.warns, unpinned)
 			}
 		})
+	}
+}
+
+func TestMixedPinning(t *testing.T) {
+	t.Parallel()
+
+	workflowDependency := checker.Dependency{
+		Name:     stringAsPointer("actions/checkout"),
+		PinnedAt: stringAsPointer("daadedc81d5f9d3c06d2c92f49202a3cc2b919ba"),
+		Location: &checker.File{
+			Path:      ".github/workflows/workflow-not-pinned.yaml",
+			Snippet:   "actions/checkout@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba",
+			Offset:    31,
+			EndOffset: 31,
+			FileSize:  0,
+			Type:      1,
+		},
+		Pinned:      boolAsPointer(false),
+		Type:        "GitHubAction",
+		Remediation: nil,
+	}
+	dockerDependency := checker.Dependency{
+		Name:     stringAsPointer("python"),
+		PinnedAt: stringAsPointer("3.7"),
+		Location: &checker.File{
+			Path:      "./testdata/Dockerfile-not-pinned",
+			Snippet:   "FROM python:3.7",
+			Offset:    17,
+			EndOffset: 17,
+			Type:      0,
+		},
+		Pinned: boolAsPointer(false),
+		Type:   "containerImage",
+	}
+	dependencies := []checker.Dependency{
+		workflowDependency,
+		dockerDependency,
+	}
+
+	//nolint:errcheck
+	remediationMetadata, _ := remediation.New(nil)
+	remediationMetadata.Branch = "mybranch"
+	remediationMetadata.Repo = "myrepo"
+
+	applyWorkflowPinningRemediations(remediationMetadata, dependencies)
+	if dependencies[0].Remediation == nil {
+		t.Errorf("No remediation added to workflow dependency")
+		return
+	}
+	if !strings.Contains(dependencies[0].Remediation.Text, "update your workflow") {
+		t.Errorf("Unexpected workflow remediation text")
+	}
+	if dependencies[1].Remediation != nil {
+		t.Errorf("Unexpected docker remediation")
+		return
+	}
+	applyDockerfilePinningRemediations(dependencies)
+	if dependencies[0].Remediation == nil {
+		t.Errorf("Remediation disappeared from workflow dependency")
+	}
+	if !strings.Contains(dependencies[0].Remediation.Text, "update your workflow") {
+		t.Errorf("Unexpected workflow remediation text")
+	}
+	if dependencies[1].Remediation == nil {
+		t.Errorf("No remediation added to docker dependency")
+		return
+	}
+	if !strings.Contains(dependencies[1].Remediation.Text, "Docker") {
+		t.Errorf("Unexpected Docker remediation text")
 	}
 }
 

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -420,13 +420,13 @@ func TestMixedPinning(t *testing.T) {
 	t.Parallel()
 
 	workflowDependency := checker.Dependency{
-		Name:     stringAsPointer("actions/checkout"),
-		PinnedAt: stringAsPointer("daadedc81d5f9d3c06d2c92f49202a3cc2b919ba"),
+		Name:     stringAsPointer("github/codeql-action/analyze"),
+		PinnedAt: nil,
 		Location: &checker.File{
 			Path:      ".github/workflows/workflow-not-pinned.yaml",
-			Snippet:   "actions/checkout@daadedc81d5f9d3c06d2c92f49202a3cc2b919ba",
-			Offset:    31,
-			EndOffset: 31,
+			Snippet:   "github/codeql-action/analyze@v1",
+			Offset:    79,
+			EndOffset: 79,
 			FileSize:  0,
 			Type:      1,
 		},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

As both the check for unpinned dependencies in GitHub Actions and the check for unpinned Docker dependencies contribute to d.Dependencies, the loop that created remediations for Docker dependencies would also create try to create Docker remediations for the unpinned GitHub Actions dependencies.

This could get really slow, especially when scanning a repo with many GitHub Actions such as https://github.com/apache/beam.

#### What is the new behavior (if this is a feature change)?**

Only create Docker remediations for Docker dependencies (and similar for GitHub workflow remediations)

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Improve Pinned-Dependencies remediation creation
```
