### PR TITLE
:seedling: Tighten restrictions for running `scdiff` workflow 

### DIFF
--- a/.github/workflows/scdiff.yml
+++ b/.github/workflows/scdiff.yml
@@ -56,7 +56,7 @@ jobs:
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           script: |
-            const allowedAssociations = ["COLLABORATOR", "CONTRIBUTOR", "MEMBER", "OWNER"];
+            const allowedAssociations = ["COLLABORATOR", "MEMBER", "OWNER"];
             authorAssociation = '${{ github.event.comment.author_association }}'
             if (!allowedAssociations.includes(authorAssociation)) {
               core.setFailed("You don't have access to run scdiff");

--- a/.github/workflows/scdiff.yml
+++ b/.github/workflows/scdiff.yml
@@ -60,6 +60,7 @@ jobs:
             authorAssociation = '${{ github.event.comment.author_association }}'
             if (!allowedAssociations.includes(authorAssociation)) {
               core.setFailed("You don't have access to run scdiff");
+              return
             }
 
             const response = await github.rest.pulls.get({
@@ -67,6 +68,16 @@ jobs:
               repo: context.repo.repo,
               pull_number: context.issue.number,
             })
+
+            // avoid race condition between scdiff comment and fetching PR head sha
+            const commentTime = new Date('${{ github.event.comment.created_at }}');
+            const prTime = new Date(response.data.head.repo.pushed_at)
+            if (prTime >= commentTime) {
+              core.setFailed("The PR may have been updated since the scdiff request, " +
+                             "please review any changes and relaunch if safe.");
+              return
+            }
+
             core.setOutput('base', response.data.base.sha)
             core.setOutput('head', response.data.head.sha)
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

workflow change

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Any previous contributor can run the `scdiff` workflow

#### What is the new behavior (if this is a feature change)?**
Only members of the `ossf` GitHub org can run the `scdiff` workflow. 

Previously we matched GitHub's "Require approval for first-time
contributors", which represents a minor barrier for attackers
(e.g. submitting a typo fix). Project members should ensure their
visibility in the "ossf" GitHub org is "Public" to be able to run
scdiff.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
