### PR TITLE
🐛 Ensure % character in the artifactLocation in sarif output are escaped

### DIFF
--- a/pkg/scorecard/sarif.go
+++ b/pkg/scorecard/sarif.go
@@ -355,7 +355,7 @@ func detailsToLocations(details []checker.CheckDetail,
 		loc := location{
 			PhysicalLocation: physicalLocation{
 				ArtifactLocation: artifactLocation{
-					URI:       getPath(&d),
+					URI:       strings.ReplaceAll(getPath(&d), "%", "%%"),
 					URIBaseID: "%SRCROOT%",
 				},
 			},

--- a/pkg/scorecard/sarif.go
+++ b/pkg/scorecard/sarif.go
@@ -18,6 +18,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
 	"sort"
 	"strings"
@@ -352,10 +353,11 @@ func detailsToLocations(details []checker.CheckDetail,
 			continue
 		}
 
+		artifactURI := url.URL{Path: getPath(&d)}
 		loc := location{
 			PhysicalLocation: physicalLocation{
 				ArtifactLocation: artifactLocation{
-					URI:       strings.ReplaceAll(getPath(&d), "%", "%%"),
+					URI:       artifactURI.EscapedPath(),
 					URIBaseID: "%SRCROOT%",
 				},
 			},

--- a/pkg/scorecard/sarif_test.go
+++ b/pkg/scorecard/sarif_test.go
@@ -389,7 +389,8 @@ func TestSARIFOutput(t *testing.T) {
 								Type: checker.DetailWarn,
 								Msg: checker.LogMessage{
 									Text:    "warn message",
-									Path:    "src/doc.txt",
+									// Intenionally add a % to ensure that we URL-encode paths
+									Path:    "src/%doc.txt",
 									Type:    finding.FileTypeText,
 									Offset:  3,
 									Snippet: "some text",

--- a/pkg/scorecard/sarif_test.go
+++ b/pkg/scorecard/sarif_test.go
@@ -388,7 +388,7 @@ func TestSARIFOutput(t *testing.T) {
 							{
 								Type: checker.DetailWarn,
 								Msg: checker.LogMessage{
-									Text:    "warn message",
+									Text: "warn message",
 									// Intenionally add a % to ensure that we URL-encode paths
 									Path:    "src/%doc.txt",
 									Type:    finding.FileTypeText,

--- a/pkg/scorecard/testdata/check3.sarif
+++ b/pkg/scorecard/testdata/check3.sarif
@@ -140,7 +140,7 @@
                            }
                         },
                         "artifactLocation": {
-                           "uri": "src/%%doc.txt",
+                           "uri": "src/%25doc.txt",
                            "uriBaseId": "%SRCROOT%"
                         }
                      },

--- a/pkg/scorecard/testdata/check3.sarif
+++ b/pkg/scorecard/testdata/check3.sarif
@@ -140,7 +140,7 @@
                            }
                         },
                         "artifactLocation": {
-                           "uri": "src/doc.txt",
+                           "uri": "src/%%doc.txt",
                            "uriBaseId": "%SRCROOT%"
                         }
                      },


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Currently if a filename contains a `%` character it is passed through in plain text in the result in `sarif` file. If the location is later parsed again, an URL-decoder will stumble upon it as it tries decode the escape sequence.

As an example see the following `scorecard-action` where the SARIF upload failed: https://github.com/Quantco/copier-template-python-open-source/actions/runs/14924466359

#### What is the new behavior (if this is a feature change)?**

`%` characters are escaped in the SARIF output.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
