### PR TITLE
:seedling: Require minimum version of Go 1.23.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -37,7 +37,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   analyze:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -23,7 +23,7 @@ on:
   - main
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   docs_only_check:

--- a/.github/workflows/gitlab.yml
+++ b/.github/workflows/gitlab.yml
@@ -25,7 +25,7 @@ on:
       - main
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   gitlab-integration-trusted:

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   goreleaser:

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -24,7 +24,7 @@ permissions:
   contents: read
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   approve:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,7 +12,7 @@ permissions:
   pull-requests: read # Use with `only-new-issues` option.
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   golangci:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ on:
 
 env:
   PROTOC_VERSION: 21.6
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   unit-test:

--- a/.github/workflows/publishimage.yml
+++ b/.github/workflows/publishimage.yml
@@ -23,7 +23,7 @@ on:
       - v*
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   publishimage:

--- a/.github/workflows/scdiff.yml
+++ b/.github/workflows/scdiff.yml
@@ -6,7 +6,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   share-link:

--- a/.github/workflows/slsa-goreleaser.yml
+++ b/.github/workflows/slsa-goreleaser.yml
@@ -8,7 +8,7 @@ on:
 permissions: read-all
 
 env:
-  GO_VERSION: 1.23
+  GO_VERSION: 1.24
 
 jobs:
   # Generate ldflags dynamically.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,7 +53,7 @@ You must install these tools:
 1.  [`git`](https://help.github.com/articles/set-up-git/): For source control
 
 1.  [`go`](https://golang.org/doc/install): You need go version
-    [v1.22.0](https://golang.org/dl/) or higher.
+    [v1.23.0](https://golang.org/dl/) or higher.
 
 1.  [`protoc`](https://grpc.io/docs/protoc-installation/): `v3` or higher
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/scorecard/v5
 
-go 1.22.10
+go 1.23.0
 
 require (
 	cloud.google.com/go/bigquery v1.66.2

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -2,8 +2,6 @@ module github.com/ossf/scorecard/tools
 
 go 1.23.4
 
-toolchain go1.23.6
-
 require (
 	github.com/golang/mock v1.6.0
 	github.com/golangci/golangci-lint v1.64.6


### PR DESCRIPTION
#### What kind of change does this PR introduce?

go directive bump

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Go 1.22.10 is the minimum version required to compile Scorecard or use it as a library.
Workflows use Go 1.23

#### What is the new behavior (if this is a feature change)?**

Go 1.23.0 is now the minimum version. 
Workflows use Go 1.24

At least one of our dependencies now requires 1.23 (see #4544, which is why the build is failing). Additionally, with the Go 1.24 release, Go 1.22 is no longer supported.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Go 1.23.0 is now required to build Scorecard or use it as a library.
```
