### PR TITLE
:sparkles: implement `ListIssues` and `GetCreatedAt` for Azure DevOps

### DIFF
--- a/clients/azuredevopsrepo/audit.go
+++ b/clients/azuredevopsrepo/audit.go
@@ -64,14 +64,14 @@ func (a *auditHandler) setup() error {
 					*entry.ProjectName == a.repourl.project &&
 					(*entry.Data)["RepoName"] == a.repourl.name {
 					a.createdAt = entry.Timestamp.Time
-					break
+					return
 				}
 			}
 
 			if *auditLog.HasMore {
 				continuationToken = *auditLog.ContinuationToken
 			} else {
-				break
+				return
 			}
 		}
 	})

--- a/clients/azuredevopsrepo/audit.go
+++ b/clients/azuredevopsrepo/audit.go
@@ -1,0 +1,87 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/audit"
+)
+
+type auditHandler struct {
+	auditClient audit.Client
+	once        *sync.Once
+	ctx         context.Context
+	errSetup    error
+	repourl     *Repo
+	createdAt   time.Time
+	queryLog    fnQueryLog
+}
+
+func (a *auditHandler) init(ctx context.Context, repourl *Repo) {
+	a.ctx = ctx
+	a.errSetup = nil
+	a.once = new(sync.Once)
+	a.repourl = repourl
+	a.queryLog = a.auditClient.QueryLog
+}
+
+type (
+	fnQueryLog func(ctx context.Context, args audit.QueryLogArgs) (*audit.AuditLogQueryResult, error)
+)
+
+func (a *auditHandler) setup() error {
+	a.once.Do(func() {
+		continuationToken := ""
+		for {
+			auditLog, err := a.queryLog(a.ctx, audit.QueryLogArgs{
+				ContinuationToken: &continuationToken,
+			})
+			if err != nil {
+				a.errSetup = fmt.Errorf("error querying audit log: %w", err)
+				return
+			}
+
+			// Check if Git.CreateRepo event exists for the repository
+			for i := range *auditLog.DecoratedAuditLogEntries {
+				entry := &(*auditLog.DecoratedAuditLogEntries)[i]
+				if *entry.ActionId == "Git.CreateRepo" &&
+					*entry.ProjectName == a.repourl.project &&
+					(*entry.Data)["RepoName"] == a.repourl.name {
+					a.createdAt = entry.Timestamp.Time
+					break
+				}
+			}
+
+			if *auditLog.HasMore {
+				continuationToken = *auditLog.ContinuationToken
+			} else {
+				break
+			}
+		}
+	})
+	return a.errSetup
+}
+
+func (a *auditHandler) getRepsitoryCreatedAt() (time.Time, error) {
+	if err := a.setup(); err != nil {
+		return time.Time{}, fmt.Errorf("error during auditHandler.setup: %w", err)
+	}
+
+	return a.createdAt, nil
+}

--- a/clients/azuredevopsrepo/audit_test.go
+++ b/clients/azuredevopsrepo/audit_test.go
@@ -1,0 +1,89 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/audit"
+)
+
+func Test_auditHandler_setup(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		queryLog  fnQueryLog
+		createdAt time.Time
+		name      string
+		wantErr   bool
+	}{
+		{
+			name: "successful setup",
+			queryLog: func(ctx context.Context, args audit.QueryLogArgs) (*audit.AuditLogQueryResult, error) {
+				return &audit.AuditLogQueryResult{
+					HasMore:           new(bool),
+					ContinuationToken: new(string),
+					DecoratedAuditLogEntries: &[]audit.DecoratedAuditLogEntry{
+						{
+							ActionId:    strptr("Git.CreateRepo"),
+							ProjectName: strptr("test-project"),
+							Data:        &map[string]interface{}{"RepoName": "test-repo"},
+							Timestamp:   &azuredevops.Time{Time: time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC)},
+						},
+					},
+				}, nil
+			},
+			wantErr:   false,
+			createdAt: time.Date(2023, time.January, 1, 0, 0, 0, 0, time.UTC),
+		},
+		{
+			name: "query log error",
+			queryLog: func(ctx context.Context, args audit.QueryLogArgs) (*audit.AuditLogQueryResult, error) {
+				return nil, errors.New("query log error")
+			},
+			wantErr:   true,
+			createdAt: time.Time{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			handler := &auditHandler{
+				once:     new(sync.Once),
+				queryLog: tt.queryLog,
+				repourl: &Repo{
+					project: "test-project",
+					name:    "test-repo",
+				},
+			}
+			err := handler.setup()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("setup() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if !tt.wantErr && !handler.createdAt.Equal(tt.createdAt) {
+				t.Errorf("setup() createdAt = %v, want %v", handler.createdAt, tt.createdAt)
+			}
+		})
+	}
+}
+
+func strptr(s string) *string {
+	return &s
+}

