### PR TITLE
:book: Update security policy to be specific to OpenSSF Scorecard

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,6 +3,9 @@
 This document outlines security procedures and general policies for the
 OpenSSF Scorecard project.
 
+This policy adheres to the [vulnerability management guidance](https://www.linuxfoundation.org/security)
+for Linux Foundation projects.
+
 - [Disclosing a security issue](#disclosing-a-security-issue)
 - [Vulnerability management](#vulnerability-management)
 - [Suggesting changes](#suggesting-changes)
@@ -28,9 +31,15 @@ Here are some helpful details to include in your report:
 
 A maintainer will acknowledge the report within 72 hours, and will send a more
 detailed response within an additional 72 hours indicating the next steps in
-handling your report. After the initial reply to your report, the maintainers
-will endeavor to keep you informed of the progress towards a fix and full
-announcement, and may ask for additional information or guidance.
+handling your report.
+
+If you've been unable to successfully draft a vulnerability report via GitHub
+or have not received a response during the alloted response window, please
+reach out via the [OpenSSF security contact email](mailto:security@openssf.org).
+
+After the initial reply to your report, the maintainers will endeavor to keep
+you informed of the progress towards a fix and full announcement, and may ask
+for additional information or guidance.
 
 ## Vulnerability management
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,24 +1,51 @@
-# Reporting Security Issues
+# OpenSSF Scorecard Security Policy
 
-<!-- TODO: Adapt any useful components from previous policy.
+This document outlines security procedures and general policies for the
+OpenSSF Scorecard project.
 
-- Where should issues be reported?
-- What goes in a report?
-  - a description of the issue
-  - the steps required to recreate the issue
-  - affected versions
-  - (if known) mitigations for the issue
-- What is the project's response time?
-- What happens next?
-- How are contributions acknowledged?
-- Is there a disclosure timeline?
--->
+- [Disclosing a security issue](#disclosing-a-security-issue)
+- [Vulnerability management](#vulnerability-management)
+- [Suggesting changes](#suggesting-changes)
 
-Per the [Linux Foundation Vulnerability Disclosure Policy](https://www.linuxfoundation.org/security),
-if you find a vulnerability in a project maintained by the Open Source Security
-Foundation (OpenSSF), please report that directly to the project maintaining
-that code, preferably using GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+## Disclosing a security issue
 
-If you've been unable to find a way to report it, or have received no response
-after repeated attempts, please contact the OpenSSF security contact email,
-[security@openssf.org](mailto:security@openssf.org).
+The OpenSSF Scorecard maintainers take all security issues in the project
+seriously. Thank you for improving the security of OpenSSF Scorecard. We
+appreciate your dedication to responsible disclosure and will make every effort
+to acknowledge your contributions.
+
+OpenSSF Scorecard leverages GitHub's private vulnerability reporting.
+
+To learn more about this feature and how to submit a vulnerability report,
+review [GitHub's documentation on private reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+
+Here are some helpful details to include in your report:
+
+- a detailed description of the issue
+- the steps required to reproduce the issue
+- versions of the project that may be affected by the issue
+- if known, any mitigations for the issue
+
+A maintainer will acknowledge the report within 72 hours, and will send a more
+detailed response within an additional 72 hours indicating the next steps in
+handling your report. After the initial reply to your report, the maintainers
+will endeavor to keep you informed of the progress towards a fix and full
+announcement, and may ask for additional information or guidance.
+
+## Vulnerability management
+
+When the maintainers receive a disclosure report, they will assign it to a
+primary handler.
+
+This person will coordinate the fix and release process, which involves the
+following steps:
+
+- confirming the issue
+- determining affected versions of the project
+- auditing code to find any potential similar problems
+- preparing fixes for all releases under maintenance
+
+## Suggesting changes
+
+If you have suggestions on how this process could be improved please submit an
+issue or pull request.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -20,7 +20,7 @@ to acknowledge your contributions.
 OpenSSF Scorecard leverages GitHub's private vulnerability reporting.
 
 To learn more about this feature and how to submit a vulnerability report,
-review [GitHub's documentation on private reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
+review [GitHub's documentation on private reporting](https://docs.github.com/code-security/security-advisories/guidance-on-reporting-and-writing-information-about-vulnerabilities/privately-reporting-a-security-vulnerability).
 
 Here are some helpful details to include in your report:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,11 +1,24 @@
 # Reporting Security Issues
 
-To report a security issue, please email
-[oss-security@googlegroups.com](mailto:oss-security@googlegroups.com)
-with a description of the issue, the steps you took to create the issue,
-affected versions, and, if known, mitigations for the issue.
+<!-- TODO: Adapt any useful components from previous policy.
 
-Our vulnerability management team will respond within 3 working days of your
-email. If the issue is confirmed as a vulnerability, we will open a
-Security Advisory and acknowledge your contributions as part of it. This project
-follows a 90 day disclosure timeline.
+- Where should issues be reported?
+- What goes in a report?
+  - a description of the issue
+  - the steps required to recreate the issue
+  - affected versions
+  - (if known) mitigations for the issue
+- What is the project's response time?
+- What happens next?
+- How are contributions acknowledged?
+- Is there a disclosure timeline?
+-->
+
+Per the [Linux Foundation Vulnerability Disclosure Policy](https://www.linuxfoundation.org/security),
+if you find a vulnerability in a project maintained by the Open Source Security
+Foundation (OpenSSF), please report that directly to the project maintaining
+that code, preferably using GitHub's [Private Vulnerability Reporting](https://docs.github.com/en/code-security/security-advisories/guidance-on-reporting-and-writing/privately-reporting-a-security-vulnerability#privately-reporting-a-security-vulnerability).
+
+If you've been unable to find a way to report it, or have received no response
+after repeated attempts, please contact the OpenSSF security contact email,
+[security@openssf.org](mailto:security@openssf.org).


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The [current security policy](https://github.com/ossf/scorecard/blob/5f7cea363724ba03923eb07bdb4e6fa3b2927c15/SECURITY.md) was last updated three years and appears to be boilerplate from Google open source projects.

#### What is the new behavior (if this is a feature change)?**

This updated security policy is specific to the OpenSSF Scorecard project and considers:

- the previously-written policy
- the inherited [SECURITY.md from ossf/.github](https://github.com/ossf/.github/blob/692a363fd99ad0ea50a9512795d53a24e1754d9c/SECURITY.md)
- the LF vulnerability disclosure process for projects: https://www.linuxfoundation.org/security
- the Cisco open source project [SECURITY.md](https://github.com/cisco-ospo/oss-template/blob/main/SECURITY.md), which was itself inspired by the [Wayfair OSS project template](https://github.com/wayfair-incubator/oss-template)

#### Which issue(s) this PR fixes

Partially addresses https://github.com/ossf/scorecard/issues/4194.

#### Special notes for your reviewer

Tagging a few different groups for review here, as the new standard for OpenSSF Scorecard subproject security policies should be something along the lines of:

> This project adheres to the [OpenSSF Scorecard security policy](https://github.com/ossf/scorecard/blob/main/SECURITY.md).

(to minimize drift across the project)

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
