### PR TITLE
✨ Initial experimental Azure DevOps client

### DIFF
--- a/clients/azuredevopsrepo/branches.go
+++ b/clients/azuredevopsrepo/branches.go
@@ -25,6 +25,7 @@ import (
 
 type branchesHandler struct {
 	gitClient        git.Client
+	ctx              context.Context
 	once             *sync.Once
 	errSetup         error
 	repourl          *Repo
@@ -32,7 +33,8 @@ type branchesHandler struct {
 	queryBranch      fnQueryBranch
 }
 
-func (handler *branchesHandler) init(repourl *Repo) {
+func (handler *branchesHandler) init(ctx context.Context, repourl *Repo) {
+	handler.ctx = ctx
 	handler.repourl = repourl
 	handler.errSetup = nil
 	handler.once = new(sync.Once)
@@ -45,7 +47,7 @@ type (
 
 func (handler *branchesHandler) setup() error {
 	handler.once.Do(func() {
-		branch, err := handler.queryBranch(context.Background(), git.GetBranchArgs{
+		branch, err := handler.queryBranch(handler.ctx, git.GetBranchArgs{
 			RepositoryId: &handler.repourl.ID,
 			Name:         &handler.repourl.defaultBranch,
 		})

--- a/clients/azuredevopsrepo/branches.go
+++ b/clients/azuredevopsrepo/branches.go
@@ -1,0 +1,73 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+type branchesHandler struct {
+	gitClient        git.Client
+	once             *sync.Once
+	errSetup         error
+	repourl          *Repo
+	defaultBranchRef *clients.BranchRef
+	queryBranch      fnQueryBranch
+}
+
+func (handler *branchesHandler) init(repourl *Repo) {
+	handler.repourl = repourl
+	handler.errSetup = nil
+	handler.once = new(sync.Once)
+	handler.queryBranch = handler.gitClient.GetBranch
+}
+
+type (
+	fnQueryBranch func(ctx context.Context, args git.GetBranchArgs) (*git.GitBranchStats, error)
+)
+
+func (handler *branchesHandler) setup() error {
+	handler.once.Do(func() {
+		branch, err := handler.queryBranch(context.Background(), git.GetBranchArgs{
+			RepositoryId: &handler.repourl.ID,
+			Name:         &handler.repourl.defaultBranch,
+		})
+		if err != nil {
+			handler.errSetup = fmt.Errorf("request for default branch failed with error %w", err)
+			return
+		}
+		handler.defaultBranchRef = &clients.BranchRef{
+			Name: branch.Name,
+		}
+
+		handler.errSetup = nil
+	})
+	return handler.errSetup
+
+}
+
+func (handler *branchesHandler) getDefaultBranch() (*clients.BranchRef, error) {
+	err := handler.setup()
+	if err != nil {
+		return nil, fmt.Errorf("error during branchesHandler.setup: %w", err)
+	}
+
+	return handler.defaultBranchRef, nil
+}

--- a/clients/azuredevopsrepo/branches.go
+++ b/clients/azuredevopsrepo/branches.go
@@ -48,7 +48,7 @@ type (
 func (handler *branchesHandler) setup() error {
 	handler.once.Do(func() {
 		branch, err := handler.queryBranch(handler.ctx, git.GetBranchArgs{
-			RepositoryId: &handler.repourl.ID,
+			RepositoryId: &handler.repourl.id,
 			Name:         &handler.repourl.defaultBranch,
 		})
 		if err != nil {

--- a/clients/azuredevopsrepo/branches.go
+++ b/clients/azuredevopsrepo/branches.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+
 	"github.com/ossf/scorecard/v5/clients"
 )
 
@@ -62,7 +63,6 @@ func (handler *branchesHandler) setup() error {
 		handler.errSetup = nil
 	})
 	return handler.errSetup
-
 }
 
 func (handler *branchesHandler) getDefaultBranch() (*clients.BranchRef, error) {

--- a/clients/azuredevopsrepo/branches_test.go
+++ b/clients/azuredevopsrepo/branches_test.go
@@ -24,11 +24,12 @@ import (
 )
 
 func TestGetDefaultBranch(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
-		name          string
 		setupMock     func() fnQueryBranch
-		expectedError bool
+		name          string
 		expectedName  string
+		expectedError bool
 	}{
 		{
 			name: "successful branch retrieval",
@@ -53,6 +54,7 @@ func TestGetDefaultBranch(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			handler := &branchesHandler{
 				queryBranch: tt.setupMock(),
 				once:        new(sync.Once),

--- a/clients/azuredevopsrepo/branches_test.go
+++ b/clients/azuredevopsrepo/branches_test.go
@@ -57,7 +57,7 @@ func TestGetDefaultBranch(t *testing.T) {
 				queryBranch: tt.setupMock(),
 				once:        new(sync.Once),
 				repourl: &Repo{
-					ID:            "repo-id",
+					id:            "repo-id",
 					defaultBranch: "main",
 				},
 			}

--- a/clients/azuredevopsrepo/branches_test.go
+++ b/clients/azuredevopsrepo/branches_test.go
@@ -1,0 +1,74 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"testing"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+)
+
+func TestGetDefaultBranch(t *testing.T) {
+	tests := []struct {
+		name          string
+		setupMock     func() fnQueryBranch
+		expectedError bool
+		expectedName  string
+	}{
+		{
+			name: "successful branch retrieval",
+			setupMock: func() fnQueryBranch {
+				return func(ctx context.Context, args git.GetBranchArgs) (*git.GitBranchStats, error) {
+					return &git.GitBranchStats{Name: args.Name}, nil
+				}
+			},
+			expectedError: false,
+			expectedName:  "main",
+		},
+		{
+			name: "error during branch retrieval",
+			setupMock: func() fnQueryBranch {
+				return func(ctx context.Context, args git.GetBranchArgs) (*git.GitBranchStats, error) {
+					return nil, fmt.Errorf("error")
+				}
+			},
+			expectedError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			handler := &branchesHandler{
+				queryBranch: tt.setupMock(),
+				once:        new(sync.Once),
+				repourl: &Repo{
+					ID:            "repo-id",
+					defaultBranch: "main",
+				},
+			}
+
+			branch, err := handler.getDefaultBranch()
+			if (err != nil) != tt.expectedError {
+				t.Errorf("expected error: %v, got: %v", tt.expectedError, err)
+			}
+			if branch != nil && *branch.Name != tt.expectedName {
+				t.Errorf("expected branch name: %v, got: %v", tt.expectedName, *branch.Name)
+			}
+		})
+	}
+}

--- a/clients/azuredevopsrepo/client.go
+++ b/clients/azuredevopsrepo/client.go
@@ -1,0 +1,216 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+var (
+	_                clients.RepoClient = &Client{}
+	errInputRepoType                    = errors.New("input repo should be of type repoURL")
+)
+
+type Client struct {
+	repourl     *Repo
+	azdoClient  git.Client
+	branches    *branchesHandler
+	commits     *commitsHandler
+	ctx         context.Context
+	commitDepth int
+}
+
+func (client *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitDepth int) error {
+	azdoRepo, ok := inputRepo.(*Repo)
+	if !ok {
+		return fmt.Errorf("%w: %v", errInputRepoType, inputRepo)
+	}
+
+	repo, err := client.azdoClient.GetRepository(context.Background(), git.GetRepositoryArgs{
+		Project:      &azdoRepo.project,
+		RepositoryId: &azdoRepo.name,
+	})
+	if err != nil {
+		return fmt.Errorf("could not get repository with error: %w", err)
+	}
+
+	if commitDepth <= 0 {
+		client.commitDepth = 30 // default
+	} else {
+		client.commitDepth = commitDepth
+	}
+
+	branch, _ := strings.CutPrefix(*repo.DefaultBranch, "refs/heads/")
+
+	client.repourl = &Repo{
+		scheme:        azdoRepo.scheme,
+		host:          azdoRepo.host,
+		organization:  azdoRepo.organization,
+		project:       azdoRepo.project,
+		name:          azdoRepo.name,
+		ID:            fmt.Sprint(*repo.Id),
+		defaultBranch: branch,
+		commitSHA:     commitSHA,
+	}
+
+	client.branches.init(client.repourl)
+
+	client.commits.init(client.repourl, client.commitDepth)
+
+	return nil
+}
+
+func (client *Client) URI() string {
+	return fmt.Sprintf("%s/%s/_git/%s", client.repourl.host, client.repourl.organization, client.repourl.project)
+}
+
+func (client *Client) IsArchived() (bool, error) {
+	repo, err := client.azdoClient.GetRepository(context.Background(), git.GetRepositoryArgs{RepositoryId: &client.repourl.ID})
+	if err != nil {
+		return false, fmt.Errorf("could not get repository with error: %w", err)
+	}
+
+	return *repo.IsDisabled, nil
+}
+
+func (client *Client) ListFiles(predicate func(string) (bool, error)) ([]string, error) {
+	return []string{}, nil
+}
+
+func (client *Client) LocalPath() (string, error) {
+	return "", nil
+}
+
+func (client *Client) GetFileReader(filename string) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (client *Client) GetBranch(branch string) (*clients.BranchRef, error) {
+	return nil, nil
+}
+
+func (client *Client) GetCreatedAt() (time.Time, error) {
+	return time.Time{}, nil
+}
+
+func (client *Client) GetDefaultBranchName() (string, error) {
+	if len(client.repourl.defaultBranch) > 0 {
+		return client.repourl.defaultBranch, nil
+	}
+
+	return "", fmt.Errorf("%s", "default branch name is empty")
+}
+
+func (client *Client) GetDefaultBranch() (*clients.BranchRef, error) {
+	return client.branches.getDefaultBranch()
+}
+
+func (client *Client) GetOrgRepoClient(context.Context) (clients.RepoClient, error) {
+	return nil, fmt.Errorf("GetOrgRepoClient (GitLab): %w", clients.ErrUnsupportedFeature)
+}
+
+func (client *Client) ListCommits() ([]clients.Commit, error) {
+	return client.commits.listCommits()
+}
+
+func (client *Client) ListIssues() ([]clients.Issue, error) {
+	return nil, nil
+}
+
+func (client *Client) ListLicenses() ([]clients.License, error) {
+	return nil, nil
+}
+
+func (client *Client) ListReleases() ([]clients.Release, error) {
+	return nil, nil
+}
+
+func (client *Client) ListContributors() ([]clients.User, error) {
+	return nil, nil
+}
+
+func (client *Client) ListSuccessfulWorkflowRuns(filename string) ([]clients.WorkflowRun, error) {
+	return nil, nil
+}
+
+func (client *Client) ListCheckRunsForRef(ref string) ([]clients.CheckRun, error) {
+	return nil, nil
+}
+
+func (client *Client) ListStatuses(ref string) ([]clients.Status, error) {
+	return nil, nil
+}
+
+func (client *Client) ListWebhooks() ([]clients.Webhook, error) {
+	return nil, nil
+}
+
+func (client *Client) ListProgrammingLanguages() ([]clients.Language, error) {
+	return nil, nil
+}
+
+func (client *Client) Search(request clients.SearchRequest) (clients.SearchResponse, error) {
+	return clients.SearchResponse{}, nil
+}
+
+func (client *Client) SearchCommits(request clients.SearchCommitsOptions) ([]clients.Commit, error) {
+	return nil, nil
+}
+
+func (client *Client) Close() error {
+	return nil
+}
+
+func CreateAzureDevOpsClient(ctx context.Context, repo clients.Repo) (*Client, error) {
+	token := os.Getenv("AZURE_DEVOPS_AUTH_TOKEN")
+	return CreateAzureDevOpsClientWithToken(ctx, token, repo)
+}
+
+func CreateAzureDevOpsClientWithToken(ctx context.Context, token string, repo clients.Repo) (*Client, error) {
+	// https://dev.azure.com/<org>
+	url := "https://" + repo.Host() + "/" + strings.Split(repo.Path(), "/")[0]
+	connection := azuredevops.NewPatConnection(url, token)
+
+	gitClient, err := git.NewClient(ctx, connection)
+	if err != nil {
+		return nil, fmt.Errorf("could not create azure devops git client with error: %w", err)
+	}
+
+	return &Client{
+		ctx:        ctx,
+		azdoClient: gitClient,
+		branches: &branchesHandler{
+			gitClient: gitClient,
+		},
+		commits: &commitsHandler{
+			gitClient: gitClient,
+		},
+	}, nil
+}
+
+func CreateOssFuzzRepoClient(ctx context.Context, logger *log.Logger) (clients.RepoClient, error) {
+	return nil, fmt.Errorf("%w, oss fuzz currently only supported for github repos", clients.ErrUnsupportedFeature)
+}

--- a/clients/azuredevopsrepo/client.go
+++ b/clients/azuredevopsrepo/client.go
@@ -26,22 +26,24 @@ import (
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+
 	"github.com/ossf/scorecard/v5/clients"
 )
 
 var (
-	_                clients.RepoClient = &Client{}
-	errInputRepoType                    = errors.New("input repo should be of type azuredevopsrepo.Repo")
+	_                        clients.RepoClient = &Client{}
+	errInputRepoType                            = errors.New("input repo should be of type azuredevopsrepo.Repo")
+	errDefaultBranchNotFound                    = errors.New("default branch not found")
 )
 
 type Client struct {
-	repourl     *Repo
 	azdoClient  git.Client
-	once        sync.Once
+	ctx         context.Context
+	repourl     *Repo
 	branches    *branchesHandler
 	commits     *commitsHandler
-	ctx         context.Context
 	commitDepth int
+	once        sync.Once
 }
 
 func (c *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitDepth int) error {
@@ -135,7 +137,7 @@ func (c *Client) GetDefaultBranchName() (string, error) {
 		return c.repourl.defaultBranch, nil
 	}
 
-	return "", fmt.Errorf("%s", "default branch name is empty")
+	return "", fmt.Errorf("%w", errDefaultBranchNotFound)
 }
 
 func (c *Client) GetDefaultBranch() (*clients.BranchRef, error) {

--- a/clients/azuredevopsrepo/client_test.go
+++ b/clients/azuredevopsrepo/client_test.go
@@ -24,8 +24,8 @@ import (
 
 type mockGitClient struct {
 	git.Client
-	isDisabled bool
 	err        error
+	isDisabled bool
 }
 
 func (m *mockGitClient) GetRepository(ctx context.Context, args git.GetRepositoryArgs) (*git.GitRepository, error) {
@@ -36,10 +36,11 @@ func (m *mockGitClient) GetRepository(ctx context.Context, args git.GetRepositor
 }
 
 func TestIsArchived(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
+		err        error
 		name       string
 		isDisabled bool
-		err        error
 		want       bool
 		wantErr    bool
 	}{
@@ -65,6 +66,7 @@ func TestIsArchived(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			client := &Client{
 				azdoClient: &mockGitClient{
 					isDisabled: tt.isDisabled,

--- a/clients/azuredevopsrepo/client_test.go
+++ b/clients/azuredevopsrepo/client_test.go
@@ -15,25 +15,10 @@
 package azuredevopsrepo
 
 import (
-	"context"
-	"errors"
 	"testing"
 
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
 )
-
-type mockGitClient struct {
-	git.Client
-	err        error
-	isDisabled bool
-}
-
-func (m *mockGitClient) GetRepository(ctx context.Context, args git.GetRepositoryArgs) (*git.GitRepository, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return &git.GitRepository{IsDisabled: &m.isDisabled}, nil
-}
 
 func TestIsArchived(t *testing.T) {
 	t.Parallel()
@@ -56,21 +41,14 @@ func TestIsArchived(t *testing.T) {
 			want:       false,
 			wantErr:    false,
 		},
-		{
-			name:    "error getting repository",
-			err:     errors.New("some error"),
-			want:    false,
-			wantErr: true,
-		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			client := &Client{
-				azdoClient: &mockGitClient{
-					isDisabled: tt.isDisabled,
-					err:        tt.err,
+				repo: &git.GitRepository{
+					IsDisabled: &tt.isDisabled,
 				},
 				repourl: &Repo{id: "test-repo-id"},
 			}

--- a/clients/azuredevopsrepo/client_test.go
+++ b/clients/azuredevopsrepo/client_test.go
@@ -70,7 +70,7 @@ func TestIsArchived(t *testing.T) {
 					isDisabled: tt.isDisabled,
 					err:        tt.err,
 				},
-				repourl: &Repo{ID: "test-repo-id"},
+				repourl: &Repo{id: "test-repo-id"},
 			}
 
 			got, err := client.IsArchived()

--- a/clients/azuredevopsrepo/client_test.go
+++ b/clients/azuredevopsrepo/client_test.go
@@ -1,0 +1,86 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+)
+
+type mockGitClient struct {
+	git.Client
+	isDisabled bool
+	err        error
+}
+
+func (m *mockGitClient) GetRepository(ctx context.Context, args git.GetRepositoryArgs) (*git.GitRepository, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return &git.GitRepository{IsDisabled: &m.isDisabled}, nil
+}
+
+func TestIsArchived(t *testing.T) {
+	tests := []struct {
+		name       string
+		isDisabled bool
+		err        error
+		want       bool
+		wantErr    bool
+	}{
+		{
+			name:       "repository is archived",
+			isDisabled: true,
+			want:       true,
+			wantErr:    false,
+		},
+		{
+			name:       "repository is not archived",
+			isDisabled: false,
+			want:       false,
+			wantErr:    false,
+		},
+		{
+			name:    "error getting repository",
+			err:     errors.New("some error"),
+			want:    false,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			client := &Client{
+				azdoClient: &mockGitClient{
+					isDisabled: tt.isDisabled,
+					err:        tt.err,
+				},
+				repourl: &Repo{ID: "test-repo-id"},
+			}
+
+			got, err := client.IsArchived()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("IsArchived() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("IsArchived() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/clients/azuredevopsrepo/commits.go
+++ b/clients/azuredevopsrepo/commits.go
@@ -1,0 +1,167 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/git"
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+type commitsHandler struct {
+	gitClient           git.Client
+	once                *sync.Once
+	errSetup            error
+	repourl             *Repo
+	commitsRaw          *[]git.GitCommitRef
+	pullRequestsRaw     *git.GitPullRequestQuery
+	commitDepth         int
+	getCommits          fnGetCommits
+	getPullRequestQuery fnGetPullRequestQuery
+}
+
+func (handler *commitsHandler) init(repourl *Repo, commitDepth int) {
+	handler.repourl = repourl
+	handler.errSetup = nil
+	handler.once = new(sync.Once)
+	handler.commitDepth = commitDepth
+	handler.getCommits = handler.gitClient.GetCommits
+	handler.getPullRequestQuery = handler.gitClient.GetPullRequestQuery
+}
+
+type (
+	fnGetCommits          func(ctx context.Context, args git.GetCommitsArgs) (*[]git.GitCommitRef, error)
+	fnGetPullRequestQuery func(ctx context.Context, args git.GetPullRequestQueryArgs) (*git.GitPullRequestQuery, error)
+)
+
+func (handler *commitsHandler) setup() error {
+	handler.once.Do(func() {
+		opt := git.GetCommitsArgs{
+			RepositoryId: &handler.repourl.ID,
+			Top:          &handler.commitDepth,
+			SearchCriteria: &git.GitQueryCommitsCriteria{
+				ItemVersion: &git.GitVersionDescriptor{
+					VersionType: &git.GitVersionTypeValues.Branch,
+					Version:     &handler.repourl.defaultBranch,
+				},
+			},
+		}
+
+		commits, err := handler.getCommits(context.Background(), opt)
+		if err != nil {
+			handler.errSetup = fmt.Errorf("request for commits failed with %w", err)
+			return
+		}
+
+		commitIds := make([]string, len(*commits))
+		for i, commit := range *commits {
+			commitIds[i] = *commit.CommitId
+		}
+
+		pullRequestQuery := git.GetPullRequestQueryArgs{
+			RepositoryId: &handler.repourl.ID,
+			Queries: &git.GitPullRequestQuery{
+				Queries: &[]git.GitPullRequestQueryInput{
+					{
+						Type:  &git.GitPullRequestQueryTypeValues.Commit,
+						Items: &commitIds,
+					},
+				},
+			},
+		}
+		pullRequests, err := handler.getPullRequestQuery(context.Background(), pullRequestQuery)
+		if err != nil {
+			handler.errSetup = fmt.Errorf("request for pull requests failed with %w", err)
+			return
+		}
+
+		handler.commitsRaw = commits
+		handler.pullRequestsRaw = pullRequests
+
+		handler.errSetup = nil
+	})
+	return handler.errSetup
+}
+
+func (handler *commitsHandler) listCommits() ([]clients.Commit, error) {
+	err := handler.setup()
+	if err != nil {
+		return nil, fmt.Errorf("error during commitsHandler.setup: %w", err)
+	}
+
+	commits := make([]clients.Commit, len(*handler.commitsRaw))
+	for i, commit := range *handler.commitsRaw {
+		commits[i] = clients.Commit{
+			SHA:           *commit.CommitId,
+			Message:       *commit.Comment,
+			CommittedDate: commit.Committer.Date.Time,
+			Committer: clients.User{
+				Login: *commit.Committer.Name,
+			},
+		}
+	}
+
+	// Associate pull requests with commits
+	pullRequests, err := handler.listPullRequests()
+	if err != nil {
+		return nil, fmt.Errorf("error during commitsHandler.listPullRequests: %w", err)
+	}
+
+	for i, commit := range commits {
+		associatedPullRequest, ok := pullRequests[commit.SHA]
+		if !ok {
+			continue
+		}
+
+		commit.AssociatedMergeRequest = associatedPullRequest
+		commits[i] = commit
+	}
+
+	return commits, nil
+}
+
+func (handler *commitsHandler) listPullRequests() (map[string]clients.PullRequest, error) {
+	err := handler.setup()
+	if err != nil {
+		return nil, fmt.Errorf("error during commitsHandler.setup: %w", err)
+	}
+
+	pullRequests := make(map[string]clients.PullRequest)
+	for commit, azdoPullRequests := range (*handler.pullRequestsRaw.Results)[0] {
+		if len(azdoPullRequests) == 0 {
+			continue
+		}
+
+		if len(azdoPullRequests) > 1 {
+			return nil, fmt.Errorf("expected 1 pull request for commit %s, got %d", commit, len(azdoPullRequests))
+		}
+
+		azdoPullRequest := azdoPullRequests[0]
+
+		pullRequests[commit] = clients.PullRequest{
+			Number: *azdoPullRequest.PullRequestId,
+			Author: clients.User{
+				Login: *azdoPullRequest.CreatedBy.DisplayName,
+			},
+			HeadSHA:  *azdoPullRequest.LastMergeSourceCommit.CommitId,
+			MergedAt: azdoPullRequest.ClosedDate.Time,
+		}
+	}
+
+	return pullRequests, nil
+}

--- a/clients/azuredevopsrepo/commits.go
+++ b/clients/azuredevopsrepo/commits.go
@@ -67,7 +67,7 @@ func (handler *commitsHandler) setup() error {
 		}
 
 		opt := git.GetCommitsArgs{
-			RepositoryId: &handler.repourl.ID,
+			RepositoryId: &handler.repourl.id,
 			Top:          &handler.commitDepth,
 			SearchCriteria: &git.GitQueryCommitsCriteria{
 				ItemVersion: &itemVersion,
@@ -86,7 +86,7 @@ func (handler *commitsHandler) setup() error {
 		}
 
 		pullRequestQuery := git.GetPullRequestQueryArgs{
-			RepositoryId: &handler.repourl.ID,
+			RepositoryId: &handler.repourl.id,
 			Queries: &git.GitPullRequestQuery{
 				Queries: &[]git.GitPullRequestQueryInput{
 					{
@@ -140,8 +140,7 @@ func (handler *commitsHandler) listCommits() ([]clients.Commit, error) {
 			continue
 		}
 
-		commit.AssociatedMergeRequest = associatedPullRequest
-		commits[i] = commit
+		commits[i].AssociatedMergeRequest = associatedPullRequest
 	}
 
 	return commits, nil

--- a/clients/azuredevopsrepo/repo.go
+++ b/clients/azuredevopsrepo/repo.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package azuredevops
+package azuredevopsrepo
 
 import (
 	"fmt"
@@ -24,12 +24,15 @@ import (
 )
 
 type Repo struct {
-	scheme       string
-	host         string
-	organization string
-	project      string
-	name         string
-	metadata     []string
+	scheme        string
+	host          string
+	organization  string
+	project       string
+	name          string
+	ID            string
+	defaultBranch string
+	commitSHA     string
+	metadata      []string
 }
 
 // Parses input string into repoURL struct

--- a/clients/azuredevopsrepo/repo.go
+++ b/clients/azuredevopsrepo/repo.go
@@ -29,7 +29,7 @@ type Repo struct {
 	organization  string
 	project       string
 	name          string
-	ID            string
+	id            string
 	defaultBranch string
 	commitSHA     string
 	metadata      []string

--- a/clients/azuredevopsrepo/repo_test.go
+++ b/clients/azuredevopsrepo/repo_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package azuredevops
+package azuredevopsrepo
 
 import (
 	"testing"

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -221,18 +221,28 @@ func printCheckResults(enabledChecks checker.CheckNameToFnMap) {
 func makeRepo(uri string) (clients.Repo, error) {
 	var repo clients.Repo
 	var errGitHub, errGitLab, errAzureDevOps error
-	if repo, errGitHub = githubrepo.MakeGithubRepo(uri); errGitHub != nil {
-		if repo, errGitLab = gitlabrepo.MakeGitlabRepo(uri); errGitLab != nil {
-			_, experimental := os.LookupEnv("SCORECARD_EXPERIMENTAL")
-			if experimental {
-				repo, errAzureDevOps = azuredevopsrepo.MakeAzureDevOpsRepo(uri)
-				if errAzureDevOps != nil {
-					return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", errors.Join(errGitHub, errGitLab, errAzureDevOps))
-				}
-			} else {
-				return nil, fmt.Errorf("unable to parse as github or gitlab: %w", errors.Join(errGitHub, errGitLab))
-			}
-		}
+	var compositeErr error
+
+	repo, errGitHub = githubrepo.MakeGithubRepo(uri)
+	if errGitHub == nil {
+		return repo, nil
 	}
-	return repo, nil
+	compositeErr = errors.Join(compositeErr, errGitHub)
+
+	repo, errGitLab = gitlabrepo.MakeGitlabRepo(uri)
+	if errGitLab == nil {
+		return repo, nil
+	}
+	compositeErr = errors.Join(compositeErr, errGitLab)
+
+	_, experimental := os.LookupEnv("SCORECARD_EXPERIMENTAL")
+	if experimental {
+		repo, errAzureDevOps = azuredevopsrepo.MakeAzureDevOpsRepo(uri)
+		if errAzureDevOps == nil {
+			return repo, nil
+		}
+		compositeErr = errors.Join(compositeErr, errAzureDevOps)
+	}
+
+	return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", compositeErr)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/clients/azuredevopsrepo"
 	"github.com/ossf/scorecard/v5/clients/githubrepo"
 	"github.com/ossf/scorecard/v5/clients/gitlabrepo"
 	"github.com/ossf/scorecard/v5/clients/localdir"
@@ -215,15 +216,17 @@ func printCheckResults(enabledChecks checker.CheckNameToFnMap) {
 }
 
 // makeRepo helps turn a URI into the appropriate clients.Repo.
-// currently this is a decision between GitHub and GitLab,
+// currently this is a decision between GitHub, GitLab, and Azure DevOps,
 // but may expand in the future.
 func makeRepo(uri string) (clients.Repo, error) {
 	var repo clients.Repo
-	var errGitHub, errGitLab error
+	var errGitHub, errGitLab, errAzureDevOps error
 	if repo, errGitHub = githubrepo.MakeGithubRepo(uri); errGitHub != nil {
-		repo, errGitLab = gitlabrepo.MakeGitlabRepo(uri)
-		if errGitLab != nil {
-			return nil, fmt.Errorf("unable to parse as github or gitlab: %w", errors.Join(errGitHub, errGitLab))
+		if repo, errGitLab = gitlabrepo.MakeGitlabRepo(uri); errGitLab != nil {
+			repo, errAzureDevOps = azuredevopsrepo.MakeAzureDevOpsRepo(uri)
+			if errAzureDevOps != nil {
+				return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", errors.Join(errGitHub, errGitLab))
+			}
 		}
 	}
 	return repo, nil

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -223,9 +223,14 @@ func makeRepo(uri string) (clients.Repo, error) {
 	var errGitHub, errGitLab, errAzureDevOps error
 	if repo, errGitHub = githubrepo.MakeGithubRepo(uri); errGitHub != nil {
 		if repo, errGitLab = gitlabrepo.MakeGitlabRepo(uri); errGitLab != nil {
-			repo, errAzureDevOps = azuredevopsrepo.MakeAzureDevOpsRepo(uri)
-			if errAzureDevOps != nil {
-				return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", errors.Join(errGitHub, errGitLab))
+			_, experimental := os.LookupEnv("SCORECARD_EXPERIMENTAL")
+			if experimental {
+				repo, errAzureDevOps = azuredevopsrepo.MakeAzureDevOpsRepo(uri)
+				if errAzureDevOps != nil {
+					return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", errors.Join(errGitHub, errGitLab, errAzureDevOps))
+				}
+			} else {
+				return nil, fmt.Errorf("unable to parse as github or gitlab: %w", errors.Join(errGitHub, errGitLab))
 			}
 		}
 	}

--- a/go.mod
+++ b/go.mod
@@ -169,6 +169,7 @@ require (
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/mattn/go-runewidth v0.0.16 // indirect
+	github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0
 	github.com/mitchellh/go-homedir v1.1.0 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -565,6 +565,8 @@ github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5
 github.com/maxbrunsfeld/counterfeiter/v6 v6.2.2/go.mod h1:eD9eIE7cdwcMi9rYluz88Jz2VyhSmden33/aXg4oVIY=
 github.com/mcuadros/go-jsonschema-generator v0.0.0-20200330054847-ba7a369d4303 h1:mc6Th1b2xkPDUHTIUynE0LMJUgPEJdIDUjBLvj8yprs=
 github.com/mcuadros/go-jsonschema-generator v0.0.0-20200330054847-ba7a369d4303/go.mod h1:O6IeMrJ2EU+kDaxu7Dchbd0fbmrsTcjg8SGYFVJCr5A=
+github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0 h1:mmJCWLe63QvybxhW1iBmQWEaCKdc4SKgALfTNZ+OphU=
+github.com/microsoft/azure-devops-go-api/azuredevops/v7 v7.1.0/go.mod h1:mDunUZ1IUJdJIRHvFb+LPBUtxe3AYB5MI6BMXNg8194=
 github.com/miekg/dns v1.0.14/go.mod h1:W1PPwlIAgtquWBMBEV9nkV9Cazfe8ScdGz/Lj7v3Nrg=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/go-homedir v1.0.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/clients/azuredevopsrepo"
 	"github.com/ossf/scorecard/v5/clients/githubrepo"
 	"github.com/ossf/scorecard/v5/clients/gitlabrepo"
 	"github.com/ossf/scorecard/v5/clients/localdir"
@@ -383,6 +384,13 @@ func Run(ctx context.Context, repo clients.Repo, opts ...Option) (Result, error)
 			c.client, err = gitlabrepo.CreateGitlabClient(ctx, repo.Host())
 			if err != nil {
 				return Result{}, fmt.Errorf("creating gitlab client: %w", err)
+			}
+		}
+	case *azuredevopsrepo.Repo:
+		if c.client == nil {
+			c.client, err = azuredevopsrepo.CreateAzureDevOpsClient(ctx, repo)
+			if err != nil {
+				return Result{}, fmt.Errorf("creating azure devops client: %w", err)
 			}
 		}
 	}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR introduces early experimental support for Azure DevOps. It's the MVP for a scorecard scan to complete without panicing.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

No Support for Azure DevOps repository scanning

#### What is the new behavior (if this is a feature change)?**

This is a followup from #4178, and the next step for #4177. It is the minimal client implementation for Azure DevOps repository support.

I'd like to get feedback at this stage, before I implement the remainder of the client.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Continued work on #4177 

#### Special notes for your reviewer

This change is currenltly gated behind the `SCORECARD_EXPERIMENTAL` environment variable, same as the initial GitLab client was.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Initial experimental Azure DevOps client
```
