### PR TITLE
✨ Add woodpecker as known CI

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -149,7 +149,7 @@ number of vulnerabilities that find their way into a project.
 The check works by looking for a set of CI-system names in GitHub `CheckRuns`
 and `Statuses` among the recent commits (~30). A CI-system is considered
 well-known if its name contains any of the following: appveyor, buildkite,
-circleci, e2e, github-actions, jenkins, mergeable, test, travis-ci.
+circleci, e2e, github-actions, jenkins, mergeable, test, travis-ci, woodpecker.
 
 Note: A project that fulfills this criterion with other tools may still receive
 a low score on this test. There are many ways to implement CI testing, and it is

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -242,7 +242,7 @@ checks:
       The check works by looking for a set of CI-system names in GitHub `CheckRuns`
       and `Statuses` among the recent commits (~30). A CI-system is considered
       well-known if its name contains any of the following: appveyor, buildkite,
-      circleci, e2e, github-actions, jenkins, mergeable, test, travis-ci.
+      circleci, e2e, github-actions, jenkins, mergeable, test, travis-ci, woodpecker.
 
       Note: A project that fulfills this criterion with other tools may still receive
       a low score on this test. There are many ways to implement CI testing, and it is

--- a/probes/testsRunInCI/impl.go
+++ b/probes/testsRunInCI/impl.go
@@ -165,7 +165,7 @@ func isTest(s string) bool {
 	for _, pattern := range []string{
 		"appveyor", "buildkite", "circleci", "e2e", "github-actions", "jenkins",
 		"mergeable", "packit-as-a-service", "semaphoreci", "test", "travis-ci",
-		"flutter-dashboard", "Cirrus CI", "azure-pipelines", "woodpecker",
+		"flutter-dashboard", "Cirrus CI", "azure-pipelines", "ci/woodpecker",
 	} {
 		if strings.Contains(l, pattern) {
 			return true

--- a/probes/testsRunInCI/impl.go
+++ b/probes/testsRunInCI/impl.go
@@ -165,7 +165,7 @@ func isTest(s string) bool {
 	for _, pattern := range []string{
 		"appveyor", "buildkite", "circleci", "e2e", "github-actions", "jenkins",
 		"mergeable", "packit-as-a-service", "semaphoreci", "test", "travis-ci",
-		"flutter-dashboard", "Cirrus CI", "azure-pipelines",
+		"flutter-dashboard", "Cirrus CI", "azure-pipelines", "woodpecker",
 	} {
 		if strings.Contains(l, pattern) {
 			return true

--- a/probes/testsRunInCI/impl_test.go
+++ b/probes/testsRunInCI/impl_test.go
@@ -238,6 +238,13 @@ func Test_isTest(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "woodpecker",
+			args: args{
+				s: "ci/woodpecker/pr/test-release",
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		tt := tt


### PR DESCRIPTION
#### What kind of change does this PR introduce?

It addresses #4210

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

It does not count tests run by Woodpecker
e.g. `CI-Tests` score of woodpecker's own main repo is 8/10

#### What is the new behavior (if this is a feature change)?**

it detects woodpecker and score the tests acordingly
e.g. `CI-Tests` score of woodpecker's own main repo is 10/10

`scorecard --repo=https://github.com/woodpecker-ci/woodpecker `:
![image](https://github.com/user-attachments/assets/78a85413-85fe-4d64-8d21-6e64d11ed728)


#### Which issue(s) this PR fixes

Fixes #4210

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

no