### PR TITLE
:sparkles: Support results output as in-toto statement

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -43,6 +43,7 @@ require (
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-github/v53 v53.2.0
 	github.com/google/osv-scanner v1.9.2
+	github.com/in-toto/attestation v1.1.1
 	github.com/mcuadros/go-jsonschema-generator v0.0.0-20200330054847-ba7a369d4303
 	github.com/onsi/ginkgo/v2 v2.22.2
 	github.com/otiai10/copy v1.14.1

--- a/go.sum
+++ b/go.sum
@@ -510,6 +510,8 @@ github.com/ianlancetaylor/demangle v0.0.0-20240912202439-0a2b6291aafd/go.mod h1:
 github.com/imdario/mergo v0.3.5/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/imdario/mergo v0.3.16 h1:wwQJbIsHYGMUyLSPrEq1CT16AhnhNJQ51+4fdHUnCl4=
 github.com/imdario/mergo v0.3.16/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+hD27ysY=
+github.com/in-toto/attestation v1.1.1 h1:QD3d+oATQ0dFsWoNh5oT0udQ3tUrOsZZ0Fc3tSgWbzI=
+github.com/in-toto/attestation v1.1.1/go.mod h1:Dcq1zVwA2V7Qin8I7rgOi+i837wEf/mOZwRm047Sjys=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/options/flags.go
+++ b/options/flags.go
@@ -195,6 +195,7 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		FormatDefault,
 		FormatJSON,
 		FormatProbe,
+		FormatInToto,
 	}
 
 	if o.isSarifEnabled() {

--- a/options/options.go
+++ b/options/options.go
@@ -83,6 +83,8 @@ const (
 	FormatDefault = "default"
 	// FormatRaw specifies that results should be output in raw format.
 	FormatRaw = "raw"
+	// FormatInToyo specifies that results should be output in an in-toto statement.
+	FormatInToto = "intoto"
 
 	// File Modes
 	// FileModeGit specifies that files should be fetched using git.
@@ -255,7 +257,7 @@ func (o *Options) isV6Enabled() bool {
 
 func validateFormat(format string) bool {
 	switch format {
-	case FormatJSON, FormatProbe, FormatSarif, FormatDefault, FormatRaw:
+	case FormatJSON, FormatProbe, FormatSarif, FormatDefault, FormatRaw, FormatInToto:
 		return true
 	default:
 		return false

--- a/pkg/scorecard/scorecard_result.go
+++ b/pkg/scorecard/scorecard_result.go
@@ -157,10 +157,12 @@ func FormatResults(
 		}
 		err = results.AsJSON2(output, doc, o)
 	case options.FormatInToto:
-		o := &AsJSON2ResultOption{
-			Details:     opts.ShowDetails,
-			Annotations: opts.ShowAnnotations,
-			LogLevel:    log.ParseLevel(opts.LogLevel),
+		o := &AsInTotoResultOption{
+			AsJSON2ResultOption: AsJSON2ResultOption{
+				Details:     opts.ShowDetails,
+				Annotations: opts.ShowAnnotations,
+				LogLevel:    log.ParseLevel(opts.LogLevel),
+			},
 		}
 		err = results.AsInToto(output, doc, o)
 	case options.FormatProbe:

--- a/pkg/scorecard/scorecard_result.go
+++ b/pkg/scorecard/scorecard_result.go
@@ -156,6 +156,13 @@ func FormatResults(
 			LogLevel:    log.ParseLevel(opts.LogLevel),
 		}
 		err = results.AsJSON2(output, doc, o)
+	case options.FormatInToto:
+		o := &AsJSON2ResultOption{
+			Details:     opts.ShowDetails,
+			Annotations: opts.ShowAnnotations,
+			LogLevel:    log.ParseLevel(opts.LogLevel),
+		}
+		err = results.AsInToto(output, doc, o)
 	case options.FormatProbe:
 		var opts *ProbeResultOption
 		err = results.AsProbe(output, opts)

--- a/pkg/scorecard/statement.go
+++ b/pkg/scorecard/statement.go
@@ -1,0 +1,96 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+
+	intoto "github.com/in-toto/attestation/go/v1"
+
+	docs "github.com/ossf/scorecard/v5/docs/checks"
+	sce "github.com/ossf/scorecard/v5/errors"
+	"github.com/ossf/scorecard/v5/log"
+)
+
+const (
+	InTotoPredicateType = "https://scorecard.dev/result/v0.1"
+)
+
+type statement struct {
+	Predicate InTotoPredicate `json:"predicate"`
+	intoto.Statement
+}
+
+// Predicate overrides JSONScorecardResultV2 with a nullable Repo field.
+type InTotoPredicate struct {
+	Repo *jsonRepoV2 `json:"repo,omitempty"`
+	JSONScorecardResultV2
+}
+
+// AsInTotoResultOption wraps AsJSON2ResultOption preparing it for export as an
+// intoto statement.
+type AsInTotoResultOption struct {
+	AsJSON2ResultOption
+}
+
+// AsStatement converts the results as an in-toto statement.
+func (r *Result) AsStatement(writer io.Writer, checkDocs docs.Doc, opt *AsInTotoResultOption) error {
+	// Build the attestation subject from the result Repo.
+	subject := intoto.ResourceDescriptor{
+		Name: r.Repo.Name,
+		Uri:  fmt.Sprintf("git+https://%s@%s", r.Repo.Name, r.Repo.CommitSHA),
+		Digest: map[string]string{
+			"gitCommit": r.Repo.CommitSHA,
+		},
+	}
+
+	if opt == nil {
+		opt = &AsInTotoResultOption{
+			AsJSON2ResultOption{
+				LogLevel:    log.DefaultLevel,
+				Details:     false,
+				Annotations: false,
+			},
+		}
+	}
+
+	json2, err := r.resultsToJSON2(checkDocs, &opt.AsJSON2ResultOption)
+	if err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, err.Error())
+	}
+
+	out := statement{
+		Statement: intoto.Statement{
+			Type: intoto.StatementTypeUri,
+			Subject: []*intoto.ResourceDescriptor{
+				&subject,
+			},
+			PredicateType: InTotoPredicateType,
+		},
+		Predicate: InTotoPredicate{
+			JSONScorecardResultV2: json2,
+			Repo:                  nil,
+		},
+	}
+
+	encoder := json.NewEncoder(writer)
+	if err := encoder.Encode(&out); err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("encoder.Encode: %v", err))
+	}
+
+	return nil
+}

--- a/pkg/scorecard/statement.go
+++ b/pkg/scorecard/statement.go
@@ -48,7 +48,7 @@ type AsInTotoResultOption struct {
 }
 
 // AsStatement converts the results as an in-toto statement.
-func (r *Result) AsStatement(writer io.Writer, checkDocs docs.Doc, opt *AsInTotoResultOption) error {
+func (r *Result) AsInToto(writer io.Writer, checkDocs docs.Doc, opt *AsInTotoResultOption) error {
 	// Build the attestation subject from the result Repo.
 	subject := intoto.ResourceDescriptor{
 		Name: r.Repo.Name,

--- a/pkg/scorecard/statement_test.go
+++ b/pkg/scorecard/statement_test.go
@@ -1,0 +1,99 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"bytes"
+	"encoding/json"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+func TestInToto(t *testing.T) {
+	t.Parallel()
+	// The intoto statement generation relies on the same generation as
+	// the json output, so here we just check for correct assignments
+	result := Result{
+		Repo: RepoInfo{
+			Name:      "github.com/example/example",
+			CommitSHA: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		},
+		Scorecard: ScorecardInfo{
+			Version:   "1.2.3",
+			CommitSHA: "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+		},
+		Date: time.Date(2024, time.February, 1, 13, 48, 0, 0, time.UTC),
+		Findings: []finding.Finding{
+			{
+				Probe:   "check for X",
+				Outcome: finding.OutcomeTrue,
+				Message: "found X",
+				Location: &finding.Location{
+					Path: "some/path/to/file",
+					Type: finding.FileTypeText,
+				},
+			},
+			{
+				Probe:   "check for Y",
+				Outcome: finding.OutcomeFalse,
+				Message: "did not find Y",
+			},
+		},
+	}
+	var w bytes.Buffer
+	err := result.AsInToto(&w, jsonMockDocRead(), nil)
+	if err != nil {
+		t.Error("unexpected error: ", err)
+	}
+
+	// Unmarshal the written json to a generic map
+	stmt := statement{}
+	if err := json.Unmarshal(w.Bytes(), &stmt); err != nil {
+		t.Error("error unmarshaling statement", err)
+		return
+	}
+
+	// Check the data
+	if len(stmt.Subject) != 1 {
+		t.Error("unexpected statement subject length")
+	}
+	if stmt.Subject[0].GetDigest()["gitCommit"] != result.Repo.CommitSHA {
+		t.Error("mismatched statement subject digest")
+	}
+	if stmt.Subject[0].GetName() != result.Repo.Name {
+		t.Error("mismatched statement subject name")
+	}
+
+	if stmt.PredicateType != InTotoPredicateType {
+		t.Error("incorrect predicate type", stmt.PredicateType)
+	}
+
+	// Check the predicate
+	if stmt.Predicate.Scorecard.Commit != result.Scorecard.CommitSHA {
+		t.Error("mismatch in scorecard commit")
+	}
+	if stmt.Predicate.Scorecard.Version != result.Scorecard.Version {
+		t.Error("mismatch in scorecard version")
+	}
+	if stmt.Predicate.Repo != nil {
+		t.Error("repo should be null")
+	}
+	if !slices.Equal(stmt.Predicate.Metadata, result.Metadata) {
+		t.Error("mismatched metadata")
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Feature

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Currently scorecard does not support generating in-toto statements.

#### What is the new behavior (if this is a feature change)?**

This PR adds support to generate the scorecard output in an in-toto statement. It introduces a new possible value for the format flag: `--format=intoto`.

**The predicate format is open to discussion**, right now is just a reformated version of `JSONScorecardResultV2` with the repo removed (as it is now in the statement's subject section):

```
scorecard --format=intoto --checks=Maintained --repo=github.com/protobom/protobom
```

```json
{
  "type": "https://in-toto.io/Statement/v1",
  "subject": [
    {
      "name": "github.com/protobom/protobom",
      "uri": "git+https://github.com/protobom/protobom@0aa9659c6dc7354c5c60945f44b35bb2ed457857",
      "digest": {
        "gitCommit": "0aa9659c6dc7354c5c60945f44b35bb2ed457857"
      }
    }
  ],
  "predicate_type": "https://scorecard.dev/result/v0.1",
  "predicate": {
    "date": "2025-02-19T11:32:25-06:00",
    "scorecard": {
      "version": "devel",
      "commit": "unknown"
    },
    "score": 10.0,
    "checks": [
      {
        "details": null,
        "score": 10,
        "reason": "30 commit(s) and 5 issue activity found in the last 90 days -- score normalized to 10",
        "name": "Maintained",
        "documentation": {
          "url": "https://github.com/ossf/scorecard/blob/main/docs/checks.md#maintained",
          "short": "Determines if the project is \"actively maintained\"."
        }
      }
    ],
    "metadata": null
  }
}
```

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #3352

#### Special notes for your reviewer

Let me know if the predicate format should change (or if fields should be added or removed).

/cc @adityasaky as the original author of #3352
/cc @marcelamelara @mlieberman85  

#### Does this PR introduce a user-facing change?

```release-note
Scorecard can now generate its output as an in-toto statement by specifying --format=intoto 
```
