### PR TITLE
:seedling: remove OS and Arch info from scorecard release binary name

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -42,7 +42,7 @@ checksum:
   name_template: "{{ .ProjectName }}_checksums.txt"
 
 snapshot:
-  name_template: SNAPSHOT-{{ .ShortCommit }}
+  version_template: SNAPSHOT-{{ .ShortCommit }}
 changelog:
   # Set it to true if you wish to skip the changelog generation.
   # This may result in an empty release notes on GitHub/GitLab/Gitea.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -10,9 +10,7 @@ before:
 gomod:
   proxy: true
 builds:
-- id: linux
-  binary: scorecard-linux-{{ .Arch }}
-  no_unique_dist_dir: true
+- id: universal
   flags:
    # trimpath is for reproducible builds
    # remove all file system paths from the resulting executable.
@@ -29,61 +27,12 @@ builds:
   mod_timestamp: '{{ .CommitTimestamp }}'
   goos:
     - linux
-  goarch:
-    - amd64
-    - arm64
-  ldflags:
-    - -s {{.Env.VERSION_LDFLAGS}} 
-
-- id: darwin
-  binary: scorecard-darwin-{{ .Arch }}
-  no_unique_dist_dir: true
-  flags:
-   # trimpath is for reproducible builds
-   # remove all file system paths from the resulting executable.
-   # Instead of absolute file system paths, the recorded file names
-   # will begin with either "go" (for the standard library),
-   # or a module path@version (when using modules),
-   # or a plain import path (when using GOPATH).
-      - -trimpath
-      - -tags=netgo
-  # Set the modified timestamp on the output binary, typically
-  # you would do this to ensure a build was reproducible. Pass
-  # empty string to skip modifying the output.
-  # Default is empty string.
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  goos:
     - darwin
-  goarch:
-    - amd64
-    - arm64
-  ldflags:
-    - -s {{.Env.VERSION_LDFLAGS}} 
-
-- id: windows
-  binary: scorecard-windows-{{ .Arch }}
-  no_unique_dist_dir: true
-  flags:
-   # trimpath is for reproducible builds
-   # remove all file system paths from the resulting executable.
-   # Instead of absolute file system paths, the recorded file names
-   # will begin with either "go" (for the standard library),
-   # or a module path@version (when using modules),
-   # or a plain import path (when using GOPATH).
-      - -trimpath
-      - -tags=netgo
-  # Set the modified timestamp on the output binary, typically
-  # you would do this to ensure a build was reproducible. Pass
-  # empty string to skip modifying the output.
-  # Default is empty string.
-  mod_timestamp: '{{ .CommitTimestamp }}'
-  goos:
     - windows
   goarch:
     - amd64
     - arm64
   ldflags:
-    - -buildmode=exe
     - -s {{.Env.VERSION_LDFLAGS}} 
 
 checksum:

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,7 @@
 module github.com/ossf/scorecard/tools
 
-go 1.23.0
+go 1.23.4
+
 toolchain go1.23.6
 
 require (


### PR DESCRIPTION
#### What kind of change does this PR introduce?

release config

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
- `scorecard_5.0.0_darwin_amd64`
- `scorecard_5.0.0_darwin_arm64`
- `scorecard_5.0.0_linux_amd64`
- `scorecard_5.0.0_linux_arm64`
- `scorecard_5.0.0_windows_amd64.exe`
- `scorecard_5.0.0_windows_arm64.exe`


#### What is the new behavior (if this is a feature change)?**

There will be a single binary called `scorecard`, or for windows `scorecard.exe`

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4517 


#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Scorecard binary name is now consistent across all release platforms
```
