### PR TITLE
:seedling: avoid assumptions about versions in tests

### DIFF
--- a/pkg/scorecard_test.go
+++ b/pkg/scorecard_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/golang/mock/gomock"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"sigs.k8s.io/release-utils/version"
 
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/clients"
@@ -128,6 +129,10 @@ func TestRunScorecard(t *testing.T) {
 		uri       string
 		commitSHA string
 	}
+	// These values depend on the environment,
+	// so don't encode particular expectations
+	// in the test:
+	versionInfo := version.GetVersionInfo()
 	tests := []struct {
 		name    string
 		args    args
@@ -145,8 +150,8 @@ func TestRunScorecard(t *testing.T) {
 					Name: "github.com/ossf/scorecard",
 				},
 				Scorecard: ScorecardInfo{
-					Version:   "devel",
-					CommitSHA: "unknown",
+					Version:   versionInfo.GitVersion,
+					CommitSHA: versionInfo.GitCommit,
 				},
 			},
 			wantErr: false,
@@ -194,6 +199,10 @@ func TestRunScorecard(t *testing.T) {
 
 func TestExperimentalRunProbes(t *testing.T) {
 	t.Parallel()
+	// These values depend on the environment,
+	// so don't encode particular expectations
+	// in the test:
+	versionInfo := version.GetVersionInfo()
 	type args struct {
 		uri       string
 		commitSHA string
@@ -230,8 +239,8 @@ func TestExperimentalRunProbes(t *testing.T) {
 					},
 				},
 				Scorecard: ScorecardInfo{
-					Version:   "devel",
-					CommitSHA: "unknown",
+					Version:   versionInfo.GitVersion,
+					CommitSHA: versionInfo.GitCommit,
 				},
 				Findings: []finding.Finding{
 					{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

It makes the tests more resilient against differences in the environment in which scorecard is built.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Tests assume they are ran in an environment where the application version is not known/set.

#### What is the new behavior (if this is a feature change)?**

Tests make no assumptions about version fields anymore

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
