### PR TITLE
:sparkles: Add Erlang as a language

### DIFF
--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -56,6 +56,14 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		Desc: asPointer(
 			"Go fuzzing intelligently walks through the source code to report failures and find vulnerabilities."),
 	},
+	// Fuzz patterns for Erlang based on property-based testing.
+	clients.Erlang: {
+		filePatterns: []string{"*.erl", "*.hrl"},
+		// Look for direct imports of QuickCheck or Proper,
+		funcPattern: `-include_lib\("(eqc|proper)/include/(eqc|proper).hrl"\)\.`,
+		Name:        fuzzers.PropertyBasedErlang,
+		Desc:        propertyBasedDescription("Erlang"),
+	},
 	// Fuzz patterns for Haskell based on property-based testing.
 	//
 	// Based on the import of one of these packages:

--- a/checks/raw/fuzzing_test.go
+++ b/checks/raw/fuzzing_test.go
@@ -261,6 +261,43 @@ func Test_checkFuzzFunc(t *testing.T) {
 			fileContent: "func TestFoo (t *testing.T)",
 		},
 		{
+			name:     "Erlang QuickCheck",
+			want:     true,
+			fileName: []string{"erlang-eqc.hs"},
+			langs: []clients.Language{
+				{
+					Name:     clients.Erlang,
+					NumLines: 50,
+				},
+			},
+			fileContent: "-include_lib(\"eqc/include/eqc.hrl\").",
+		},
+		{
+			name:     "Erlang Proper",
+			want:     true,
+			fileName: []string{"erlang-proper.hs"},
+			langs: []clients.Language{
+				{
+					Name:     clients.Erlang,
+					NumLines: 50,
+				},
+			},
+			fileContent: "-include_lib(\"proper/include/proper.hrl\").",
+		},
+		{
+			name:     "Erlang with no property-based testing",
+			want:     false,
+			fileName: []string{"erlang-ct.erl"},
+			wantErr:  true,
+			langs: []clients.Language{
+				{
+					Name:     clients.Erlang,
+					NumLines: 50,
+				},
+			},
+			fileContent: "-include_lib(\"common_test/include/ct.hrl\").",
+		},
+		{
 			name:     "Haskell QuickCheck",
 			want:     true,
 			fileName: []string{"ModuleSpec.hs"},

--- a/clients/languages.go
+++ b/clients/languages.go
@@ -74,6 +74,9 @@ const (
 	// Dockerfile: https://docs.docker.com/engine/reference/builder/
 	Dockerfile LanguageName = "dockerfile"
 
+	// Erlang: https://www.erlang.org/
+	Erlang LanguageName = "erlang"
+
 	// Haskell: https://www.haskell.org/
 	Haskell LanguageName = "haskell"
 

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -343,6 +343,7 @@ This check tries to determine if the project uses
    - currently only supports [Go fuzzing](https://go.dev/doc/fuzz/),
    - a limited set of property-based testing libraries for Haskell including [QuickCheck](https://hackage.haskell.org/package/QuickCheck), [Hedgehog](https://hedgehog.qa/), [validity](https://hackage.haskell.org/package/validity) or [SmallCheck](https://hackage.haskell.org/package/smallcheck),
    - a limited set of property-based testing libraries for JavaScript and TypeScript including [fast-check](https://fast-check.dev/).
+   - a limited set of property-based testing libraries for Erlang, including proper and quickcheck.
 
 Fuzzing, or fuzz testing, is the practice of feeding unexpected or random data
 into a program to expose bugs. Regular fuzzing is important to detect

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -403,6 +403,7 @@ checks:
          - currently only supports [Go fuzzing](https://go.dev/doc/fuzz/),
          - a limited set of property-based testing libraries for Haskell including [QuickCheck](https://hackage.haskell.org/package/QuickCheck), [Hedgehog](https://hedgehog.qa/), [validity](https://hackage.haskell.org/package/validity) or [SmallCheck](https://hackage.haskell.org/package/smallcheck),
          - a limited set of property-based testing libraries for JavaScript and TypeScript including [fast-check](https://fast-check.dev/).
+         - a limited set of property-based testing libraries for Erlang, including proper and quickcheck.
 
       Fuzzing, or fuzz testing, is the practice of feeding unexpected or random data
       into a program to expose bugs. Regular fuzzing is important to detect

--- a/internal/fuzzers/fuzzers.go
+++ b/internal/fuzzers/fuzzers.go
@@ -19,6 +19,7 @@ const (
 	OSSFuzz                 = "OSSFuzz"
 	ClusterFuzzLite         = "ClusterFuzzLite"
 	BuiltInGo               = "GoBuiltInFuzzer"
+	PropertyBasedErlang     = "ErlangPropertyBasedTesting"
 	PropertyBasedHaskell    = "HaskellPropertyBasedTesting"
 	PropertyBasedJavaScript = "JavaScriptPropertyBasedTesting"
 	PropertyBasedTypeScript = "TypeScriptPropertyBasedTesting"


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Use the presence of property-based tests to detect the use of fuzzing in Erlang code.

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

There is no support for fuzz detection for Erlang.

#### What is the new behavior (if this is a feature change)?**

Adds Erlang as a client language.
Scans for the import of property-based test frameworks to detect the use of fuzzing in Erlang

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

~For the next section, I think there are no user-facing changes, but a previous PR for Haskell #2843 wrote a release note~

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Support detection of fuzzing in Erlang through the import of property-based testing modules
```
