### PR TITLE
:seedling: switch to copyloopvar linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -28,7 +28,7 @@ issues:
 linters:
   enable:
     - asciicheck
-    # - copyloopvar # TODO(spencer)
+    - copyloopvar
     - dogsled
     - err113
     - errcheck

--- a/attestor/policy/attestation_policy_test.go
+++ b/attestor/policy/attestation_policy_test.go
@@ -571,7 +571,6 @@ func TestAttestationPolicy_GetRequiredChecksForPolicy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ap := &AttestationPolicy{
@@ -679,7 +678,6 @@ func TestAttestationPolicy_EvaluateResults(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ap := &AttestationPolicy{

--- a/checker/check_request_test.go
+++ b/checker/check_request_test.go
@@ -56,7 +56,6 @@ func TestListUnsupported(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := ListUnsupported(tt.args.required, tt.args.supported); cmp.Equal(got, tt.want) {
@@ -111,7 +110,6 @@ func Test_contains(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := contains(tt.args.in, tt.args.exists); got != tt.want {

--- a/checker/check_result_test.go
+++ b/checker/check_result_test.go
@@ -51,7 +51,6 @@ func TestAggregateScores(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := AggregateScores(tt.args.scores...); got != tt.want {
@@ -87,7 +86,6 @@ func TestAggregateScoresWithWeight(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := AggregateScoresWithWeight(tt.args.scores); got != tt.want {
@@ -141,7 +139,6 @@ func TestCreateProportionalScore(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := CreateProportionalScore(tt.args.success, tt.args.total); got != tt.want {
@@ -399,7 +396,6 @@ func TestCreateProportionalScoreWeighted(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := CreateProportionalScoreWeighted(tt.scores...)
@@ -447,7 +443,6 @@ func TestNormalizeReason(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := NormalizeReason(tt.args.reason, tt.args.score); got != tt.want {
@@ -544,7 +539,6 @@ func TestCreateResultWithScore(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := CreateResultWithScore(tt.args.name, tt.args.reason, tt.args.score)
@@ -616,7 +610,6 @@ func TestCreateProportionalScoreResult(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := CreateProportionalScoreResult(tt.args.name, tt.args.reason, tt.args.b, tt.args.t)
@@ -666,7 +659,6 @@ func TestCreateMaxScoreResult(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := CreateMaxScoreResult(tt.args.name, tt.args.reason); !cmp.Equal(got, tt.want) {
@@ -715,7 +707,6 @@ func TestCreateMinScoreResult(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := CreateMinScoreResult(tt.args.name, tt.args.reason); !cmp.Equal(got, tt.want) {
@@ -764,7 +755,6 @@ func TestCreateInconclusiveResult(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := CreateInconclusiveResult(tt.args.name, tt.args.reason); !cmp.Equal(got, tt.want) {
@@ -801,7 +791,6 @@ func TestCreateRuntimeErrorResult(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := CreateRuntimeErrorResult(tt.args.name, tt.args.e); !reflect.DeepEqual(got, tt.want) {
@@ -971,7 +960,6 @@ func TestAnnotations(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			reasons := tt.args.check.Annotations(tt.args.config)

--- a/checker/client_test.go
+++ b/checker/client_test.go
@@ -98,7 +98,6 @@ func TestGetClients(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.experimental {
 				t.Setenv("SCORECARD_EXPERIMENTAL", "true")

--- a/checks/all_checks_test.go
+++ b/checks/all_checks_test.go
@@ -57,7 +57,6 @@ func Test_registerCheck(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if err := registerCheck(tt.args.name, tt.args.fn, nil /*supportedRequestTypes*/); (err != nil) != tt.wanterr {

--- a/checks/binary_artifact_test.go
+++ b/checks/binary_artifact_test.go
@@ -57,7 +57,6 @@ func TestBinaryArtifacts(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -399,7 +399,6 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/cii_best_practices_test.go
+++ b/checks/cii_best_practices_test.go
@@ -101,7 +101,6 @@ func TestCIIBestPractices(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/code_review_test.go
+++ b/checks/code_review_test.go
@@ -261,7 +261,6 @@ func TestCodereview(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/checks/contributors_test.go
+++ b/checks/contributors_test.go
@@ -156,7 +156,6 @@ func TestContributors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/checks/dangerous_workflow_test.go
+++ b/checks/dangerous_workflow_test.go
@@ -74,7 +74,6 @@ func TestDangerousWorkflow(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/dependency_update_tool_test.go
+++ b/checks/dependency_update_tool_test.go
@@ -159,7 +159,6 @@ func TestDependencyUpdateTool(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/checks/evaluation/binary_artifacts_test.go
+++ b/checks/evaluation/binary_artifacts_test.go
@@ -122,7 +122,6 @@ func TestBinaryArtifacts(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/branch_protection_test.go
+++ b/checks/evaluation/branch_protection_test.go
@@ -408,7 +408,6 @@ func TestBranchProtection(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/ci_tests_test.go
+++ b/checks/evaluation/ci_tests_test.go
@@ -106,7 +106,6 @@ func TestCITests(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/cii_best_practices_test.go
+++ b/checks/evaluation/cii_best_practices_test.go
@@ -138,7 +138,6 @@ func TestCIIBestPractices(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Parallel testing
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/code_review_test.go
+++ b/checks/evaluation/code_review_test.go
@@ -90,7 +90,6 @@ func TestCodeReview(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := &scut.TestDetailLogger{}

--- a/checks/evaluation/contributors_test.go
+++ b/checks/evaluation/contributors_test.go
@@ -78,7 +78,6 @@ func TestContributors(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/dangerous_workflow_test.go
+++ b/checks/evaluation/dangerous_workflow_test.go
@@ -225,7 +225,6 @@ func TestDangerousWorkflow(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/dependency_update_tool_test.go
+++ b/checks/evaluation/dependency_update_tool_test.go
@@ -80,7 +80,6 @@ func TestDependencyUpdateTool(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/fuzzing_test.go
+++ b/checks/evaluation/fuzzing_test.go
@@ -82,7 +82,6 @@ func TestFuzzing(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/license_test.go
+++ b/checks/evaluation/license_test.go
@@ -110,7 +110,6 @@ func TestLicense(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Parallel testing scoping hack.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/maintained_test.go
+++ b/checks/evaluation/maintained_test.go
@@ -155,7 +155,6 @@ func TestMaintained(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Parallel testing
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/packaging_test.go
+++ b/checks/evaluation/packaging_test.go
@@ -83,7 +83,6 @@ func TestPackaging(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Parallel testing
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/pinned_dependencies_test.go
+++ b/checks/evaluation/pinned_dependencies_test.go
@@ -217,7 +217,6 @@ func Test_createScoreForGitHubActionsWorkflow(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}
@@ -460,7 +459,6 @@ func Test_PinningDependencies(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}
@@ -560,7 +558,6 @@ func Test_addWorkflowPinnedResult(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			addWorkflowPinnedResult(tt.args.outcome, tt.args.w, tt.args.isGitHub)
@@ -728,7 +725,6 @@ func TestUpdatePinningResults(t *testing.T) {
 		},
 	}
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			updatePinningResults(tc.args.dependencyType, tc.args.outcome, tc.args.snippet, tc.args.w, tc.args.pr)
@@ -775,7 +771,6 @@ func Test_generateOwnerToDisplay(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := generateOwnerToDisplay(tt.gitHubOwned); got != tt.want {

--- a/checks/evaluation/sast_test.go
+++ b/checks/evaluation/sast_test.go
@@ -162,7 +162,6 @@ func TestSAST(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/sbom_test.go
+++ b/checks/evaluation/sbom_test.go
@@ -84,7 +84,6 @@ func TestSBOM(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/security_policy_test.go
+++ b/checks/evaluation/security_policy_test.go
@@ -187,7 +187,6 @@ func TestSecurityPolicy(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/signed_releases_test.go
+++ b/checks/evaluation/signed_releases_test.go
@@ -216,7 +216,6 @@ func TestSignedReleases(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}
@@ -272,7 +271,6 @@ func Test_getReleaseName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := getReleaseName(tt.args.f); got != tt.want {

--- a/checks/evaluation/vulnerabilities_test.go
+++ b/checks/evaluation/vulnerabilities_test.go
@@ -73,7 +73,6 @@ func TestVulnerabilities(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/evaluation/webhooks_test.go
+++ b/checks/evaluation/webhooks_test.go
@@ -224,7 +224,6 @@ func TestWebhooks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -118,7 +118,6 @@ func TestGitHubWorkflowShell(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := stdos.ReadFile(tt.filename)
@@ -132,9 +131,7 @@ func TestGitHubWorkflowShell(t *testing.T) {
 			}
 			actualShells := make([]string, 0)
 			for _, job := range workflow.Jobs {
-				job := job
 				for _, step := range job.Steps {
-					step := step
 					shell, err := GetShellForStep(step, job)
 					if err != nil {
 						t.Errorf("error getting shell: %v", err)
@@ -204,7 +201,6 @@ func TestIsWorkflowFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := strings.Replace(tt.args.pathfn, "./testdata/", "", 1)
@@ -248,7 +244,6 @@ func TestIsGitHubOwnedAction(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := IsGitHubOwnedAction(tt.args.actionName); got != tt.want {
@@ -294,7 +289,6 @@ func TestGetJobName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := GetJobName(tt.args.job); got != tt.want {
@@ -339,7 +333,6 @@ func TestGetStepName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := GetStepName(tt.args.step); got != tt.want {
@@ -386,7 +379,6 @@ func TestIsStepExecKind(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := IsStepExecKind(tt.args.step, tt.args.kind); got != tt.want {
@@ -433,7 +425,6 @@ func TestGetLineNumber(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := GetLineNumber(tt.args.pos); got != tt.want {
@@ -473,7 +464,6 @@ func TestFormatActionlintError(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if err := FormatActionlintError(tt.args.errs); (err != nil) != tt.wantErr {
@@ -547,7 +537,6 @@ func TestGetUses(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := GetUses(tt.args.step); !reflect.DeepEqual(got, tt.want) {
@@ -633,7 +622,6 @@ func Test_getWith(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := getWith(tt.args.step); !reflect.DeepEqual(got, tt.want) {
@@ -730,7 +718,6 @@ func Test_getRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := getRun(tt.args.step); !reflect.DeepEqual(got, tt.want) {
@@ -905,7 +892,6 @@ func Test_stepsMatch(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := stepsMatch(tt.args.stepToMatch, tt.args.step); got != tt.want {
@@ -1010,7 +996,6 @@ func TestIsPackagingWorkflow(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := stdos.ReadFile(tt.filename)

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -124,7 +124,6 @@ func TestIsTemplateFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.filename, func(t *testing.T) {
 			t.Parallel()
 			if got := IsTemplateFile(tt.filename); got != tt.isTemplate {
@@ -171,7 +170,6 @@ func TestCheckFileContainsCommands(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := CheckFileContainsCommands(tt.args.content, tt.args.comment); got != tt.want {
@@ -314,7 +312,6 @@ func Test_isMatchingPath(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := isMatchingPath(tt.args.fullpath, PathMatcher{
@@ -386,7 +383,6 @@ func Test_isTestdataFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := isTestdataFile(tt.args.fullpath); got != tt.want {
@@ -512,7 +508,6 @@ func TestOnMatchingFileContent(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			x := func(path string, content []byte, args ...interface{}) (bool, error) {
@@ -628,7 +623,6 @@ func TestOnAllFilesDo(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/fuzzing_test.go
+++ b/checks/fuzzing_test.go
@@ -130,7 +130,6 @@ func TestFuzzing(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/checks/license_test.go
+++ b/checks/license_test.go
@@ -63,7 +63,6 @@ func TestLicenseFileSubdirectory(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/maintained_test.go
+++ b/checks/maintained_test.go
@@ -323,7 +323,6 @@ func Test_Maintained(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -425,7 +425,6 @@ func TestGithubTokenPermissions(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -492,7 +491,6 @@ func TestGithubTokenPermissionsLineNumber(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := strings.Replace(tt.filename, "./testdata/", "", 1)

--- a/checks/pinned_dependencies_test.go
+++ b/checks/pinned_dependencies_test.go
@@ -48,7 +48,6 @@ func TestPinningDependencies(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/raw/binary_artifact_test.go
+++ b/checks/raw/binary_artifact_test.go
@@ -229,7 +229,6 @@ func TestBinaryArtifacts(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/raw/branch_protection_test.go
+++ b/checks/raw/branch_protection_test.go
@@ -255,7 +255,6 @@ func TestBranchProtection(t *testing.T) {
 		// TODO: Add tests for commitSHA regex matching.
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/checks/raw/code_review_test.go
+++ b/checks/raw/code_review_test.go
@@ -387,7 +387,6 @@ func Test_getChangesets(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			changesets := getChangesets(tt.commits)

--- a/checks/raw/contributors_test.go
+++ b/checks/raw/contributors_test.go
@@ -53,7 +53,6 @@ func TestCompanyContains(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := companyContains(tc.cs, tc.company)
@@ -93,7 +92,6 @@ func TestOrgContains(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := orgContains(tc.os, tc.login)

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -78,7 +78,6 @@ func TestUntrustedContextVariables(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if r := containsUntrustedContextPattern(tt.variable); !r == tt.expected {
@@ -152,7 +151,6 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -155,7 +155,6 @@ func Test_checkDependencyFileExists(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			results := []checker.Tool{}
@@ -235,7 +234,6 @@ func TestDependencyUpdateTool(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/raw/fuzzing_test.go
+++ b/checks/raw/fuzzing_test.go
@@ -67,7 +67,6 @@ func Test_checkOSSFuzz(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -130,7 +129,6 @@ func Test_checkCFLite(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -208,7 +206,6 @@ func Test_fuzzFileAndFuncMatchPattern(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			langSpecs, ok := languageFuzzSpecs[tt.lang]
@@ -577,7 +574,6 @@ func Test_checkFuzzFunc(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -678,7 +674,6 @@ func Test_getProminentLanguages(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := getProminentLanguages(tt.languages)

--- a/checks/raw/gitlab/packaging_test.go
+++ b/checks/raw/gitlab/packaging_test.go
@@ -68,7 +68,6 @@ func TestGitlabPackagingYamlCheck(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -123,7 +122,6 @@ func TestGitlabPackagingPackager(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/raw/license_test.go
+++ b/checks/raw/license_test.go
@@ -647,7 +647,6 @@ func TestLicenseFileCheck(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		for _, ext := range tt.extensions {
 			name := tt.name + ext
 			shouldFail := tt.shouldFail

--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -617,15 +617,12 @@ var validateGitHubWorkflowIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFile
 
 	githubVarRegex := regexp.MustCompile(`{{[^{}]*}}`)
 	for jobName, job := range workflow.Jobs {
-		jobName := jobName
-		job := job
 		if len(fileparser.GetJobName(job)) > 0 {
 			jobName = fileparser.GetJobName(job)
 		}
 		taintedFiles := make(map[string]bool)
 
 		for _, step := range job.Steps {
-			step := step
 			if !fileparser.IsStepExecKind(step, actionlint.ExecKindRun) {
 				continue
 			}
@@ -739,8 +736,6 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 	}
 
 	for jobName, job := range workflow.Jobs {
-		jobName := jobName
-		job := job
 		if len(fileparser.GetJobName(job)) > 0 {
 			jobName = fileparser.GetJobName(job)
 		}

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -79,7 +79,6 @@ func TestGithubWorkflowPinning(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -182,7 +181,6 @@ func TestGithubWorkflowPinningPattern(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			p := isActionDependencyPinned(tt.uses)
@@ -233,7 +231,6 @@ func TestNonGithubWorkflowPinning(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -292,7 +289,6 @@ func TestGithubWorkflowPkgManagerPinning(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -384,7 +380,6 @@ func TestDockerfilePinning(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -526,7 +521,6 @@ func TestFileIsInVendorDir(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := fileIsInVendorDir(tt.filename)
@@ -600,7 +594,6 @@ func TestDockerfilePinningFromLineNumber(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := os.ReadFile(tt.filename)
@@ -690,7 +683,6 @@ func TestDockerfileInvalidFiles(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var c []byte
@@ -717,7 +709,6 @@ func TestDockerfileInsecureDownloadsBrokenCommands(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := os.ReadFile(tt.filename)
@@ -911,7 +902,6 @@ func TestDockerfileInsecureDownloadsLineNumber(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := os.ReadFile(tt.filename)
@@ -1053,7 +1043,6 @@ func TestDockerfileWithHeredocsInsecureDownloadsLineNumber(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := os.ReadFile(tt.filename)
@@ -1260,7 +1249,6 @@ func TestShellscriptInsecureDownloadsLineNumber(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := os.ReadFile(tt.filename)
@@ -1316,7 +1304,6 @@ func TestDockerfilePinningWithoutHash(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -1425,7 +1412,6 @@ func TestDockerfileScriptDownload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -1483,7 +1469,6 @@ func TestDockerfileScriptDownloadInfo(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -1561,7 +1546,6 @@ func TestShellScriptDownload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -1618,7 +1602,6 @@ func TestShellScriptDownloadPinned(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -1682,7 +1665,6 @@ func TestGitHubWorkflowRunDownload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -1769,7 +1751,6 @@ func TestGitHubWorkflowUsesLineNumber(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := os.ReadFile(tt.filename)
@@ -1840,7 +1821,6 @@ func TestGitHubWorkInsecureDownloadsLineNumber(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			content, err := os.ReadFile(tt.filename)
@@ -1957,7 +1937,6 @@ func TestCollectDockerfilePinning(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2051,7 +2030,6 @@ func TestCollectGitHubActionsWorkflowPinning(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2123,7 +2101,6 @@ func TestCsProjAnalysis(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -2279,7 +2256,6 @@ func TestCollectInsecureNugetCsproj(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -2435,7 +2411,6 @@ func TestCollectPostProcessNugetCPMDependencies(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			collectPostProcessNugetCPMDependencies(tt.inputNugetDependencies, tt.data)
@@ -2546,7 +2521,6 @@ func TestPinningDependenciesData_GetDependenciesByType(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := getDependenciesByType(&tt.data, tt.useType)
@@ -2630,7 +2604,6 @@ func TestAnalyseCentralPackageManagementPinned(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte

--- a/checks/raw/sast_test.go
+++ b/checks/raw/sast_test.go
@@ -197,7 +197,6 @@ func TestSAST(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/raw/sbom_test.go
+++ b/checks/raw/sbom_test.go
@@ -89,7 +89,6 @@ func TestSbom(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -51,7 +51,6 @@ func Test_isSecurityPolicyFilename(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := isSecurityPolicyFilename(tt.filename); got != tt.expected {
@@ -131,7 +130,6 @@ func TestSecurityPolicy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/checks/raw/shell_download_validate_test.go
+++ b/checks/raw/shell_download_validate_test.go
@@ -72,7 +72,6 @@ func TestIsSupportedShellScriptFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.filename, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -354,7 +353,6 @@ func Test_isDotNetUnpinnedDownload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := isNugetUnpinned(tt.args.cmd); got != tt.want {
@@ -390,7 +388,6 @@ func Test_isGoUnpinnedDownload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := isGoUnpinnedDownload(tt.args.cmd); got != tt.want {
@@ -426,7 +423,6 @@ func Test_isNpmDownload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := isNpmDownload(tt.args.cmd); got != tt.want {
@@ -462,7 +458,6 @@ func Test_isNpmUnpinnedDownload(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := isNpmUnpinnedDownload(tt.args.cmd); got != tt.want {
@@ -590,7 +585,6 @@ func Test_hasUnpinnedURLs(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if actual := hasUnpinnedURLs(tt.args.cmd); actual != tt.expected {

--- a/checks/raw/vulnerabilities_test.go
+++ b/checks/raw/vulnerabilities_test.go
@@ -67,7 +67,6 @@ func TestVulnerabilities(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/raw/webhooks_test.go
+++ b/checks/raw/webhooks_test.go
@@ -90,7 +90,6 @@ func TestWebhooks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -296,7 +296,6 @@ func Test_SAST(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		searchRequest := clients.SearchRequest{
 			Query: "github/codeql-action/analyze",
 			Path:  "/.github/workflows",

--- a/checks/sbom_test.go
+++ b/checks/sbom_test.go
@@ -78,7 +78,6 @@ func TestSbom(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("SCORECARD_EXPERIMENTAL", "true")
 			ctrl := gomock.NewController(t)

--- a/checks/security_policy_test.go
+++ b/checks/security_policy_test.go
@@ -169,7 +169,6 @@ func TestSecurityPolicy(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -431,7 +431,6 @@ func TestSignedRelease(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/vulnerabilities_test.go
+++ b/checks/vulnerabilities_test.go
@@ -41,7 +41,6 @@ func TestVulnerabilities(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/checks/webhook_test.go
+++ b/checks/webhook_test.go
@@ -92,7 +92,6 @@ func TestWebhooks(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Setenv("SCORECARD_EXPERIMENTAL", "true")
 			ctrl := gomock.NewController(t)

--- a/clients/azuredevopsrepo/commits_test.go
+++ b/clients/azuredevopsrepo/commits_test.go
@@ -115,7 +115,6 @@ func Test_listStatuses(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &commitsHandler{

--- a/clients/azuredevopsrepo/repo_test.go
+++ b/clients/azuredevopsrepo/repo_test.go
@@ -61,7 +61,6 @@ func TestRepo_parse(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := Repo{}
@@ -118,7 +117,6 @@ func TestRepo_IsValid(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if err := tt.repo.IsValid(); (err != nil) != tt.wantErr {

--- a/clients/azuredevopsrepo/search_test.go
+++ b/clients/azuredevopsrepo/search_test.go
@@ -176,7 +176,6 @@ func Test_search(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			s := searchHandler{

--- a/clients/azuredevopsrepo/zip_test.go
+++ b/clients/azuredevopsrepo/zip_test.go
@@ -122,7 +122,6 @@ func TestExtractZip(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/cii_response_test.go
+++ b/clients/cii_response_test.go
@@ -50,7 +50,6 @@ func TestParseBadgeResponseFromJSON(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := ParseBadgeResponseFromJSON(tt.args.data)
@@ -149,7 +148,6 @@ func TestBadgeResponse_getBadgeLevel(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			resp := BadgeResponse{

--- a/clients/git/client_test.go
+++ b/clients/git/client_test.go
@@ -94,7 +94,6 @@ func TestInitRepo(t *testing.T) {
 	repoPath := createTestRepo(t)
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			uri := repoPath
@@ -209,7 +208,6 @@ func TestSearch(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			client := &Client{}

--- a/clients/githubrepo/branches_test.go
+++ b/clients/githubrepo/branches_test.go
@@ -118,13 +118,10 @@ func Test_rulesMatchingBranch(t *testing.T) {
 
 	active := "ACTIVE"
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			inputRules := []*repoRuleSet{{Enforcement: &active, Conditions: testcase.condition}}
 			for branchName, expected := range testcase.defaultBranchNames {
-				branchName := branchName
-				expected := expected
 				t.Run(fmt.Sprintf("default branch %s", branchName), func(t *testing.T) {
 					t.Parallel()
 					matching, err := rulesMatchingBranch(inputRules, branchName, true)
@@ -137,8 +134,6 @@ func Test_rulesMatchingBranch(t *testing.T) {
 				})
 			}
 			for branchName, expected := range testcase.nonDefaultBranchNames {
-				branchName := branchName
-				expected := expected
 				t.Run(fmt.Sprintf("non-default branch %s", branchName), func(t *testing.T) {
 					t.Parallel()
 					matching, err := rulesMatchingBranch(inputRules, branchName, false)
@@ -527,7 +522,6 @@ func Test_applyRepoRules(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			applyRepoRules(testcase.base, testcase.ruleSets)
@@ -627,7 +621,6 @@ func Test_translationFromGithubAPIBranchProtectionData(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/githubrepo/copy_test.go
+++ b/clients/githubrepo/copy_test.go
@@ -49,7 +49,6 @@ func TestCopyBoolPtr(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			copyBoolPtr(tt.src, tt.dest)
@@ -99,7 +98,6 @@ func TestCopyInt32Ptr(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			copyInt32Ptr(tt.src, tt.dest)
@@ -149,7 +147,6 @@ func TestCopyStringPtr(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			copyStringPtr(tt.src, tt.dest)
@@ -197,7 +194,6 @@ func TestCopyTimePtr(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			copyTimePtr(tt.src, tt.dest)
@@ -236,7 +232,6 @@ func TestCopyStringSlice(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			copyStringSlice(tt.src, &tt.dest)
@@ -279,7 +274,6 @@ func TestCopyRepoAssociationPtr(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			copyRepoAssociationPtr(tt.src, tt.dest)

--- a/clients/githubrepo/repo_test.go
+++ b/clients/githubrepo/repo_test.go
@@ -102,7 +102,6 @@ func TestRepoURL_IsValid(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.ghHost {
 				t.Setenv("GH_HOST", "github.corp.com")

--- a/clients/githubrepo/roundtripper/tokens/round_robin_test.go
+++ b/clients/githubrepo/roundtripper/tokens/round_robin_test.go
@@ -35,7 +35,6 @@ func TestNext(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.releaseID != nil {
 				rr.Release(*tt.releaseID)

--- a/clients/githubrepo/searchCommits_test.go
+++ b/clients/githubrepo/searchCommits_test.go
@@ -55,7 +55,6 @@ func TestSearchCommitsBuildQuery(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/githubrepo/search_test.go
+++ b/clients/githubrepo/search_test.go
@@ -105,7 +105,6 @@ func TestBuildQuery(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/githubrepo/tarball_test.go
+++ b/clients/githubrepo/tarball_test.go
@@ -130,7 +130,6 @@ func TestExtractTarball(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -222,7 +221,6 @@ func Test_setup_empty_repo(t *testing.T) {
 	}))
 	t.Cleanup(ts.Close)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			h := tarballHandler{
 				httpClient: http.DefaultClient,

--- a/clients/githubrepo/webhook_test.go
+++ b/clients/githubrepo/webhook_test.go
@@ -63,7 +63,6 @@ func Test_listWebhooks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/clients/gitlabrepo/branches_test.go
+++ b/clients/gitlabrepo/branches_test.go
@@ -76,8 +76,6 @@ func TestGetBranches(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/gitlabrepo/checkruns_test.go
+++ b/clients/gitlabrepo/checkruns_test.go
@@ -60,7 +60,6 @@ func Test_CheckRuns(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			httpClient := &http.Client{
@@ -197,7 +196,6 @@ func TestParseGitlabStatus(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.status, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/gitlabrepo/client_test.go
+++ b/clients/gitlabrepo/client_test.go
@@ -62,8 +62,6 @@ func TestCheckRepoInaccessible(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -98,8 +96,6 @@ func TestListCommits(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			httpClient := &http.Client{

--- a/clients/gitlabrepo/commits_test.go
+++ b/clients/gitlabrepo/commits_test.go
@@ -50,8 +50,6 @@ func TestParsingEmail(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := parseEmailToName(tt.email)
@@ -102,7 +100,6 @@ func TestListRawCommits(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/gitlabrepo/contributors_test.go
+++ b/clients/gitlabrepo/contributors_test.go
@@ -51,8 +51,6 @@ func TestContributors(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
-
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/gitlabrepo/issues_test.go
+++ b/clients/gitlabrepo/issues_test.go
@@ -90,7 +90,6 @@ func Test_listIssues(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			httpClient := &http.Client{

--- a/clients/gitlabrepo/repo_test.go
+++ b/clients/gitlabrepo/repo_test.go
@@ -98,7 +98,6 @@ func TestRepoURL_IsValid(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure blow
 		if tt.flagRequired && os.Getenv("TEST_GITLAB_EXTERNAL") == "" {
 			continue
 		}

--- a/clients/gitlabrepo/searchCommits_test.go
+++ b/clients/gitlabrepo/searchCommits_test.go
@@ -55,7 +55,6 @@ func TestSearchCommitsBuildQuery(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/gitlabrepo/search_test.go
+++ b/clients/gitlabrepo/search_test.go
@@ -109,7 +109,6 @@ func TestBuildQuery(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -168,7 +167,6 @@ func Test_search(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			httpClient := &http.Client{

--- a/clients/gitlabrepo/statuses_test.go
+++ b/clients/gitlabrepo/statuses_test.go
@@ -53,7 +53,6 @@ func Test_listStatuses(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			httpClient := &http.Client{

--- a/clients/gitlabrepo/tarball_test.go
+++ b/clients/gitlabrepo/tarball_test.go
@@ -122,7 +122,6 @@ func TestExtractTarball(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/gitlabrepo/webhook_test.go
+++ b/clients/gitlabrepo/webhook_test.go
@@ -69,7 +69,6 @@ func Test_listWebhooks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			httpClient := &http.Client{

--- a/clients/localdir/client_test.go
+++ b/clients/localdir/client_test.go
@@ -59,7 +59,6 @@ func TestClient_CreationAndCaching(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -170,7 +169,6 @@ func TestClient_GetFileListAndContent(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/clients/ossfuzz/client_test.go
+++ b/clients/ossfuzz/client_test.go
@@ -86,7 +86,6 @@ func TestClient(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			url := setupServer(t)
@@ -156,7 +155,6 @@ func TestClientEager(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			url := setupServer(t)

--- a/clients/osv_test.go
+++ b/clients/osv_test.go
@@ -37,7 +37,6 @@ func TestRemoveDuplicate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := removeDuplicate(tt.list, tt.keyExtract)

--- a/cmd/internal/nuget/client_test.go
+++ b/cmd/internal/nuget/client_test.go
@@ -531,7 +531,6 @@ func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/cmd/internal/packagemanager/client_test.go
+++ b/cmd/internal/packagemanager/client_test.go
@@ -44,7 +44,6 @@ func Test_GetURI_calls_client_get_with_input(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -98,7 +97,6 @@ func Test_Get_calls_client_get_with_input(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/internal/scdiff/app/compare/compare_test.go
+++ b/cmd/internal/scdiff/app/compare/compare_test.go
@@ -214,7 +214,6 @@ func TestResults(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := Results(tt.a, tt.b); got != tt.wantEqual {

--- a/cmd/internal/scdiff/app/compare_test.go
+++ b/cmd/internal/scdiff/app/compare_test.go
@@ -74,7 +74,6 @@ func Test_compare(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			x := strings.NewReader(tt.x)
@@ -123,7 +122,6 @@ func Test_compare_reader_err(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if err := compareReaders(tt.x, tt.y, os.Stderr); err == nil { // if NO error

--- a/cmd/internal/scdiff/app/format/format_test.go
+++ b/cmd/internal/scdiff/app/format/format_test.go
@@ -146,7 +146,6 @@ func TestJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var bufA, bufB bytes.Buffer

--- a/cmd/internal/scdiff/app/generate_test.go
+++ b/cmd/internal/scdiff/app/generate_test.go
@@ -86,7 +86,6 @@ badCheck`,
 	}
 	var stubRunner stubRunner
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			input := strings.NewReader(tt.input)

--- a/cmd/internal/scdiff/app/stats_test.go
+++ b/cmd/internal/scdiff/app/stats_test.go
@@ -71,7 +71,6 @@ func Test_countScores(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			input := strings.NewReader(tt.results)

--- a/cmd/package_managers_test.go
+++ b/cmd/package_managers_test.go
@@ -130,7 +130,6 @@ func Test_fetchGitRepositoryFromNPM(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -272,7 +271,6 @@ func Test_findGitRepositoryInPYPIResponse(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := findGitRepositoryInPYPIResponse("somePackage", strings.NewReader(tt.partialPYPIResponse))
@@ -437,7 +435,6 @@ func Test_fetchGitRepositoryFromPYPI(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -701,7 +698,6 @@ func Test_fetchGitRepositoryFromRubyGems(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -761,7 +757,6 @@ func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -118,7 +118,6 @@ func Test_Parse_Checks(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r, err := os.Open(tt.configPath)

--- a/cron/config/config_test.go
+++ b/cron/config/config_test.go
@@ -145,7 +145,6 @@ func TestYAMLParsing(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			byteValue, err := getByteValueFromFile(testcase.filename)
@@ -197,7 +196,6 @@ func TestGetStringConfigValue(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			os.Unsetenv(testEnvVar)
 			if testcase.setEnv {
@@ -251,7 +249,6 @@ func TestGetIntConfigValue(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			os.Unsetenv(testEnvVar)
 			if testcase.setEnv {
@@ -445,7 +442,6 @@ func TestInputBucket(t *testing.T) {
 		},
 	}
 	for _, testcase := range tests {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			os.Unsetenv(testcase.envVar)
 			got, err := testcase.f()
@@ -481,7 +477,6 @@ func TestEnvVarName(t *testing.T) {
 		},
 	}
 	for _, testcase := range tests {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			got := envVarName(testcase.mapName, testcase.subKey)
@@ -515,7 +510,6 @@ func TestGetAdditionalParams(t *testing.T) {
 		},
 	}
 	for _, testcase := range tests {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			got, err := GetAdditionalParams(testcase.mapName)

--- a/cron/data/blob_test.go
+++ b/cron/data/blob_test.go
@@ -44,7 +44,6 @@ func TestGetBlobFilename(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			datetime, err := time.Parse(inputTimeFormat, testcase.inputTime)
@@ -98,7 +97,6 @@ func TestParseBlobFilename(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			datetime, filename, err := ParseBlobFilename(testcase.input)
@@ -161,7 +159,6 @@ func TestBlobKeysPrefix(t *testing.T) {
 	ctx := context.Background()
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			got, err := blobKeysPrefix(ctx, bucket, testcase.prefix)
 			if err != nil {

--- a/cron/data/format_test.go
+++ b/cron/data/format_test.go
@@ -50,7 +50,6 @@ func TestToString(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			actual := testcase.input.ToString()
@@ -91,7 +90,6 @@ func TestUnmarshalCsv(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			s := new(CSVStrings)

--- a/cron/data/iterator_test.go
+++ b/cron/data/iterator_test.go
@@ -249,7 +249,6 @@ func TestCsvIterator(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			testFile, err := os.OpenFile(testcase.filename, os.O_RDONLY, 0o644)
@@ -386,7 +385,6 @@ func TestNestedIterator(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			var iters []Iterator

--- a/cron/data/summary_test.go
+++ b/cron/data/summary_test.go
@@ -57,7 +57,6 @@ func TestIsCompleted(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			shards := &ShardSummary{

--- a/cron/data/writer_test.go
+++ b/cron/data/writer_test.go
@@ -59,7 +59,6 @@ gitlab.com/owner4/repo4,meta4
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			var buf bytes.Buffer

--- a/cron/internal/controller/bucket_test.go
+++ b/cron/internal/controller/bucket_test.go
@@ -72,7 +72,6 @@ func TestGetPrefix(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Setenv("INPUT_BUCKET_URL", testcase.url)
 			t.Setenv("INPUT_BUCKET_PREFIX", testcase.prefix)

--- a/cron/internal/data/add/main_test.go
+++ b/cron/internal/data/add/main_test.go
@@ -119,8 +119,6 @@ func TestGetRepoURLs(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
-
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			testFile, err := os.OpenFile(testcase.filename, os.O_RDONLY, 0o644)

--- a/cron/internal/format/json_test.go
+++ b/cron/internal/format/json_test.go
@@ -426,7 +426,6 @@ func TestJSONOutput(t *testing.T) {
 		t.Fatalf("gojsonschema.NewSchema: %s", err)
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte

--- a/cron/internal/format/schema_gen_test.go
+++ b/cron/internal/format/schema_gen_test.go
@@ -48,7 +48,6 @@ func Test_GenerateBQSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -106,7 +105,6 @@ func Test_GenerateJSONSchema(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/cron/internal/pubsub/publisher_test.go
+++ b/cron/internal/pubsub/publisher_test.go
@@ -60,7 +60,6 @@ func TestPublish(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/cron/internal/pubsub/subscriber_gocloud_test.go
+++ b/cron/internal/pubsub/subscriber_gocloud_test.go
@@ -81,7 +81,6 @@ func TestSubscriber(t *testing.T) {
 		},
 	}
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			ctx := context.Background()

--- a/cron/worker/worker_test.go
+++ b/cron/worker/worker_test.go
@@ -45,7 +45,6 @@ func TestResultFilename(t *testing.T) {
 	}
 
 	for _, testcase := range testcases {
-		testcase := testcase
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
 			got := ResultFilename(testcase.req)

--- a/errors/public_test.go
+++ b/errors/public_test.go
@@ -48,7 +48,6 @@ func TestWithMessage(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if err := WithMessage(tt.args.e, tt.args.msg); (err != nil) != tt.wantErr {
@@ -98,7 +97,6 @@ func TestGetName(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := GetName(tt.args.err); !strings.EqualFold(got, tt.want) {

--- a/finding/finding_test.go
+++ b/finding/finding_test.go
@@ -161,7 +161,6 @@ func Test_FromBytes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -275,7 +274,6 @@ func TestOutcome_UnmarshalYAML(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var v Outcome

--- a/finding/probe_test.go
+++ b/finding/probe_test.go
@@ -104,7 +104,6 @@ func Test_probeFromBytes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/dotnet/properties/properties_test.go
+++ b/internal/dotnet/properties/properties_test.go
@@ -47,7 +47,6 @@ func TestIsValidFixedVersion(t *testing.T) {
 		{"invalid", "(1.0)", false},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/probes/probes_test.go
+++ b/internal/probes/probes_test.go
@@ -99,7 +99,6 @@ func Test_register(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			err := register(tt.probe)
 			if err != nil != tt.wantErr {
@@ -143,7 +142,6 @@ func TestGet(t *testing.T) {
 	}
 	setupControlledProbes(t)
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			p, err := Get(tt.probeName)
 			if err != nil != tt.wantErr {

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -43,7 +43,6 @@ func TestNewLogger(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logger := NewLogger(tt.logLevel)
@@ -104,7 +103,6 @@ func TestParseLevel(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			level := ParseLevel(tt.levelStr)

--- a/options/flags_test.go
+++ b/options/flags_test.go
@@ -49,7 +49,6 @@ func TestOptions_AddFlags(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cmd := &cobra.Command{}
@@ -136,7 +135,6 @@ func TestOptions_AddFlags_ChecksToRun(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			e := []string{}
@@ -169,7 +167,6 @@ func TestOptions_AddFlags_Format(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cmd := &cobra.Command{}
@@ -201,7 +198,6 @@ func TestOptions_AddFlags_Annotations(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cmd := &cobra.Command{}

--- a/options/options_test.go
+++ b/options/options_test.go
@@ -107,7 +107,6 @@ func TestOptions_Validate(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		if tt.fields.FileMode == "" {
 			tt.fields.FileMode = FileModeArchive
 		}

--- a/pkg/scorecard/common_test.go
+++ b/pkg/scorecard/common_test.go
@@ -133,7 +133,6 @@ func TestDetailString(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := DetailToString(&tt.detail, tt.log)

--- a/pkg/scorecard/json_raw_results_test.go
+++ b/pkg/scorecard/json_raw_results_test.go
@@ -52,7 +52,6 @@ func TestAsPointer(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			result := asPointer(tt.input)
@@ -129,7 +128,6 @@ func TestJsonScorecardRawResult_AddPackagingRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -209,7 +207,6 @@ func TestJsonScorecardRawResult_AddTokenPermissionsRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -275,7 +272,6 @@ func TestJsonScorecardRawResult_AddDependencyPinningRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -320,7 +316,6 @@ func TestJsonScorecardRawResult_AddDangerousWorkflowRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -360,7 +355,6 @@ func TestJsonScorecardRawResult_AddContributorsRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -402,7 +396,6 @@ func TestJsonScorecardRawResult_AddSignedReleasesRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -458,7 +451,6 @@ func TestJsonScorecardRawResult_AddMaintainedRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -574,7 +566,6 @@ func TestJsonScorecardRawResult_AddOssfBestPracticesRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -641,7 +632,6 @@ func TestJsonScorecardRawResult_AddCodeReviewRawResults(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		test := test
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -1262,7 +1252,6 @@ func TestScorecardResult_AsRawJSON(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := &Result{
@@ -1337,7 +1326,6 @@ func TestAddBranchProtectionRawResults(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		tc := tc // capture range variable
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := &jsonScorecardRawResult{}

--- a/pkg/scorecard/json_test.go
+++ b/pkg/scorecard/json_test.go
@@ -479,7 +479,6 @@ func TestJSONOutput(t *testing.T) {
 		t.Fatalf("gojsonschema.NewSchema: %s", err)
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var content []byte
@@ -575,7 +574,6 @@ func TestExperimentalFromJSON2_time(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, _, err := ExperimentalFromJSON2(strings.NewReader(tt.result))

--- a/pkg/scorecard/probe_test.go
+++ b/pkg/scorecard/probe_test.go
@@ -67,7 +67,6 @@ func TestAsProbe(t *testing.T) {
 	// pretty print results so the test files are easier to read
 	opt := &ProbeResultOption{Indent: "    "}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			expected, err := os.ReadFile(tt.expected)

--- a/pkg/scorecard/sarif.go
+++ b/pkg/scorecard/sarif.go
@@ -625,8 +625,6 @@ func (r *Result) AsSARIF(showDetails bool, logLevel log.Level,
 	runs := make(map[string]*run)
 
 	for _, check := range r.Checks {
-		check := check
-
 		doc, err := checkDocs.GetCheck(check.Name)
 		if err != nil {
 			return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("GetCheck: %v: %s", err, check.Name))
@@ -701,7 +699,6 @@ func (r *Result) AsSARIF(showDetails bool, logLevel log.Level,
 			run.Results = append(run.Results, cr)
 		} else {
 			for _, loc := range locs {
-				loc := loc
 				// Use the location's message (check's detail's message) as message.
 				msg := messageWithScore(loc.Message.Text, check.Score)
 				cr := createSARIFCheckResult(RuleIndex, sarifCheckID, msg, &loc)

--- a/pkg/scorecard/sarif_test.go
+++ b/pkg/scorecard/sarif_test.go
@@ -978,7 +978,6 @@ func Test_createSARIFRuns(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := createSARIFRuns(tt.args.runs); !reflect.DeepEqual(got, tt.want) {

--- a/pkg/scorecard/scorecard.go
+++ b/pkg/scorecard/scorecard.go
@@ -53,8 +53,6 @@ func runEnabledChecks(ctx context.Context,
 ) {
 	wg := sync.WaitGroup{}
 	for checkName, checkFn := range checksToRun {
-		checkName := checkName
-		checkFn := checkFn
 		wg.Add(1)
 		go func() {
 			defer wg.Done()

--- a/pkg/scorecard/scorecard_result.go
+++ b/pkg/scorecard/scorecard_result.go
@@ -411,7 +411,6 @@ func populateRawResults(request *checker.CheckRequest, probesToRun []string, ret
 			return fmt.Errorf("getting probe %q: %w", probeName, err)
 		}
 		for _, checkName := range p.RequiredRawData {
-			checkName := checkName
 			if !seen[checkName] {
 				err := assignRawData(checkName, request, ret)
 				if err != nil {

--- a/pkg/scorecard/scorecard_result_test.go
+++ b/pkg/scorecard/scorecard_result_test.go
@@ -157,7 +157,6 @@ func Test_formatResults_outputToFile(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/pkg/scorecard/scorecard_test.go
+++ b/pkg/scorecard/scorecard_test.go
@@ -55,7 +55,6 @@ func Test_getRepoCommitHash(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -101,7 +100,6 @@ func Test_getRepoCommitHashLocal(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logger := log.NewLogger(log.DebugLevel)
@@ -163,7 +161,6 @@ func TestRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -275,7 +272,6 @@ func TestRun_WithProbes(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -391,7 +387,6 @@ func Test_findConfigFile(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/policy/policy_test.go
+++ b/policy/policy_test.go
@@ -347,7 +347,6 @@ func TestGetEnabled(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			var sp *ScorecardPolicy

--- a/probes/archived/impl_test.go
+++ b/probes/archived/impl_test.go
@@ -62,7 +62,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/blocksDeleteOnBranches/impl_test.go
+++ b/probes/blocksDeleteOnBranches/impl_test.go
@@ -157,7 +157,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/blocksForcePushOnBranches/impl_test.go
+++ b/probes/blocksForcePushOnBranches/impl_test.go
@@ -157,7 +157,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/branchProtectionAppliesToAdmins/impl_test.go
+++ b/probes/branchProtectionAppliesToAdmins/impl_test.go
@@ -157,7 +157,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/branchesAreProtected/impl_test.go
+++ b/probes/branchesAreProtected/impl_test.go
@@ -140,7 +140,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/codeApproved/impl_test.go
+++ b/probes/codeApproved/impl_test.go
@@ -332,7 +332,6 @@ func TestProbeCodeApproved(t *testing.T) {
 	}
 
 	for _, tt := range probeTests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			res, probeID, err := Run(tt.rawResults)

--- a/probes/codeReviewOneReviewers/impl_test.go
+++ b/probes/codeReviewOneReviewers/impl_test.go
@@ -313,7 +313,6 @@ func TestProbeCodeReviewOneReviewers(t *testing.T) {
 	}
 
 	for _, tt := range probeTests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below.
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			res, probeID, err := Run(tt.rawResults)

--- a/probes/contributorsFromOrgOrCompany/impl_test.go
+++ b/probes/contributorsFromOrgOrCompany/impl_test.go
@@ -141,7 +141,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/createdRecently/impl_test.go
+++ b/probes/createdRecently/impl_test.go
@@ -60,7 +60,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/dependencyUpdateToolConfigured/impl_test.go
+++ b/probes/dependencyUpdateToolConfigured/impl_test.go
@@ -68,7 +68,6 @@ func TestRun(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			findings, s, err := Run(tt.raw)
@@ -148,7 +147,6 @@ func TestRun_Detailed(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			findings, _, err := Run(tt.raw)

--- a/probes/dismissesStaleReviews/impl_test.go
+++ b/probes/dismissesStaleReviews/impl_test.go
@@ -175,7 +175,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/fuzzed/impl_test.go
+++ b/probes/fuzzed/impl_test.go
@@ -87,7 +87,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			findings, s, err := Run(tt.raw)
@@ -167,7 +166,6 @@ func TestRun_Detailed(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			findings, _, err := Run(tt.raw)

--- a/probes/hasBinaryArtifacts/impl_test.go
+++ b/probes/hasBinaryArtifacts/impl_test.go
@@ -119,7 +119,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasDangerousWorkflowScriptInjection/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/impl.go
@@ -64,7 +64,6 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	var errs []*actionlint.Error
 	localPath := raw.Metadata.Metadata["localPath"]
 	for _, w := range r.Workflows {
-		w := w
 		if w.Type != checker.DangerousWorkflowScriptInjection {
 			continue
 		}

--- a/probes/hasDangerousWorkflowScriptInjection/impl_test.go
+++ b/probes/hasDangerousWorkflowScriptInjection/impl_test.go
@@ -72,7 +72,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasDangerousWorkflowScriptInjection/internal/patch/impl.go
+++ b/probes/hasDangerousWorkflowScriptInjection/internal/patch/impl.go
@@ -116,7 +116,6 @@ func getUnsafePattern(unsafeVar string) (unsafePattern, error) {
 	}
 
 	for _, p := range unsafePatterns {
-		p := p
 		if p.idRegex.MatchString(unsafeVar) {
 			arrayVarRegex := regexp.MustCompile(`\[(.+?)\]`)
 			arrayIdx := arrayVarRegex.FindStringSubmatch(unsafeVar)

--- a/probes/hasDangerousWorkflowScriptInjection/internal/patch/impl_test.go
+++ b/probes/hasDangerousWorkflowScriptInjection/internal/patch/impl_test.go
@@ -129,7 +129,6 @@ func Test_patchWorkflow(t *testing.T) {
 		// // },
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasDangerousWorkflowUntrustedCheckout/impl.go
+++ b/probes/hasDangerousWorkflowUntrustedCheckout/impl.go
@@ -54,7 +54,6 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 
 	var findings []finding.Finding
 	for _, e := range r.Workflows {
-		e := e
 		if e.Type == checker.DangerousWorkflowUntrustedCheckout {
 			f, err := finding.NewWith(fs, Probe,
 				fmt.Sprintf("untrusted code checkout '%v'", e.File.Snippet),

--- a/probes/hasDangerousWorkflowUntrustedCheckout/impl_test.go
+++ b/probes/hasDangerousWorkflowUntrustedCheckout/impl_test.go
@@ -69,7 +69,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasFSFOrOSIApprovedLicense/impl.go
+++ b/probes/hasFSFOrOSIApprovedLicense/impl.go
@@ -54,7 +54,6 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		if !licenseFile.LicenseInformation.Approved {
 			continue
 		}
-		licenseFile := licenseFile
 		loc := licenseFile.File.Location()
 		f, err := finding.NewTrue(fs, Probe, "FSF or OSI recognized license: "+licenseFile.LicenseInformation.Name, loc)
 		if err != nil {

--- a/probes/hasFSFOrOSIApprovedLicense/impl_test.go
+++ b/probes/hasFSFOrOSIApprovedLicense/impl_test.go
@@ -138,7 +138,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasLicenseFile/impl.go
+++ b/probes/hasLicenseFile/impl.go
@@ -53,7 +53,6 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		return findings, Probe, nil
 	} else {
 		for _, licenseFile := range licenseFiles {
-			licenseFile := licenseFile
 			loc := licenseFile.File.Location()
 			f, err := finding.NewTrue(fs, Probe, "project has a license file", loc)
 			if err != nil {

--- a/probes/hasLicenseFile/impl_test.go
+++ b/probes/hasLicenseFile/impl_test.go
@@ -98,7 +98,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasNoGitHubWorkflowPermissionUnknown/impl_test.go
+++ b/probes/hasNoGitHubWorkflowPermissionUnknown/impl_test.go
@@ -78,7 +78,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasOSVVulnerabilities/impl_test.go
+++ b/probes/hasOSVVulnerabilities/impl_test.go
@@ -63,7 +63,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -146,7 +145,6 @@ func TestRun_remediation(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			findings, _, err := Run(tt.raw)

--- a/probes/hasOpenSSFBadge/impl_test.go
+++ b/probes/hasOpenSSFBadge/impl_test.go
@@ -93,7 +93,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasPermissiveLicense/impl_test.go
+++ b/probes/hasPermissiveLicense/impl_test.go
@@ -110,7 +110,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasRecentCommits/impl_test.go
+++ b/probes/hasRecentCommits/impl_test.go
@@ -97,7 +97,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasReleaseSBOM/impl_test.go
+++ b/probes/hasReleaseSBOM/impl_test.go
@@ -102,7 +102,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasSBOM/impl_test.go
+++ b/probes/hasSBOM/impl_test.go
@@ -83,7 +83,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/hasUnverifiedBinaryArtifacts/impl_test.go
+++ b/probes/hasUnverifiedBinaryArtifacts/impl_test.go
@@ -95,7 +95,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/issueActivityByProjectMember/impl_test.go
+++ b/probes/issueActivityByProjectMember/impl_test.go
@@ -136,7 +136,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -228,7 +227,6 @@ func Test_hasActivityByCollaboratorOrHigher(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := hasActivityByCollaboratorOrHigher(tt.args.issue, tt.args.threshold); got != tt.want {

--- a/probes/jobLevelPermissions/impl_test.go
+++ b/probes/jobLevelPermissions/impl_test.go
@@ -37,7 +37,6 @@ func Test_Run(t *testing.T) {
 	tests = append(tests, test.GetTests(checker.PermissionLocationJob, checker.PermissionLevelWrite, "security-events")...)
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/packagedWithAutomatedWorkflow/impl.go
+++ b/probes/packagedWithAutomatedWorkflow/impl.go
@@ -43,7 +43,6 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	r := raw.PackagingResults
 	var findings []finding.Finding
 	for _, p := range r.Packages {
-		p := p
 		if p.Msg != nil {
 			continue
 		}

--- a/probes/packagedWithAutomatedWorkflow/impl_test.go
+++ b/probes/packagedWithAutomatedWorkflow/impl_test.go
@@ -66,7 +66,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/pinsDependencies/impl_test.go
+++ b/probes/pinsDependencies/impl_test.go
@@ -575,7 +575,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -617,7 +616,6 @@ func Test_generateOwnerToDisplay(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := generateOwnerToDisplay(tt.gitHubOwned); got != tt.want {
@@ -657,7 +655,6 @@ func TestGenerateText(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			result := generateTextUnpinned(tc.dependency)

--- a/probes/releasesAreSigned/impl_test.go
+++ b/probes/releasesAreSigned/impl_test.go
@@ -215,7 +215,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/releasesHaveProvenance/impl_test.go
+++ b/probes/releasesHaveProvenance/impl_test.go
@@ -288,7 +288,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/releasesHaveVerifiedProvenance/impl_test.go
+++ b/probes/releasesHaveVerifiedProvenance/impl_test.go
@@ -84,7 +84,6 @@ func Test_Run(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.desc, func(t *testing.T) {
 			t.Parallel()
 			raw := checker.RawResults{

--- a/probes/requiresApproversForPullRequests/impl_test.go
+++ b/probes/requiresApproversForPullRequests/impl_test.go
@@ -175,7 +175,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/requiresCodeOwnersReview/impl_test.go
+++ b/probes/requiresCodeOwnersReview/impl_test.go
@@ -287,7 +287,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/requiresLastPushApproval/impl_test.go
+++ b/probes/requiresLastPushApproval/impl_test.go
@@ -156,7 +156,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/requiresPRsToChangeCode/impl_test.go
+++ b/probes/requiresPRsToChangeCode/impl_test.go
@@ -173,7 +173,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/requiresUpToDateBranches/impl_test.go
+++ b/probes/requiresUpToDateBranches/impl_test.go
@@ -174,7 +174,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/runsStatusChecksBeforeMerging/impl_test.go
+++ b/probes/runsStatusChecksBeforeMerging/impl_test.go
@@ -173,7 +173,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/sastToolConfigured/impl_test.go
+++ b/probes/sastToolConfigured/impl_test.go
@@ -78,7 +78,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -151,7 +150,6 @@ func Test_Run_tools(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			findings, s, err := Run(tt.raw)

--- a/probes/sastToolRunsOnAllCommits/impl_test.go
+++ b/probes/sastToolRunsOnAllCommits/impl_test.go
@@ -97,7 +97,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/securityPolicyContainsLinks/impl_test.go
+++ b/probes/securityPolicyContainsLinks/impl_test.go
@@ -280,7 +280,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/securityPolicyContainsText/impl_test.go
+++ b/probes/securityPolicyContainsText/impl_test.go
@@ -386,7 +386,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/securityPolicyContainsVulnerabilityDisclosure/impl_test.go
+++ b/probes/securityPolicyContainsVulnerabilityDisclosure/impl_test.go
@@ -241,7 +241,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/securityPolicyPresent/impl_test.go
+++ b/probes/securityPolicyPresent/impl_test.go
@@ -110,7 +110,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/testsRunInCI/impl_test.go
+++ b/probes/testsRunInCI/impl_test.go
@@ -116,7 +116,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
@@ -247,7 +246,6 @@ func Test_isTest(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if got := isTest(tt.args.s); got != tt.want {
@@ -319,8 +317,6 @@ func Test_prHasSuccessfulCheck(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
-
 		//nolint:errcheck
 		got, _, _ := prHasSuccessfulCheck(tt.args)
 		if got != tt.want {
@@ -385,7 +381,6 @@ func Test_prHasSuccessStatus(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, _, err := prHasSuccessStatus(tt.args.r)
@@ -477,7 +472,6 @@ func Test_prHasSuccessfulCheckAdditional(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got, _, err := prHasSuccessfulCheck(tt.args.r)

--- a/probes/topLevelPermissions/impl_test.go
+++ b/probes/topLevelPermissions/impl_test.go
@@ -37,7 +37,6 @@ func Test_Run(t *testing.T) {
 	tests = append(tests, test.GetTests(checker.PermissionLocationTop, checker.PermissionLevelWrite, "security-events")...)
 
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.Name, func(t *testing.T) {
 			t.Parallel()
 

--- a/probes/unsafeblock/impl_test.go
+++ b/probes/unsafeblock/impl_test.go
@@ -434,7 +434,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)
@@ -507,7 +506,6 @@ func Test_Run_Error_OnMatchingFileContentDo(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			ctrl := gomock.NewController(t)

--- a/probes/webhooksUseSecrets/impl_test.go
+++ b/probes/webhooksUseSecrets/impl_test.go
@@ -143,7 +143,6 @@ func Test_Run(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		tt := tt // Re-initializing variable so it is not changed while executing the closure below
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/remediation/remediations_test.go
+++ b/remediation/remediations_test.go
@@ -128,7 +128,6 @@ func TestCreateDockerfilePinningRemediation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			got := CreateDockerfilePinningRemediation(&tt.dep, stubDigester{})
@@ -176,7 +175,6 @@ func TestCreateWorkflowPinningRemediation(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			r := RemediationMetadata{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

linter clean

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
* We have some code which copies the loopvar still, which is no longer needed after Go 1.22

#### What is the new behavior (if this is a feature change)?**
* Linter to flag these unnecessary copies is added, and violations fixed.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
See https://github.com/ossf/scorecard/issues/4439#issuecomment-2537348413
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
