### PR TITLE
:seedling: Require minimum version of Go 1.22.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ You must install these tools:
 1.  [`git`](https://help.github.com/articles/set-up-git/): For source control
 
 1.  [`go`](https://golang.org/doc/install): You need go version
-    [v1.21.8](https://golang.org/dl/) or higher.
+    [v1.22.0](https://golang.org/dl/) or higher.
 
 1.  [`protoc`](https://grpc.io/docs/protoc-installation/): `v3` or higher
 

--- a/clients/gitlabrepo/repo_test.go
+++ b/clients/gitlabrepo/repo_test.go
@@ -182,7 +182,6 @@ func TestRepoURL_MakeGitLabRepo(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // uses t.Setenv, can't be parallelized
 func TestRepoURL_parse_GL_HOST(t *testing.T) {
 	tests := []struct {
 		name                 string

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/scorecard/v5
 
-go 1.21.12
+go 1.22.0
 
 require (
 	cloud.google.com/go/bigquery v1.62.0


### PR DESCRIPTION
#### What kind of change does this PR introduce?

go directive bump

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Go 1.21 is the minimum version required to compile Scorecard or use it as a library.

#### What is the new behavior (if this is a feature change)?**
Go 1.22.0 is now the minimum version. 

At least one of our dependencies now requires 1.22. Additionally, with the Go 1.23 release, Go 1.21 is no longer supported. Due to the [loopvar changes](https://go.dev/doc/go1.22#language), I'm submitting this as a standalone change.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Unblocks #4319 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
Note this is different from #3859 or #4300 which update our toolchain versions.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Go 1.22.0 is now required to build Scorecard or use it as a library.
```
