### PR TITLE
:seedling: group Go dependency updates weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,11 +5,18 @@ updates:
     - "/"
     - "/tools"
   schedule:
-    interval: daily
+    interval: weekly
   rebase-strategy: disabled
   commit-message:
       prefix: ":seedling:"
-  open-pull-requests-limit: 3
+  groups:
+    gomod:
+      patterns:
+        - "*"
+      exclude-patterns:
+        - "github.com/rhysd/actionlint" # has had breaking changes in the past
+        - "github.com/google/osv-scanner" # influences Vulnerabilities check and may require go directive fixes
+        - "github.com/golangci/golangci-lint" # require linter fixes before merge
 - package-ecosystem: "github-actions"
   directory: "/"
   schedule:


### PR DESCRIPTION
Some dependencies are excluded because of known issues upgrading them in the past.

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

- Every Go dependency update gets its own PR, up to 3 PRs daily (security fix PRs aren't constrained)

#### What is the new behavior (if this is a feature change)?**

Trying to reduce some of the toil of dependency management. About a third of our commits/PRs are from dependabot, over the last year that ratio grows to about half.

- Most Go dependencies are grouped for updates weekly. 
  - removed the 3 PR limit due to this
- Some still get their own PRs (if they've required manual intervention in the past)

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
