### PR TITLE
:seedling: add stack info to osv-scanner error

### DIFF
--- a/clients/osv.go
+++ b/clients/osv.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"runtime/debug"
 
 	"github.com/google/osv-scanner/pkg/osvscanner"
 
@@ -38,7 +39,10 @@ func (v osvClient) ListUnfixedVulnerabilities(
 ) (_ VulnerabilitiesResponse, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = sce.CreateInternal(sce.ErrScorecardInternal, fmt.Sprintf("osv-scanner panic: %v", r))
+			err = sce.CreateInternal(
+				sce.ErrScorecardInternal,
+				fmt.Sprintf("osv-scanner panic: %v\n%s", r, string(debug.Stack())),
+			)
 		}
 	}()
 	directoryPaths := []string{}

--- a/clients/osv.go
+++ b/clients/osv.go
@@ -18,11 +18,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"runtime/debug"
-
 	"github.com/google/osv-scanner/pkg/osvscanner"
-
 	sce "github.com/ossf/scorecard/v5/errors"
+	"os"
+	"runtime/debug"
 )
 
 var _ VulnerabilitiesClient = osvClient{}
@@ -39,10 +38,8 @@ func (v osvClient) ListUnfixedVulnerabilities(
 ) (_ VulnerabilitiesResponse, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = sce.CreateInternal(
-				sce.ErrScorecardInternal,
-				fmt.Sprintf("osv-scanner panic: %v\n%s", r, string(debug.Stack())),
-			)
+			err = sce.CreateInternal(sce.ErrScorecardInternal, fmt.Sprintf("osv-scanner panic: %v", r))
+			fmt.Fprintf(os.Stderr, "osv-scanner panic: %v\n%s\n", r, string(debug.Stack()))
 		}
 	}()
 	directoryPaths := []string{}

--- a/clients/osv.go
+++ b/clients/osv.go
@@ -18,10 +18,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/google/osv-scanner/pkg/osvscanner"
-	sce "github.com/ossf/scorecard/v5/errors"
 	"os"
 	"runtime/debug"
+
+	"github.com/google/osv-scanner/pkg/osvscanner"
+
+	sce "github.com/ossf/scorecard/v5/errors"
 )
 
 var _ VulnerabilitiesClient = osvClient{}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

feature

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

only print a error string for osv-scanner panic error

#### What is the new behavior (if this is a feature change)?**

also print the stacktrace

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Updates #4171 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
