### PR TITLE
:seedling: Update Go toolchain to 1.23

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   analyze:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ on:
   - main
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   docs_only_check:

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -25,7 +25,7 @@ on:
       - main
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   gitlab-integration-trusted:

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   goreleaser:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   approve:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: read # Use with `only-new-issues` option.
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   golangci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   PROTOC_VERSION: 21.6
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   unit-test:

--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -23,7 +23,7 @@ on:
       - v*
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   publishimage:

--- a/.github/workflows/scdiff.yml
+++ b/.github/workflows/scdiff.yml
@@ -6,7 +6,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   share-link:

--- a/.github/workflows/slsa-goreleaser.yml
+++ b/.github/workflows/slsa-goreleaser.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: 1.22
+  GO_VERSION: 1.23
 
 jobs:
   # Generate ldflags dynamically.

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/attestor/Dockerfile
+++ b/attestor/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src/scorecard
 COPY . ./
 

--- a/clients/githubrepo/roundtripper/tokens/server/Dockerfile
+++ b/clients/githubrepo/roundtripper/tokens/server/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/bq/Dockerfile
+++ b/cron/internal/bq/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/cii/Dockerfile
+++ b/cron/internal/cii/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/controller/Dockerfile
+++ b/cron/internal/controller/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/webhook/Dockerfile
+++ b/cron/internal/webhook/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/cron/internal/worker/Dockerfile
+++ b/cron/internal/worker/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.22.6@sha256:2bd56f00ff47baf33e64eae7996b65846c7cb5e0a46e0a882ef179fd89654afa AS base
+FROM golang:1.23.0@sha256:8e529b64d382182bb84f201dea3c72118f6ae9bc01d27190ffc5a54acf0091d2 AS base
 WORKDIR /src
 ENV CGO_ENABLED=0
 COPY go.* ./

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/scorecard/tools
 
-go 1.22.4
+go 1.23.0
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Go version bump

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Our tooling uses Go 1.22.x (see #3859)

#### What is the new behavior (if this is a feature change)?**

Use Go 1.23.X for our CI and dockerfiles.
* Our minimum Go version in our `go.mod` is unchanged
  * I did bump the tools/go.mod proactively incase any of our tools switch to requiring 1.23, this makes it so we dependabot PRs don't fail later

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
