### PR TITLE
:seedling: Use new Scorecard entrypoint for CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -96,11 +96,6 @@ func rootCmd(o *options.Options) error {
 	}
 
 	ctx := context.Background()
-	opts := []pkg.Option{
-		pkg.WithLogLevel(sclog.ParseLevel(o.LogLevel)),
-		pkg.WithCommitSHA(o.Commit),
-		pkg.WithCommitDepth(o.CommitDepth),
-	}
 
 	var repo clients.Repo
 	if o.Local != "" {
@@ -148,12 +143,14 @@ func rootCmd(o *options.Options) error {
 			printCheckStart(enabledChecks)
 		}
 	}
-	opts = append(opts,
+
+	repoResult, err = pkg.Run(ctx, repo,
+		pkg.WithLogLevel(sclog.ParseLevel(o.LogLevel)),
+		pkg.WithCommitSHA(o.Commit),
+		pkg.WithCommitDepth(o.CommitDepth),
 		pkg.WithProbes(enabledProbes),
 		pkg.WithChecks(checks),
 	)
-
-	repoResult, err = pkg.Run(ctx, repo, opts...)
 	if err != nil {
 		return fmt.Errorf("RunScorecard: %w", err)
 	}

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -268,33 +268,6 @@ func RunScorecard(ctx context.Context,
 	)
 }
 
-// ExperimentalRunProbes is experimental. Do not depend on it, it may be removed at any point.
-func ExperimentalRunProbes(ctx context.Context,
-	repo clients.Repo,
-	commitSHA string,
-	commitDepth int,
-	checksToRun checker.CheckNameToFnMap,
-	probesToRun []string,
-	repoClient clients.RepoClient,
-	ossFuzzRepoClient clients.RepoClient,
-	ciiClient clients.CIIBestPracticesClient,
-	vulnsClient clients.VulnerabilitiesClient,
-	projectClient packageclient.ProjectPackageClient,
-) (ScorecardResult, error) {
-	return runScorecard(ctx,
-		repo,
-		commitSHA,
-		commitDepth,
-		checksToRun,
-		probesToRun,
-		repoClient,
-		ossFuzzRepoClient,
-		ciiClient,
-		vulnsClient,
-		projectClient,
-	)
-}
-
 type runConfig struct {
 	client        clients.RepoClient
 	vulnClient    clients.VulnerabilitiesClient

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -301,13 +301,21 @@ type runConfig struct {
 	ciiClient     clients.CIIBestPracticesClient
 	projectClient packageclient.ProjectPackageClient
 	ossfuzzClient clients.RepoClient
-	checks        []string
 	commit        string
+	logLevel      sclog.Level
+	checks        []string
 	probes        []string
 	commitDepth   int
 }
 
 type Option func(*runConfig) error
+
+func WithLogLevel(level sclog.Level) Option {
+	return func(c *runConfig) error {
+		c.logLevel = level
+		return nil
+	}
+}
 
 func WithCommitDepth(depth int) Option {
 	return func(c *runConfig) error {
@@ -366,16 +374,16 @@ func WithOpenSSFBestPraticesClient(client clients.CIIBestPracticesClient) Option
 }
 
 func Run(ctx context.Context, repo clients.Repo, opts ...Option) (ScorecardResult, error) {
-	// TODO logger
-	logger := sclog.NewLogger(sclog.InfoLevel)
 	c := runConfig{
-		commit: clients.HeadSHA,
+		commit:   clients.HeadSHA,
+		logLevel: sclog.DefaultLevel,
 	}
 	for _, option := range opts {
 		if err := option(&c); err != nil {
 			return ScorecardResult{}, err
 		}
 	}
+	logger := sclog.NewLogger(c.logLevel)
 	if c.ciiClient == nil {
 		c.ciiClient = clients.DefaultCIIBestPracticesClient()
 	}

--- a/pkg/scorecard_test.go
+++ b/pkg/scorecard_test.go
@@ -202,7 +202,7 @@ func TestRunScorecard(t *testing.T) {
 	}
 }
 
-func TestExperimentalRunProbes(t *testing.T) {
+func TestRun_WithProbes(t *testing.T) {
 	t.Parallel()
 	// These values depend on the environment,
 	// so don't encode particular expectations
@@ -283,7 +283,7 @@ func TestExperimentalRunProbes(t *testing.T) {
 			repo.EXPECT().Host().Return("github.com").AnyTimes()
 
 			mockRepoClient.EXPECT().InitRepo(repo, tt.args.commitSHA, 0).Return(nil)
-
+			mockRepoClient.EXPECT().URI().Return(repo.URI()).AnyTimes()
 			mockRepoClient.EXPECT().Close().DoAndReturn(func() error {
 				return nil
 			})
@@ -320,17 +320,13 @@ func TestExperimentalRunProbes(t *testing.T) {
 			mockRepoClient.EXPECT().ListProgrammingLanguages().Return(progLanguages, nil).AnyTimes()
 
 			mockRepoClient.EXPECT().GetDefaultBranchName().Return("main", nil).AnyTimes()
-			got, err := ExperimentalRunProbes(context.Background(),
-				repo,
-				tt.args.commitSHA,
-				0,
-				nil,
-				tt.args.probes,
-				mockRepoClient,
-				nil,
-				nil,
-				nil,
-				nil,
+			mockOSSFuzzClient := mockrepo.NewMockRepoClient(ctrl)
+			mockOSSFuzzClient.EXPECT().Search(gomock.Any()).Return(clients.SearchResponse{}, nil).AnyTimes()
+			got, err := Run(context.Background(), repo,
+				WithRepoClient(mockRepoClient),
+				WithOSSFuzzClient(mockOSSFuzzClient),
+				WithCommitSHA(tt.args.commitSHA),
+				WithProbes(tt.args.probes),
 			)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("RunScorecard() error = %v, wantErr %v", err, tt.wantErr)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

refactor

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- the CLI uses the old `pkg.ExperimentalRunProbes` function

#### What is the new behavior (if this is a feature change)?**
- deleted `ExperimentalRunProbes`  (not a breaking change since marked experimental
- CLI uses the new `pkg.Run` entrypoint.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Followup to #3717 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
