### PR TITLE
:seedling: use scorecard as binary name for all release builds

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -11,8 +11,7 @@ gomod:
   proxy: true
 builds:
 - id: linux
-  binary: scorecard-linux-{{ .Arch }}
-  no_unique_dist_dir: true
+  binary: scorecard
   flags:
    # trimpath is for reproducible builds
    # remove all file system paths from the resulting executable.
@@ -36,8 +35,7 @@ builds:
     - -s {{.Env.VERSION_LDFLAGS}} 
 
 - id: darwin
-  binary: scorecard-darwin-{{ .Arch }}
-  no_unique_dist_dir: true
+  binary: scorecard
   flags:
    # trimpath is for reproducible builds
    # remove all file system paths from the resulting executable.
@@ -61,8 +59,7 @@ builds:
     - -s {{.Env.VERSION_LDFLAGS}} 
 
 - id: windows
-  binary: scorecard-windows-{{ .Arch }}
-  no_unique_dist_dir: true
+  binary: scorecard
   flags:
    # trimpath is for reproducible builds
    # remove all file system paths from the resulting executable.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -90,7 +90,7 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: SNAPSHOT-{{ .ShortCommit }}
+  version_template: SNAPSHOT-{{ .ShortCommit }}
 changelog:
   # Set it to true if you wish to skip the changelog generation.
   # This may result in an empty release notes on GitHub/GitLab/Gitea.

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,7 +1,6 @@
 module github.com/ossf/scorecard/tools
 
-go 1.23.0
-toolchain go1.23.6
+go 1.23.4
 
 require (
 	github.com/golang/mock v1.6.0


### PR DESCRIPTION
#### What kind of change does this PR introduce?

release config

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
each release has the platform in the binary name `scorecard_5.0.0_darwin_arm64`

#### What is the new behavior (if this is a feature change)?**

Each scorecard binary is called `scorecard` or `scorecard.exe` if Windows

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #4517 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Scorecard release binary names are now consistent across platforms.
```
