### PR TITLE
✨ probe: releases with verified provenance

### DIFF
--- a/checks/raw/signed_releases.go
+++ b/checks/raw/signed_releases.go
@@ -55,6 +55,24 @@ func SignedReleases(c *checker.CheckRequest) (checker.SignedReleasesData, error)
 		})
 	}
 
+	for _, v := range versions.Versions {
+		prov := checker.PackageProvenance{}
+
+		if len(v.SLSAProvenances) > 0 {
+			prov = checker.PackageProvenance{
+				Commit:     v.SLSAProvenances[0].Commit,
+				IsVerified: v.SLSAProvenances[0].Verified,
+			}
+		}
+
+		pkgs = append(pkgs, checker.ProjectPackage{
+			System:     v.VersionKey.System,
+			Name:       v.VersionKey.Name,
+			Version:    v.VersionKey.Version,
+			Provenance: prov,
+		})
+	}
+
 	return checker.SignedReleasesData{
 		Releases: releases,
 		Packages: pkgs,

--- a/clients/mockclients/repo.go
+++ b/clients/mockclients/repo.go
@@ -64,6 +64,20 @@ func (mr *MockRepoMockRecorder) AppendMetadata(metadata ...interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendMetadata", reflect.TypeOf((*MockRepo)(nil).AppendMetadata), metadata...)
 }
 
+// Path mocks base method.
+func (m *MockRepo) Path() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Path")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Path indicates an expected call of Path.
+func (mr *MockRepoMockRecorder) Path() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Path", reflect.TypeOf((*MockRepo)(nil).Path))
+}
+
 // Host mocks base method.
 func (m *MockRepo) Host() string {
 	m.ctrl.T.Helper()

--- a/clients/mockclients/repo.go
+++ b/clients/mockclients/repo.go
@@ -64,20 +64,6 @@ func (mr *MockRepoMockRecorder) AppendMetadata(metadata ...interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AppendMetadata", reflect.TypeOf((*MockRepo)(nil).AppendMetadata), metadata...)
 }
 
-// Path mocks base method.
-func (m *MockRepo) Path() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Path")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// Path indicates an expected call of Path.
-func (mr *MockRepoMockRecorder) Path() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Path", reflect.TypeOf((*MockRepo)(nil).Path))
-}
-
 // Host mocks base method.
 func (m *MockRepo) Host() string {
 	m.ctrl.T.Helper()

--- a/finding/finding.go
+++ b/finding/finding.go
@@ -144,10 +144,22 @@ func NewFalse(efs embed.FS, probeID, text string, loc *Location,
 	return NewWith(efs, probeID, text, loc, OutcomeFalse)
 }
 
+// NewNotApplicable create a finding with a NotApplicable outcome and the desired location.
+func NewNotApplicable(efs embed.FS, probeID, text string, loc *Location,
+) (*Finding, error) {
+	return NewWith(efs, probeID, text, loc, OutcomeNotApplicable)
+}
+
 // NewNotAvailable create a finding with a NotAvailable outcome and the desired location.
 func NewNotAvailable(efs embed.FS, probeID, text string, loc *Location,
 ) (*Finding, error) {
 	return NewWith(efs, probeID, text, loc, OutcomeNotAvailable)
+}
+
+// NewNotSupported create a finding with a NotSupported outcome and the desired location.
+func NewNotSupported(efs embed.FS, probeID, text string, loc *Location,
+) (*Finding, error) {
+	return NewWith(efs, probeID, text, loc, OutcomeNotSupported)
 }
 
 // NewTrue create a true finding with the desired location.

--- a/finding/probe.go
+++ b/finding/probe.go
@@ -142,7 +142,7 @@ func validateID(actual, expected string) error {
 
 func validateRemediation(r yamlRemediation) error {
 	if err := validateRemediationOutcomeTrigger(r.OnOutcome); err != nil {
-		return err
+		return fmt.Errorf("remediation: %w", err)
 	}
 	switch r.Effort {
 	case RemediationEffortHigh, RemediationEffortMedium, RemediationEffortLow:

--- a/options/flags.go
+++ b/options/flags.go
@@ -193,6 +193,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 	allowedFormats := []string{
 		FormatDefault,
 		FormatJSON,
+		FormatProbe,
 	}
 
 	if o.isSarifEnabled() {

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -48,6 +48,7 @@ import (
 	"github.com/ossf/scorecard/v5/probes/pinsDependencies"
 	"github.com/ossf/scorecard/v5/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveProvenance"
+	"github.com/ossf/scorecard/v5/probes/releasesHaveVerifiedProvenance"
 	"github.com/ossf/scorecard/v5/probes/requiresApproversForPullRequests"
 	"github.com/ossf/scorecard/v5/probes/requiresCodeOwnersReview"
 	"github.com/ossf/scorecard/v5/probes/requiresLastPushApproval"
@@ -139,6 +140,7 @@ var (
 	SignedReleases = []ProbeImpl{
 		releasesAreSigned.Run,
 		releasesHaveProvenance.Run,
+		releasesHaveVerifiedProvenance.Run,
 	}
 	BranchProtection = []ProbeImpl{
 		blocksDeleteOnBranches.Run,

--- a/probes/releasesHaveVerifiedProvenance/def.yml
+++ b/probes/releasesHaveVerifiedProvenance/def.yml
@@ -1,0 +1,34 @@
+# Copyright 2024 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: releasesHaveVerifiedProvenance
+short: Checks if the project releases with provenance attestations
+motivation: >
+  Package provenance attestations provide a greater guarantee of authenticity and integrity than package signatures alone, since the attestation can be performed over a hash of both the package contents and metadata. Developers can attest to particular qualities of the build, such as the build environment, build steps or builder identity.
+implementation: >
+  This probe checks how many packages published by the repository are associated with verified SLSA provenance attestations. It uses data from a ProjectPackageClient, which associates a GitHub/GitLab project with a package in a package manager. Using the data from the package manager (whom we rely on to verify the provenance attestation), this probe returns a finding for each release. For now, only NPM is supported.
+outcome:
+  - For each release, the probe returns OutcomeTrue or OutcomeFalse, depending on if the package has a verified provenance attestation.
+  - If we didn't find a package or didn't find releases, return OutcomeNotAvailable.
+remediation:
+  onOutcome: False
+  effort: Low
+  text:
+  - For NPM, publish provenance alongside your package using the `--provenance` flag (See (Introducing npm package provenance)[https://github.blog/2023-04-19-introducing-npm-package-provenance/])
+ecosystem:
+  languages:
+    - javascript
+  clients:
+    - github
+    - gitlab

--- a/probes/releasesHaveVerifiedProvenance/impl.go
+++ b/probes/releasesHaveVerifiedProvenance/impl.go
@@ -1,0 +1,70 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:stylecheck
+package releasesHaveVerifiedProvenance
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/probes"
+)
+
+func init() {
+	probes.MustRegister(Probe, Run, []probes.CheckName{probes.SignedReleases})
+}
+
+//go:embed *.yml
+var fs embed.FS
+
+const (
+	Probe = "releasesHaveVerifiedProvenance"
+)
+
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	var findings []finding.Finding
+
+	if len(raw.SignedReleasesResults.Packages) == 0 {
+		f, err := finding.NewNotAvailable(fs, Probe, "no package manager releases found", nil)
+		if err != nil {
+			return []finding.Finding{}, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		findings = append(findings, *f)
+		return findings, Probe, nil
+	}
+
+	for i := range raw.SignedReleasesResults.Packages {
+		p := raw.SignedReleasesResults.Packages[i]
+
+		if !p.Provenance.IsVerified {
+			f, err := finding.NewFalse(fs, Probe, "release without verified provenance", nil)
+			if err != nil {
+				return []finding.Finding{}, Probe, fmt.Errorf("create finding: %w", err)
+			}
+			findings = append(findings, *f)
+			continue
+		}
+
+		f, err := finding.NewTrue(fs, Probe, "release with verified provenance", nil)
+		if err != nil {
+			return []finding.Finding{}, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		findings = append(findings, *f)
+	}
+
+	return findings, Probe, nil
+}

--- a/probes/releasesHaveVerifiedProvenance/impl_test.go
+++ b/probes/releasesHaveVerifiedProvenance/impl_test.go
@@ -1,0 +1,117 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:stylecheck
+package releasesHaveVerifiedProvenance
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+func Test_Run(t *testing.T) {
+	tests := []struct {
+		desc     string
+		pkgs     []checker.ProjectPackage
+		outcomes []finding.Outcome
+		err      error
+	}{
+		{
+			desc:     "no packages found",
+			outcomes: []finding.Outcome{finding.OutcomeNotAvailable},
+		},
+		{
+			desc: "some releases with verified provenance",
+			pkgs: []checker.ProjectPackage{
+				{
+					Name:       "a",
+					Version:    "1.0.0",
+					Provenance: checker.PackageProvenance{IsVerified: true},
+				},
+				{
+					Name:    "a",
+					Version: "1.0.1",
+				},
+			},
+			outcomes: []finding.Outcome{finding.OutcomeTrue, finding.OutcomeFalse},
+		},
+		{
+			desc: "all releases with verified provenance",
+			pkgs: []checker.ProjectPackage{
+				{
+					Name:       "a",
+					Version:    "1.0.0",
+					Provenance: checker.PackageProvenance{IsVerified: true},
+				},
+				{
+					Name:       "a",
+					Version:    "1.0.1",
+					Provenance: checker.PackageProvenance{IsVerified: true},
+				},
+			},
+			outcomes: []finding.Outcome{finding.OutcomeTrue, finding.OutcomeTrue},
+		},
+		{
+			desc: "no verified provenance",
+			pkgs: []checker.ProjectPackage{
+				{
+					Name:    "a",
+					Version: "1.0.0",
+				},
+				{
+					Name:    "a",
+					Version: "1.0.1",
+				},
+			},
+			outcomes: []finding.Outcome{finding.OutcomeFalse, finding.OutcomeFalse},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // Re-initializing variable so it is not changed while executing the closure below
+		t.Run(tt.desc, func(t *testing.T) {
+			raw := checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Packages: tt.pkgs,
+				},
+			}
+
+			outcomes, _, err := Run(&raw)
+
+			if tt.err != err {
+				t.Errorf("expected %+v got %+v", tt.err, err)
+			}
+
+			if !cmpOutcomes(tt.outcomes, outcomes) {
+				t.Errorf("expected %+v got %+v", tt.outcomes, outcomes)
+			}
+		})
+	}
+}
+
+func cmpOutcomes(ex []finding.Outcome, act []finding.Finding) bool {
+	if len(ex) != len(act) {
+		return false
+	}
+
+	for i := range ex {
+		if act[i].Outcome != ex[i] {
+			return false
+		}
+	}
+
+	return true
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Add a probe to check for verified provenance. Look up the package associated with the GitHub/GitLab project, and check if the package. In the current version, this check only supports NPM packages.

#### Which issue(s) this PR fixes
Closes #3038.

Addresses #1776 and #298.

#### Special notes for your reviewer
For now, treating "No package found" the same as "this ecosystem doesn't have packages / doesn't support publishing provenance" - with `finding.NotAvailable`. In the future, we might add ecosystem detection to make the latter scenario `finding.NotApplicable`.

#### Does this PR introduce a user-facing change?

```release-note
probe: verified package provenance using package manager metadata
```
