### PR TITLE
:seedling: skip failing GitHub status e2e test temporarily

### DIFF
--- a/clients/githubrepo/statuses_e2e_test.go
+++ b/clients/githubrepo/statuses_e2e_test.go
@@ -44,6 +44,7 @@ var _ = Describe("E2E TEST: githubrepo.statusesHandler", func() {
 	})
 	Context("listStatuses()", func() {
 		It("returns statuses", func() {
+			Skip("TODO: https://github.com/ossf/scorecard/issues/4273")
 			repoURL := Repo{
 				owner:     "ossf",
 				repo:      "scorecard",


### PR DESCRIPTION
#### What kind of change does this PR introduce?

disabling one e2e test

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The e2e test is blocking PRs, see #4267
 
#### What is the new behavior (if this is a feature change)?**
The test is disabled and a TODO issue was filed #4273 

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->
NONE
#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
