### PR TITLE
:sparkles: Switched API release links to non-API release links

### DIFF
--- a/clients/githubrepo/releases.go
+++ b/clients/githubrepo/releases.go
@@ -77,7 +77,7 @@ func releasesFrom(data []*github.RepositoryRelease) []clients.Release {
 		for _, a := range r.Assets {
 			release.Assets = append(release.Assets, clients.ReleaseAsset{
 				Name: a.GetName(),
-				URL:  a.GetURL(),
+				URL:  r.GetHTMLURL(),
 			})
 		}
 		releases = append(releases, release)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR introduces a feature change for the release links generated by the following command: 
`go run main.go --repo ossf/scorecard --checks Signed-Releases --format json --show-details | jq`

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
When running command to view releases, links display API format

#### What is the new behavior (if this is a feature change)?**
When running command to view releases, links display non-API format

- [ ] Tests for the changes have been added (for bug fixes/features)
 
#### Which issue(s) this PR fixes
Fixes #4030 

#### Special notes for your reviewer
Did not add test for changes but ran current test 
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

```release-note
NONE
```
