### PR TITLE
:seedling: fix dependabot config to group docker images

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,12 @@ updates:
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
+  # currently needed to get PRs which actually update multiple directories in a single PR
+  # https://github.com/dependabot/dependabot-core/issues/2178#issuecomment-2109164992
+  groups:
+    golang:
+      patterns:
+        - "golang"
+    distroless:
+      patterns:
+        - "distroless/base"


### PR DESCRIPTION
This is apparently required with the current implementation of multi dir PRs.

#### What kind of change does this PR introduce?

ci update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- without groups dependabot only updates the deps in the first declared directory, a known bug reported upstream. For example in #4160, I had to bump the other 7 occurrences in a manual fix.

#### What is the new behavior (if this is a feature change)?**
- dependabot actually groups updates. Examples:
  - https://github.com/spencerschrock/actions-test/pull/15
  - https://github.com/spencerschrock/actions-test/pull/16

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
