### PR TITLE
🌱 maintainer annotations: search for config

### DIFF
--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -169,11 +169,11 @@ func runScorecard(ctx context.Context,
 	go runEnabledChecks(ctx, repo, request, checksToRun, resultsCh)
 
 	if os.Getenv(options.EnvVarScorecardExperimental) == "1" {
-		r, err := findConfigFile(repoClient)
+		r := findConfigFile(repoClient)
 
 		logger := sclog.NewLogger(sclog.DefaultLevel)
 
-		if err == nil {
+		if r != nil {
 			defer r.Close()
 			checks := []string{}
 			for check := range checksToRun {
@@ -196,19 +196,19 @@ func runScorecard(ctx context.Context,
 	return ret, nil
 }
 
-func findConfigFile(rc clients.RepoClient) (io.ReadCloser, error) {
+func findConfigFile(rc clients.RepoClient) io.ReadCloser {
 	// Look for a config file. Return first one regardless of validity
 	locs := []string{"scorecard.yml", ".scorecard.yml", ".github/scorecard.yml"}
 
 	for i := range locs {
 		cfr, err := rc.GetFileReader(locs[i])
-		if err == nil {
+		if err != nil {
 			continue
 		}
-		return cfr, nil
+		return cfr
 	}
 
-	return nil, fmt.Errorf("no scorecard.yml found")
+	return nil
 }
 
 func runEnabledProbes(request *checker.CheckRequest,

--- a/pkg/scorecard_test.go
+++ b/pkg/scorecard_test.go
@@ -354,26 +354,31 @@ func Test_findConfigFile(t *testing.T) {
 	tests := []struct {
 		locs      []string
 		desc      string
+		found     string
 		wantFound bool
 	}{
 		{
 			desc:      "scorecard.yml exists",
 			locs:      []string{"scorecard.yml"},
+			found:     "scorecard.yml",
 			wantFound: true,
 		},
 		{
 			desc:      ".scorecard.yml exists",
 			locs:      []string{".scorecard.yml"},
+			found:     ".scorecard.yml",
 			wantFound: true,
 		},
 		{
 			desc:      ".github/scorecard.yml exists",
 			locs:      []string{".github/scorecard.yml"},
+			found:     ".github/scorecard.yml",
 			wantFound: true,
 		},
 		{
 			desc:      "multiple configs exist",
 			locs:      []string{"scorecard.yml", ".github/scorecard.yml"},
+			found:     "scorecard.yml",
 			wantFound: true,
 		},
 		{
@@ -400,7 +405,11 @@ func Test_findConfigFile(t *testing.T) {
 				}
 				return f, nil
 			})
-			r := findConfigFile(mockRepoClient)
+			r, path := findConfigFile(mockRepoClient)
+
+			if tt.found != "" && tt.found != path {
+				t.Errorf("expected config file %+v got %+v", tt.found, path)
+			}
 
 			if tt.wantFound != (r != nil) {
 				t.Errorf("wantFound: %+v got %+v", tt.wantFound, r)

--- a/pkg/testdata/.github/scorecard.yml
+++ b/pkg/testdata/.github/scorecard.yml
@@ -1,0 +1,5 @@
+annotations:
+  - checks:
+      - binary-artifacts
+    reasons:
+      - reason: test-data

--- a/pkg/testdata/.scorecard.yml
+++ b/pkg/testdata/.scorecard.yml
@@ -1,0 +1,5 @@
+annotations:
+  - checks:
+      - binary-artifacts
+    reasons:
+      - reason: test-data

--- a/pkg/testdata/scorecard.yml
+++ b/pkg/testdata/scorecard.yml
@@ -1,0 +1,5 @@
+annotations:
+  - checks:
+      - binary-artifacts
+    reasons:
+      - reason: test-data


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Look for maintainer annotation config files in multiple locations: `scorecard.yml`, `.scorecard.yml`, `.github/scorecard.yml`. Scorecard uses the first one it finds regardless of whether it's valid.

#### What is the current behavior?
Only look for `scorecard.yml` and don't apply maintainer annotation if that file doesn't exist.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Addresses #4048