### PR TITLE
:sparkles: remove experimental gate on maintainer annotation parsing

### DIFF
--- a/cmd/internal/scdiff/app/runner/runner_test.go
+++ b/cmd/internal/scdiff/app/runner/runner_test.go
@@ -16,6 +16,7 @@ package runner
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -44,6 +45,7 @@ func TestRunner_Run(t *testing.T) {
 	mockRepo.EXPECT().InitRepo(gomock.Any(), gomock.Any(), gomock.Any()).Return(nil)
 	mockRepo.EXPECT().GetDefaultBranchName().Return("main", nil)
 	mockRepo.EXPECT().Close().Return(nil)
+	mockRepo.EXPECT().GetFileReader(gomock.Any()).Return(nil, errors.New("reading files unsupported for this test")).AnyTimes()
 	r := Runner{
 		ctx: context.Background(),
 		// use a check which works locally, but we declare no files above so no-op

--- a/options/flags.go
+++ b/options/flags.go
@@ -155,14 +155,12 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		"show extra details about each check",
 	)
 
-	if o.isExperimentalEnabled() {
-		cmd.Flags().BoolVar(
-			&o.ShowAnnotations,
-			FlagShowAnnotations,
-			o.ShowAnnotations,
-			"show maintainers annotations for checks",
-		)
-	}
+	cmd.Flags().BoolVar(
+		&o.ShowAnnotations,
+		FlagShowAnnotations,
+		o.ShowAnnotations,
+		"show maintainers annotations for checks",
+	)
 
 	cmd.Flags().IntVar(
 		&o.CommitDepth,

--- a/options/flags_test.go
+++ b/options/flags_test.go
@@ -182,6 +182,7 @@ func TestOptions_AddFlags_Format(t *testing.T) {
 }
 
 func TestOptions_AddFlags_Annotations(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		opts *Options
 		name string
@@ -202,6 +203,7 @@ func TestOptions_AddFlags_Annotations(t *testing.T) {
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			cmd := &cobra.Command{}
 			tt.opts.AddFlags(cmd)
 			value, err := cmd.Flags().GetBool(FlagShowAnnotations)

--- a/options/flags_test.go
+++ b/options/flags_test.go
@@ -183,50 +183,33 @@ func TestOptions_AddFlags_Format(t *testing.T) {
 
 func TestOptions_AddFlags_Annotations(t *testing.T) {
 	tests := []struct {
-		opts         *Options
-		name         string
-		experimental bool
+		opts *Options
+		name string
 	}{
 		{
-			name: "Cannot show annotations if experimental is disabled",
+			name: "Show annotations",
 			opts: &Options{
 				ShowAnnotations: true,
 			},
 		},
 		{
-			name: "Show annotations with experimental enabled",
-			opts: &Options{
-				ShowAnnotations: true,
-			},
-			experimental: true,
-		},
-		{
-			name: "Don't show annotations with experimental enabled",
+			name: "Don't show annotations",
 			opts: &Options{
 				ShowAnnotations: false,
 			},
-			experimental: true,
 		},
 	}
 	for _, tt := range tests {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := &cobra.Command{}
-			if tt.experimental {
-				t.Setenv("SCORECARD_EXPERIMENTAL", "1")
-			}
 			tt.opts.AddFlags(cmd)
-			if tt.experimental == false && cmd.Flag(FlagShowAnnotations) != nil {
-				t.Fatal("expected FlagShowAnnotations to be nil since experimental is disabled")
+			value, err := cmd.Flags().GetBool(FlagShowAnnotations)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
-			if tt.experimental == true {
-				value, err := cmd.Flags().GetBool(FlagShowAnnotations)
-				if err != nil {
-					t.Fatal("expected FlagShowAnnotations to be set but got error %w", err)
-				}
-				if tt.opts.ShowAnnotations != value {
-					t.Fatalf("expected FlagShowAnnotations to be %t, got %t", tt.opts.ShowAnnotations, value)
-				}
+			if tt.opts.ShowAnnotations != value {
+				t.Fatalf("expected FlagShowAnnotations to be %t, got %t", tt.opts.ShowAnnotations, value)
 			}
 		})
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -229,13 +229,6 @@ func (o *Options) Probes() []string {
 	return o.ProbesToRun
 }
 
-// isExperimentalEnabled returns true if experimental features were enabled via
-// environment variable.
-func (o *Options) isExperimentalEnabled() bool {
-	value, _ := os.LookupEnv(EnvVarScorecardExperimental)
-	return value == "1"
-}
-
 // isSarifEnabled returns true if SARIF format was specified in options or via
 // environment variable.
 func (o *Options) isSarifEnabled() bool {

--- a/pkg/scorecard.go
+++ b/pkg/scorecard.go
@@ -20,7 +20,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
 	"time"
@@ -39,7 +38,6 @@ import (
 	"github.com/ossf/scorecard/v5/internal/packageclient"
 	proberegistration "github.com/ossf/scorecard/v5/internal/probes"
 	sclog "github.com/ossf/scorecard/v5/log"
-	"github.com/ossf/scorecard/v5/options"
 	"github.com/ossf/scorecard/v5/policy"
 )
 
@@ -173,19 +171,18 @@ func runScorecard(ctx context.Context,
 	// If the user runs checks
 	go runEnabledChecks(ctx, repo, request, checksToRun, resultsCh)
 
-	if os.Getenv(options.EnvVarScorecardExperimental) == "1" {
-		r, path := findConfigFile(repoClient)
-		logger := sclog.NewLogger(sclog.DefaultLevel)
+	// get the repository's config file to read annotations
+	r, path := findConfigFile(repoClient)
+	logger := sclog.NewLogger(sclog.DefaultLevel)
 
-		if r != nil {
-			defer r.Close()
-			logger.Info(fmt.Sprintf("using maintainer annotations: %s", path))
-			c, err := config.Parse(r)
-			if err != nil {
-				logger.Info(fmt.Sprintf("couldn't parse maintainer annotations: %v", err))
-			}
-			ret.Config = c
+	if r != nil {
+		defer r.Close()
+		logger.Info(fmt.Sprintf("using maintainer annotations: %s", path))
+		c, err := config.Parse(r)
+		if err != nil {
+			logger.Info(fmt.Sprintf("couldn't parse maintainer annotations: %v", err))
 		}
+		ret.Config = c
 	}
 
 	for result := range resultsCh {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

feature enablement

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Looking for maintainer annotations is gated behind the SCORECARD_EXPERIMENTAL flag

#### What is the new behavior (if this is a feature change)?**
The feature is no longer gated

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
