### PR TITLE
:seedling: Use new entrypoint for cron worker

### DIFF
--- a/cron/internal/worker/main.go
+++ b/cron/internal/worker/main.go
@@ -40,7 +40,6 @@ import (
 	"github.com/ossf/scorecard/v5/cron/worker"
 	docs "github.com/ossf/scorecard/v5/docs/checks"
 	sce "github.com/ossf/scorecard/v5/errors"
-	"github.com/ossf/scorecard/v5/internal/packageclient"
 	"github.com/ossf/scorecard/v5/log"
 	"github.com/ossf/scorecard/v5/pkg"
 	"github.com/ossf/scorecard/v5/policy"
@@ -90,7 +89,6 @@ type ScorecardWorker struct {
 	ciiClient         clients.CIIBestPracticesClient
 	ossFuzzRepoClient clients.RepoClient
 	vulnsClient       clients.VulnerabilitiesClient
-	projectClient     packageclient.ProjectPackageClient
 	apiBucketURL      string
 	rawBucketURL      string
 	blacklistedChecks []string
@@ -138,8 +136,6 @@ func newScorecardWorker() (*ScorecardWorker, error) {
 		sw.vulnsClient = clients.DefaultVulnerabilitiesClient()
 	}
 
-	sw.projectClient = packageclient.CreateDepsDevClient()
-
 	if sw.exporter, err = startMetricsExporter(); err != nil {
 		return nil, fmt.Errorf("startMetricsExporter: %w", err)
 	}
@@ -161,7 +157,7 @@ func (sw *ScorecardWorker) Close() {
 func (sw *ScorecardWorker) Process(ctx context.Context, req *data.ScorecardBatchRequest, bucketURL string) error {
 	return processRequest(ctx, req, sw.blacklistedChecks, bucketURL, sw.rawBucketURL, sw.apiBucketURL,
 		sw.checkDocs, sw.githubClient, sw.gitlabClient, sw.ossFuzzRepoClient, sw.ciiClient,
-		sw.vulnsClient, sw.projectClient, sw.logger)
+		sw.vulnsClient, sw.logger)
 }
 
 func (sw *ScorecardWorker) PostProcess() {
@@ -176,7 +172,6 @@ func processRequest(ctx context.Context,
 	githubClient, gitlabClient clients.RepoClient, ossFuzzRepoClient clients.RepoClient,
 	ciiClient clients.CIIBestPracticesClient,
 	vulnsClient clients.VulnerabilitiesClient,
-	projectClient packageclient.ProjectPackageClient,
 	logger *log.Logger,
 ) error {
 	filename := worker.ResultFilename(batchRequest)
@@ -200,6 +195,9 @@ func processRequest(ctx context.Context,
 		}
 		repo.AppendMetadata(repoReq.GetMetadata()...)
 
+		// TODO: realistically the enabled/disabled checks can just be
+		// calculated once in newScorecardWorker as all of the repos use
+		// clients.HeadSHA. but not doing yet to keep refactor small
 		commitSHA := clients.HeadSHA
 		requiredRequestType := []checker.RequestType{}
 		if repoReq.GetCommit() != clients.HeadSHA {
@@ -214,9 +212,19 @@ func processRequest(ctx context.Context,
 		for _, check := range disabledChecks {
 			delete(checksToRun, check)
 		}
+		enabledChecks := make([]string, 0, len(checksToRun))
+		for check := range checksToRun {
+			enabledChecks = append(enabledChecks, check)
+		}
 
-		result, err := pkg.RunScorecard(ctx, repo, commitSHA, 0, checksToRun,
-			repoClient, ossFuzzRepoClient, ciiClient, vulnsClient, projectClient)
+		result, err := pkg.Run(ctx, repo,
+			pkg.WithCommitSHA(commitSHA),
+			pkg.WithChecks(enabledChecks),
+			pkg.WithRepoClient(repoClient),
+			pkg.WithOSSFuzzClient(ossFuzzRepoClient),
+			pkg.WithOpenSSFBestPraticesClient(ciiClient),
+			pkg.WithVulnerabilitiesClient(vulnsClient),
+		)
 		if errors.Is(err, sce.ErrRepoUnreachable) {
 			// Not accessible repo - continue.
 			continue


### PR DESCRIPTION

#### What kind of change does this PR introduce?

cron update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Uses the old `pkg.RunScorecard`

#### What is the new behavior (if this is a feature change)?**
Uses the new `pkg.Run`
There are further simplifications that are possible, but leaving for later to keep this PR small.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Follow up of #3717 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
