### PR TITLE
:seedling: Use new entrypoint for scdiff

### DIFF
--- a/cmd/internal/scdiff/app/runner/runner.go
+++ b/cmd/internal/scdiff/app/runner/runner.go
@@ -17,36 +17,22 @@ package runner
 import (
 	"context"
 	"errors"
-	"strings"
 
-	"github.com/ossf/scorecard/v5/checker"
-	"github.com/ossf/scorecard/v5/checks"
 	"github.com/ossf/scorecard/v5/clients"
 	"github.com/ossf/scorecard/v5/clients/githubrepo"
 	"github.com/ossf/scorecard/v5/clients/gitlabrepo"
-	"github.com/ossf/scorecard/v5/clients/ossfuzz"
 	sce "github.com/ossf/scorecard/v5/errors"
-	"github.com/ossf/scorecard/v5/internal/packageclient"
 	"github.com/ossf/scorecard/v5/log"
 	"github.com/ossf/scorecard/v5/pkg"
-)
-
-const (
-	commit      = clients.HeadSHA
-	commitDepth = 0 // default
 )
 
 // Runner holds the clients and configuration needed to run Scorecard on multiple repos.
 type Runner struct {
 	ctx           context.Context
-	logger        *log.Logger
-	enabledChecks checker.CheckNameToFnMap
 	githubClient  clients.RepoClient
 	gitlabClient  clients.RepoClient
-	ossFuzz       clients.RepoClient
-	cii           clients.CIIBestPracticesClient
-	vuln          clients.VulnerabilitiesClient
-	deps          packageclient.ProjectPackageClient
+	logger        *log.Logger
+	enabledChecks []string
 }
 
 // Creates a Runner which will run the listed checks. If no checks are provided, all will run.
@@ -62,11 +48,7 @@ func New(enabledChecks []string) Runner {
 		logger:        logger,
 		githubClient:  githubrepo.CreateGithubRepoClient(ctx, logger),
 		gitlabClient:  gitlabClient,
-		ossFuzz:       ossfuzz.CreateOSSFuzzClient(ossfuzz.StatusURL),
-		cii:           clients.DefaultCIIBestPracticesClient(),
-		vuln:          clients.DefaultVulnerabilitiesClient(),
-		deps:          packageclient.CreateDepsDevClient(),
-		enabledChecks: parseChecks(enabledChecks),
+		enabledChecks: enabledChecks,
 	}
 }
 
@@ -82,8 +64,9 @@ func (r *Runner) Run(repoURI string) (pkg.ScorecardResult, error) {
 	if err != nil {
 		return pkg.ScorecardResult{}, err
 	}
-	return pkg.RunScorecard(
-		r.ctx, repo, commit, commitDepth, r.enabledChecks, repoClient, r.ossFuzz, r.cii, r.vuln, r.deps,
+	return pkg.Run(r.ctx, repo,
+		pkg.WithRepoClient(repoClient),
+		pkg.WithChecks(r.enabledChecks),
 	)
 }
 
@@ -92,21 +75,4 @@ func (r *Runner) log(msg string) {
 	if r.logger != nil {
 		r.logger.Info(msg)
 	}
-}
-
-func parseChecks(c []string) checker.CheckNameToFnMap {
-	all := checks.GetAll()
-	if len(c) == 0 {
-		return all
-	}
-
-	ret := checker.CheckNameToFnMap{}
-	for _, requested := range c {
-		for key, fn := range all {
-			if strings.EqualFold(key, requested) {
-				ret[key] = fn
-			}
-		}
-	}
-	return ret
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- uses older `pkg.RunScorecard`

#### What is the new behavior (if this is a feature change)?**
- uses new `pkg.Run`

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Follow up of #3717 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
