### PR TITLE
🐛 do not allow unsupported `ListReleases` to fail a run

### DIFF
--- a/checks/raw/branch_protection.go
+++ b/checks/raw/branch_protection.go
@@ -15,6 +15,7 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -66,6 +67,9 @@ func BranchProtection(cr *checker.CheckRequest) (checker.BranchProtectionsData, 
 	// Get release branches.
 	releases, err := c.ListReleases()
 	if err != nil {
+		if errors.Is(err, clients.ErrUnsupportedFeature) {
+			return checker.BranchProtectionsData{}, nil
+		}
 		return checker.BranchProtectionsData{}, fmt.Errorf("%w", err)
 	}
 	for _, release := range releases {

--- a/checks/raw/sbom.go
+++ b/checks/raw/sbom.go
@@ -15,6 +15,7 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -38,6 +39,9 @@ func SBOM(c *checker.CheckRequest) (checker.SBOMData, error) {
 
 	releases, lerr := c.RepoClient.ListReleases()
 	if lerr != nil {
+		if errors.Is(lerr, clients.ErrUnsupportedFeature) {
+			return results, nil
+		}
 		return results, fmt.Errorf("RepoClient.ListReleases: %w", lerr)
 	}
 

--- a/checks/raw/signed_releases.go
+++ b/checks/raw/signed_releases.go
@@ -15,15 +15,20 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
 )
 
 // SignedReleases checks for presence of signed release check.
 func SignedReleases(c *checker.CheckRequest) (checker.SignedReleasesData, error) {
 	releases, err := c.RepoClient.ListReleases()
 	if err != nil {
+		if errors.Is(err, clients.ErrUnsupportedFeature) {
+			return checker.SignedReleasesData{}, nil
+		}
 		return checker.SignedReleasesData{}, fmt.Errorf("%w", err)
 	}
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This check allows clients which currently do not support `ListReleases` to complete a Scorecard run. Currently `azuredevopsrepo`, `localdir`, and `git` do not support `ListReleases`. While I am working on support for Azure DevOps, I suspect that `localdir` and `git` may never support `ListReleases`.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Currently, if a client does not support `ListReleases`, the Scorecard run fails with an error like:

```
Error: check runtime error: Branch-Protection: internal error: unsupported feature
```

This is the case for `Branch-Protection` and `Signed-Releases`.

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

This is similar to the fix done in #4423

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Prevent unimplemented ListReleases from failing a run
```
