### PR TITLE
:sparkles: gitfile: fetch no tags during clone

### DIFF
--- a/internal/gitfile/gitfile.go
+++ b/internal/gitfile/gitfile.go
@@ -68,6 +68,8 @@ func (h *Handler) setup() error {
 			// TODO: auth may be required for private repos
 			Depth:        1, // currently only use the git repo for files, dont need history
 			SingleBranch: true,
+			// https://github.com/go-git/go-git/issues/545#issuecomment-1353681676
+			Tags: git.NoTags,
 		})
 		if err != nil {
 			h.errSetup = err


### PR DESCRIPTION
#### What kind of change does this PR introduce?

optimization

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
We already doing a shallow clone, but `go-git` fetches all tags from the remote by default. We don't need them for this operation, we just care about the files at HEAD (or whatever commit is requested).


#### What is the new behavior (if this is a feature change)?**
Don't fetch tags. This performance optimization results in a 3x speedup on my machine when analyzing the `ossf/scorecard` repository with `--file-mode git`. It practically gets performance up to `--file-mode archive` levels

See [upstream discussion here](https://www.github.com/go-git/go-git/issues/545#issuecomment-1353681676)

Before: 29.974s
After: 8.644s
(archive): 6s


- [X] Tests for the changes have been added (for bug fixes/features)
NONE
#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

scdiff tests pass (though the workflow command we have isn't configured to do this)

With a slightly modified scdiff to use `--file-mode git`, the difference is 2x or so:

Before: 4m 11s
After: 2m 21s
(archive mode): 2m 15s

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Improved the performance of `--file-mode git`
```
