### PR TITLE
:seedling: sort organizations in Contributors detail string

### DIFF
--- a/checks/evaluation/contributors.go
+++ b/checks/evaluation/contributors.go
@@ -16,6 +16,7 @@ package evaluation
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/ossf/scorecard/v5/checker"
@@ -69,14 +70,17 @@ func getNumberOfTrue(findings []finding.Finding) int {
 }
 
 func logFindings(findings []finding.Finding, dl checker.DetailLogger) {
-	var sb strings.Builder
+	var orgs []string
+	const suffix = " contributor org/company found"
 	for i := range findings {
 		f := &findings[i]
 		if f.Outcome == finding.OutcomeTrue {
-			sb.WriteString(fmt.Sprintf("%s, ", f.Message))
+			org := strings.TrimSuffix(f.Message, suffix)
+			orgs = append(orgs, org)
 		}
 	}
+	slices.Sort(orgs)
 	dl.Info(&checker.LogMessage{
-		Text: sb.String(),
+		Text: "found contributions from: " + strings.Join(orgs, ", "),
 	})
 }


### PR DESCRIPTION

#### What kind of change does this PR introduce?

cleanup for scdiff

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The orgs are printed in map iteration order (random), and there's a lot of duplication in the text:

```
Info: CatalystCode contributor org/company found, microsoft corporation contributor org/company found,
    python-trio contributor org/company found, googlers contributor org/company found,
    Azure-Samples contributor org/company found, microsoft contributor org/company found,
    syncweek-react-aad contributor org/company found, webhintio contributor org/company found,
    IPPETAD contributor org/company found, projectkudu contributor org/company found,
    Azure contributor org/company found,
```

specifically with iteration order, this creates noisy `scdiff` diffs where the only difference is the order:
```diff
-                                                       "eclipse",
+                                                       "jacoco",
                                                        " contributor org/company found, ",
-                                                       "mtrail gmbh",
+                                                       "SonarQubeCommunity",
                                                        " contributor org/company found, ",
-                                                       "jenkinsci",
+                                                       "1and1",
                                                        " contributor org/company found, ",
-                                                       "1and1",
+                                                       "dsmHack",
                                                        " contributor org/company found, ",
-                                                       "op",
                                                        "e",
-                                                       "njdk contributor org/company found, apache contributor org/compa",
-                                                       "ny found, SonarSource",
+                                                       "clipse contributor org/company found, SonarSource contributor or",
+                                                       "g/company found, sardinella",
                                                        " contributor org/company found, ",
-                                                       "SonarQubeCommunity",
+                                                       "mtrail gmbh",
                                                        " contributor org/company found, ",
-                                                       "eclipse-eclemma",
+                                                       "apache",
                                                        ... // 182 identical, 136 removed, and 144 inserted bytes
```

#### What is the new behavior (if this is a feature change)?**
The strings are sorted, which will help create less noisy diffs when running `scdiff` (like during the release process).
Removed the duplicated "contributor org/company found" text which made the output long:

```
Info: found contributions from: Azure, Azure-Samples, CatalystCode,
    IPPETAD, googlers, microsoft, microsoft corporation,
    projectkudu, python-trio, syncweek-react-aad, webhintio
```

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Lexicographically sorted contributing organizations in the Contributors check and cleaned up duplication.
```
