### PR TITLE
:warning: Make all ScorecardResult format options pointers

### DIFF
--- a/cmd/internal/scdiff/app/format/format.go
+++ b/cmd/internal/scdiff/app/format/format.go
@@ -56,7 +56,7 @@ func JSON(r *pkg.ScorecardResult, w io.Writer) error {
 		return err
 	}
 	Normalize(r)
-	o := pkg.AsJSON2ResultOption{
+	o := &pkg.AsJSON2ResultOption{
 		Details:  details,
 		LogLevel: logLevel,
 	}

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -129,9 +129,14 @@ func (r *ScorecardResult) AsJSON(showDetails bool, logLevel log.Level, writer io
 }
 
 // AsJSON2 exports results as JSON for new detail format.
-func (r *ScorecardResult) AsJSON2(writer io.Writer,
-	checkDocs docs.Doc, o AsJSON2ResultOption,
-) error {
+func (r *ScorecardResult) AsJSON2(writer io.Writer, checkDocs docs.Doc, opt *AsJSON2ResultOption) error {
+	if opt == nil {
+		opt = &AsJSON2ResultOption{
+			LogLevel:    log.DefaultLevel,
+			Details:     false,
+			Annotations: false,
+		}
+	}
 	score, err := r.GetAggregateScore(checkDocs)
 	if err != nil {
 		return err
@@ -170,17 +175,17 @@ func (r *ScorecardResult) AsJSON2(writer io.Writer,
 			Reason: checkResult.Reason,
 			Score:  checkResult.Score,
 		}
-		if o.Details {
+		if opt.Details {
 			for i := range checkResult.Details {
 				d := checkResult.Details[i]
-				m := DetailToString(&d, o.LogLevel)
+				m := DetailToString(&d, opt.LogLevel)
 				if m == "" {
 					continue
 				}
 				tmpResult.Details = append(tmpResult.Details, m)
 			}
 		}
-		if o.Annotations {
+		if opt.Annotations {
 			exempted, reasons := checkResult.IsExempted(r.Config)
 			if exempted {
 				tmpResult.Annotations = reasons

--- a/pkg/json.go
+++ b/pkg/json.go
@@ -248,9 +248,3 @@ func ExperimentalFromJSON2(r io.Reader) (result ScorecardResult, score float64, 
 
 	return sr, float64(jsr.AggregateScore), nil
 }
-
-func (r *ScorecardResult) AsFJSON(showDetails bool,
-	logLevel log.Level, checkDocs docs.Doc, writer io.Writer,
-) error {
-	return sce.WithMessage(sce.ErrScorecardInternal, "WIP: not supported")
-}

--- a/pkg/json_test.go
+++ b/pkg/json_test.go
@@ -499,7 +499,7 @@ func TestJSONOutput(t *testing.T) {
 			}
 
 			var result bytes.Buffer
-			o := AsJSON2ResultOption{
+			o := &AsJSON2ResultOption{
 				Details:     tt.showDetails,
 				LogLevel:    tt.logLevel,
 				Annotations: tt.showAnnotations,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

breaking change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Some of the `AsX` functions take pointers (`AsProbe`), some take structs (`AsString`, `AsJSON2`)

#### What is the new behavior (if this is a feature change)?**
All three `AsX` functions which have option structs, take pointers.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
One item from #4048 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