--- a/clients/azuredevopsrepo/commits.go
+++ b/clients/azuredevopsrepo/commits.go
@@ -111,10 +111,12 @@ func (handler *commitsHandler) setup() error {
 			return
 		}
 
-		// If there are fewer commits than requested, the first commit is the createdAt date
-		if len(*commits) < handler.commitDepth {
+		switch {
+		case len(*commits) == 0:
+			handler.firstCommitCreatedAt = time.Time{}
+		case len(*commits) < handler.commitDepth:
 			handler.firstCommitCreatedAt = (*commits)[len(*commits)-1].Committer.Date.Time
-		} else {
+		default:
 			firstCommit, err := handler.getFirstCommit(handler.ctx, git.GetCommitsArgs{
 				RepositoryId: &handler.repourl.id,
 				SearchCriteria: &git.GitQueryCommitsCriteria{

--- a/clients/azuredevopsrepo/work_items.go
+++ b/clients/azuredevopsrepo/work_items.go
@@ -1,0 +1,175 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/workitemtracking"
+
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+var (
+	errSystemCreatedByFieldNotMap      = fmt.Errorf("error: System.CreatedBy field is not a map")
+	errSystemCreatedDateFieldNotString = fmt.Errorf("error: System.CreatedDate field is not a string")
+)
+
+type (
+	fnQueryWorkItems func(
+		ctx context.Context,
+		args workitemtracking.QueryByWiqlArgs,
+	) (*workitemtracking.WorkItemQueryResult, error)
+
+	fnGetWorkItems func(
+		ctx context.Context,
+		args workitemtracking.GetWorkItemsArgs,
+	) (*[]workitemtracking.WorkItem, error)
+
+	fnGetWorkItemComments func(
+		ctx context.Context,
+		args workitemtracking.GetCommentsArgs,
+	) (*workitemtracking.CommentList, error)
+)
+
+type workItemsHandler struct {
+	ctx                 context.Context
+	repourl             *Repo
+	once                *sync.Once
+	errSetup            error
+	workItemsClient     workitemtracking.Client
+	queryWorkItems      fnQueryWorkItems
+	getWorkItems        fnGetWorkItems
+	getWorkItemComments fnGetWorkItemComments
+	issues              []clients.Issue
+}
+
+func (w *workItemsHandler) init(ctx context.Context, repourl *Repo) {
+	w.ctx = ctx
+	w.errSetup = nil
+	w.once = new(sync.Once)
+	w.repourl = repourl
+	w.queryWorkItems = w.workItemsClient.QueryByWiql
+	w.getWorkItems = w.workItemsClient.GetWorkItems
+	w.getWorkItemComments = w.workItemsClient.GetComments
+}
+
+func (w *workItemsHandler) setup() error {
+	w.once.Do(func() {
+		// Fetch URI, CreatedAt, Author, and Issue comments
+		wiql := `
+			SELECT [System.Id]
+			FROM WorkItems
+			WHERE [System.TeamProject] = @project
+			ORDER BY [System.Id] DESC
+		`
+		workItems, err := w.queryWorkItems(w.ctx, workitemtracking.QueryByWiqlArgs{
+			Project: &w.repourl.project,
+			Wiql: &workitemtracking.Wiql{
+				Query: &wiql,
+			},
+		})
+		if err != nil {
+			w.errSetup = fmt.Errorf("error getting work items: %w", err)
+			return
+		}
+
+		ids := make([]int, 0, len(*workItems.WorkItems))
+		for _, wi := range *workItems.WorkItems {
+			ids = append(ids, *wi.Id)
+		}
+
+		// Get details for each work item
+		workItemDetails, err := w.getWorkItems(w.ctx, workitemtracking.GetWorkItemsArgs{
+			Ids: &ids,
+		})
+		if err != nil {
+			w.errSetup = fmt.Errorf("error getting work item details: %w", err)
+			return
+		}
+
+		// Get comments for each work item
+		for i := range *workItemDetails {
+			wi := &(*workItemDetails)[i]
+
+			createdBy, ok := (*wi.Fields)["System.CreatedBy"].(map[string]interface{})
+			if !ok {
+				w.errSetup = errSystemCreatedByFieldNotMap
+				return
+			}
+			createdDate, ok := (*wi.Fields)["System.CreatedDate"].(string)
+			if !ok {
+				w.errSetup = errSystemCreatedDateFieldNotString
+				return
+			}
+			parsedTime, err := time.Parse(time.RFC3339, createdDate)
+			if err != nil {
+				w.errSetup = fmt.Errorf("error parsing created date: %w", err)
+				return
+			}
+			// There is not currently an official API to get user permissions in Azure DevOps
+			// so we will default to RepoAssociationMember for all users.
+			repoAssociation := clients.RepoAssociationMember
+
+			issue := clients.Issue{
+				URI:               wi.Url,
+				CreatedAt:         &parsedTime,
+				Author:            &clients.User{Login: createdBy["uniqueName"].(string)},
+				AuthorAssociation: &repoAssociation,
+				Comments:          make([]clients.IssueComment, 0),
+			}
+
+			workItemComments, err := w.getWorkItemComments(w.ctx, workitemtracking.GetCommentsArgs{
+				Project:    &w.repourl.project,
+				WorkItemId: wi.Id,
+			})
+			if err != nil {
+				w.errSetup = fmt.Errorf("error getting comments for work item %d: %w", *wi.Id, err)
+				return
+			}
+
+			for i := range *workItemComments.Comments {
+				workItemComment := &(*workItemComments.Comments)[i]
+
+				// There is not currently an official API to get user permissions in Azure DevOps
+				// so we will default to RepoAssociationMember for all users.
+				repoAssociation := clients.RepoAssociationMember
+
+				comment := clients.IssueComment{
+					CreatedAt:         &workItemComment.CreatedDate.Time,
+					Author:            &clients.User{Login: *workItemComment.CreatedBy.DisplayName},
+					AuthorAssociation: &repoAssociation,
+				}
+
+				issue.Comments = append(issue.Comments, comment)
+			}
+
+			w.issues = append(w.issues, issue)
+		}
+	})
+
+	return w.errSetup
+}
+
+func (w *workItemsHandler) listIssues() ([]clients.Issue, error) {
+	if err := w.setup(); err != nil {
+		return nil, fmt.Errorf("error during issuesHandler.setup: %w", err)
+	}
+
+	return w.issues, nil
+}

--- a/clients/azuredevopsrepo/work_items.go
+++ b/clients/azuredevopsrepo/work_items.go
@@ -68,6 +68,7 @@ func (w *workItemsHandler) init(ctx context.Context, repourl *Repo) {
 	w.queryWorkItems = w.workItemsClient.QueryByWiql
 	w.getWorkItems = w.workItemsClient.GetWorkItems
 	w.getWorkItemComments = w.workItemsClient.GetComments
+	w.issues = nil
 }
 
 func (w *workItemsHandler) setup() error {
@@ -103,7 +104,7 @@ func (w *workItemsHandler) setup() error {
 			return
 		}
 
-		// Get comments for each work item
+		w.issues = make([]clients.Issue, 0, len(*workItemDetails))
 		for i := range *workItemDetails {
 			wi := &(*workItemDetails)[i]
 

--- a/clients/azuredevopsrepo/work_items_test.go
+++ b/clients/azuredevopsrepo/work_items_test.go
@@ -1,0 +1,168 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package azuredevopsrepo
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/workitemtracking"
+
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+func TestWorkItemsHandler_listIssues(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		mockSetup  func(*workItemsHandler)
+		want       []clients.Issue
+		wantErrStr string
+		name       string
+	}{
+		{
+			name: "happy path",
+			mockSetup: func(w *workItemsHandler) {
+				workItems := &workitemtracking.WorkItemQueryResult{
+					WorkItems: &[]workitemtracking.WorkItemReference{
+						{Id: toPtr(1)},
+					},
+				}
+				w.queryWorkItems = func(ctx context.Context, args workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error) {
+					return workItems, nil
+				}
+
+				createdDate := "2024-01-01T00:00:00Z"
+				workItemDetails := &[]workitemtracking.WorkItem{
+					{
+						Id:     toPtr(1),
+						Url:    toPtr("http://example.com"),
+						Fields: &map[string]interface{}{"System.CreatedDate": createdDate},
+					},
+				}
+				w.getWorkItems = func(ctx context.Context, args workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error) {
+					return workItemDetails, nil
+				}
+
+				commentTime := time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC)
+				comments := &workitemtracking.CommentList{
+					Comments: &[]workitemtracking.Comment{
+						{CreatedDate: &azuredevops.Time{Time: commentTime}},
+					},
+				}
+				w.getWorkItemComments = func(ctx context.Context, args workitemtracking.GetCommentsArgs) (*workitemtracking.CommentList, error) {
+					return comments, nil
+				}
+			},
+			want: []clients.Issue{
+				{
+					URI:       toPtr("http://example.com"),
+					CreatedAt: toPtr(time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)),
+					Comments: []clients.IssueComment{
+						{CreatedAt: toPtr(time.Date(2024, 1, 2, 0, 0, 0, 0, time.UTC))},
+					},
+				},
+			},
+		},
+		{
+			name: "query work items error",
+			mockSetup: func(w *workItemsHandler) {
+				w.queryWorkItems = func(ctx context.Context, args workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error) {
+					return nil, fmt.Errorf("query error")
+				}
+			},
+			wantErrStr: "error during issuesHandler.setup: error getting work items: query error",
+		},
+		{
+			name: "get work items error",
+			mockSetup: func(w *workItemsHandler) {
+				workItems := &workitemtracking.WorkItemQueryResult{
+					WorkItems: &[]workitemtracking.WorkItemReference{
+						{Id: toPtr(1)},
+					},
+				}
+				w.queryWorkItems = func(ctx context.Context, args workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error) {
+					return workItems, nil
+				}
+				w.getWorkItems = func(ctx context.Context, args workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error) {
+					return nil, fmt.Errorf("get items error")
+				}
+			},
+			wantErrStr: "error during issuesHandler.setup: error getting work item details: get items error",
+		},
+		{
+			name: "get comments error",
+			mockSetup: func(w *workItemsHandler) {
+				workItems := &workitemtracking.WorkItemQueryResult{
+					WorkItems: &[]workitemtracking.WorkItemReference{
+						{Id: toPtr(1)},
+					},
+				}
+				w.queryWorkItems = func(ctx context.Context, args workitemtracking.QueryByWiqlArgs) (*workitemtracking.WorkItemQueryResult, error) {
+					return workItems, nil
+				}
+				createdDate := "2024-01-01T00:00:00Z"
+				workItemDetails := &[]workitemtracking.WorkItem{
+					{
+						Id:     toPtr(1),
+						Url:    toPtr("http://example.com"),
+						Fields: &map[string]interface{}{"System.CreatedDate": createdDate},
+					},
+				}
+				w.getWorkItems = func(ctx context.Context, args workitemtracking.GetWorkItemsArgs) (*[]workitemtracking.WorkItem, error) {
+					return workItemDetails, nil
+				}
+				w.getWorkItemComments = func(ctx context.Context, args workitemtracking.GetCommentsArgs) (*workitemtracking.CommentList, error) {
+					return nil, fmt.Errorf("comments error")
+				}
+			},
+			wantErrStr: "error during issuesHandler.setup: error getting comments for work item 1: comments error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			w := &workItemsHandler{
+				ctx:     context.Background(),
+				once:    new(sync.Once),
+				repourl: &Repo{project: "test-project"},
+			}
+			tt.mockSetup(w)
+
+			got, err := w.listIssues()
+			if tt.wantErrStr != "" {
+				if err == nil || err.Error() != tt.wantErrStr {
+					t.Errorf("listIssues() error = %v, wantErr %v", err, tt.wantErrStr)
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("listIssues() unexpected error: %v", err)
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("listIssues() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func toPtr[T any](v T) *T {
+	return &v
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`ListIssues` and `GetCreatedAt` throw an unsupported error

#### What is the new behavior (if this is a feature change)?**

`ListIssues` and `GetCreatedAt` have implementations

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Next step of https://github.com/ossf/scorecard/issues/4177

#### Special notes for your reviewer

Azure DevOps doesn't have an official API to retrieve user permissions for a project or a repository. As a stopgap solution, I've defaulted all issue and comment authors to `RepoAssociationMember`. This is probably a good minimum bar.

The audit log is the best way to retrieve the repository creation date, but this may not be enabled. So I am using the first repository commit as a fallback value.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
implement `ListIssues` and `GetCreatedAt` for Azure DevOps
```
