### PR TITLE
:seedling: fix sorting contributors before comparing in test

### DIFF
--- a/clients/azuredevopsrepo/contributors_test.go
+++ b/clients/azuredevopsrepo/contributors_test.go
@@ -122,7 +122,8 @@ func Test_listContributors(t *testing.T) {
 				t.Errorf("contributorsHandler.setup() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if diff := cmp.Diff(tt.wantContribs, c.contributors, cmpopts.SortSlices(func(a, b string) bool { return a < b })); diff != "" {
+			sortUsers := func(a, b clients.User) bool { return a.Login < b.Login }
+			if diff := cmp.Diff(tt.wantContribs, c.contributors, cmpopts.SortSlices(sortUsers)); diff != "" {
 				t.Errorf("contributorsHandler.setup() mismatch (-want +got):\n%s", diff)
 			}
 		})


### PR DESCRIPTION
#### What kind of change does this PR introduce?

test fix follow up of #4437

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The intention for the test was always to sort, but the wrong sort function was used. This led to an unsorted list, which was dependent on map iteration order, leading to flaky unit tests. This was reproducible with `go test` when passing a large `--count` option.

#### What is the new behavior (if this is a feature change)?**
The contributors are sorted correctly.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
See https://github.com/ossf/scorecard/actions/runs/12300084637/job/34327383076#step:9:26

```
--- FAIL: Test_listContributors (0.00s)
    --- FAIL: Test_listContributors/multiple_contributors (0.00s)
        contributors_test.go:126: contributorsHandler.setup() mismatch (-want +got):
              []clients.User{
              	{
            - 		Login:            "test@example.com",
            + 		Login:            "test2@example.com",
              		Companies:        {"testOrg"},
              		Organizations:    nil,
            - 		NumContributions: 1,
            + 		NumContributions: 2,
              		ID:               0,
              		IsBot:            false,
              	},
              	{
            - 		Login:            "test2@example.com",
            + 		Login:            "test@example.com",
              		Companies:        {"testOrg"},
              		Organizations:    nil,
            - 		NumContributions: 2,
            + 		NumContributions: 1,
              		ID:               0,
              		IsBot:            false,
              	},
              }
FAIL
```
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
