### PR TITLE
:seedling: Logging a warning if readGitHubTokens finds several values which clash.

### DIFF
--- a/clients/githubrepo/roundtripper/tokens/accessor.go
+++ b/clients/githubrepo/roundtripper/tokens/accessor.go
@@ -35,7 +35,13 @@ type TokenAccessor interface {
 }
 
 var logDuplicateTokenWarning = func(firstName string, clashingName string) {
-	log.Printf("Warning: PATs stored in env variables %s and %s differ. Scorecard will use the former.\n", firstName, clashingName)
+	var stringBuilder strings.Builder
+	stringBuilder.WriteString("Warning: PATs stored in env variables ")
+	stringBuilder.WriteString(firstName)
+	stringBuilder.WriteString(" and ")
+	stringBuilder.WriteString(clashingName)
+	stringBuilder.WriteString(" differ. Scorecard will use the former.")
+	log.Println(stringBuilder.String())
 }
 
 func readGitHubTokens() (string, bool) {

--- a/clients/githubrepo/roundtripper/tokens/accessor.go
+++ b/clients/githubrepo/roundtripper/tokens/accessor.go
@@ -16,7 +16,7 @@
 package tokens
 
 import (
-	"fmt"
+	"log"
 	"os"
 	"strings"
 )
@@ -35,7 +35,7 @@ type TokenAccessor interface {
 }
 
 var logDuplicateTokenWarning = func(firstName string, clashingName string) {
-	fmt.Printf("Warning: PATs stored in env variables %s and %s differ. Scorecard will use the former.\n", firstName, clashingName)
+	log.Printf("Warning: PATs stored in env variables %s and %s differ. Scorecard will use the former.\n", firstName, clashingName)
 }
 
 func readGitHubTokens() (string, bool) {

--- a/clients/githubrepo/roundtripper/tokens/accessor_test.go
+++ b/clients/githubrepo/roundtripper/tokens/accessor_test.go
@@ -93,7 +93,6 @@ func testServer(t *testing.T) {
 }
 
 func TestClashingTokensDisplayWarning(t *testing.T) {
-	t.Helper()
 	someToken := "test_token"
 	otherToken := "clashing_token"
 	t.Setenv("GITHUB_AUTH_TOKEN", someToken)
@@ -120,7 +119,6 @@ func TestClashingTokensDisplayWarning(t *testing.T) {
 }
 
 func TestConsistentTokensDoNotDisplayWarning(t *testing.T) {
-	t.Helper()
 	someToken := "test_token"
 	t.Setenv("GITHUB_AUTH_TOKEN", someToken)
 	t.Setenv("GITHUB_TOKEN", someToken)
@@ -146,8 +144,6 @@ func TestConsistentTokensDoNotDisplayWarning(t *testing.T) {
 }
 
 func TestNoTokensDoNoDisplayWarning(t *testing.T) {
-	t.Helper()
-
 	warningCalled := false
 	originalLogWarning := logDuplicateTokenWarning
 	logDuplicateTokenWarning = func(firstName string, clashingName string) {

--- a/clients/githubrepo/roundtripper/tokens/accessor_test.go
+++ b/clients/githubrepo/roundtripper/tokens/accessor_test.go
@@ -90,7 +90,6 @@ func testServer(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // test uses t.Setenv indirectly
 func TestClashingTokensDisplayWarning(t *testing.T) {
 	unsetTokens(t)
 
@@ -119,7 +118,6 @@ func TestClashingTokensDisplayWarning(t *testing.T) {
 	}
 }
 
-//nolint:paralleltest // test uses t.Setenv indirectly
 func TestConsistentTokensDoNotDisplayWarning(t *testing.T) {
 	unsetTokens(t)
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Print a warning if several GitHub Access Tokens with different values are found.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Scorecard ignores any GitHub PAT environment variables after the first one it finds.

#### What is the new behavior (if this is a feature change)?**

Scorecards checks all possible PAT env vars and prints a warning if their values differ. It still uses the first one it finds, such that the behaviour is non-breaking.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4475

#### Special notes for your reviewer

The local tests failed already for a clean checkout of the main branch. I am hoping for the CI to sucessfully run them for me.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Print a warning if several GitHub PAT environment variables with different values are set.
```
