### PR TITLE
:book: Fix typo in branch protections details

### DIFF
--- a/probes/internal/utils/branchprotection/branchProtection.go
+++ b/probes/internal/utils/branchprotection/branchProtection.go
@@ -32,7 +32,7 @@ func GetTextOutcomeFromBool(b *bool, rule, branchName string) (string, finding.O
 		msg := fmt.Sprintf("'%s' is required to merge on branch '%s'", rule, branchName)
 		return msg, finding.OutcomeTrue, nil
 	case !*b:
-		msg := fmt.Sprintf("'%s' is disable on branch '%s'", rule, branchName)
+		msg := fmt.Sprintf("'%s' is disabled on branch '%s'", rule, branchName)
 		return msg, finding.OutcomeFalse, nil
 	}
 	return "", finding.OutcomeError, errWrongValue


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Fix typo in branch protections details message.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Messages such as the following are emitted in scorecard reports:

```text
Warn: 'stale review dismissal' is disable on branch 'main'
```

#### What is the new behavior (if this is a feature change)?**

Grammar in message is fixed to use the correct text:

```diff
- Warn: 'stale review dismissal' is disable on branch 'main'
+ Warn: 'stale review dismissal' is disabled on branch 'main'
```

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Fix typo in branch protections details.
```
