### PR TITLE
:bug: add stopgap check for GCS error that is now wrapped

### DIFF
--- a/clients/cii_blob_client.go
+++ b/clients/cii_blob_client.go
@@ -16,8 +16,10 @@ package clients
 
 import (
 	"context"
+	"errors"
 	"fmt"
 
+	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
 	// Needed to link GCP drivers.
 	_ "gocloud.dev/blob/gcsblob"
@@ -40,7 +42,8 @@ func (client *blobClientCIIBestPractices) GetBadgeLevel(ctx context.Context, uri
 	objectName := fmt.Sprintf("%s/result.json", uri)
 
 	exists, err := bucket.Exists(ctx, objectName)
-	if err != nil {
+	// TODO(https://github.com/ossf/scorecard/issues/4636)
+	if err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
 		return Unknown, fmt.Errorf("error during bucket.Exists: %w", err)
 	}
 	if !exists {

--- a/cron/data/blob.go
+++ b/cron/data/blob.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"time"
 
+	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
 	// Needed to read file:/// buckets. Intended primarily for testing, though needed here for tests outside the package.
 	_ "gocloud.dev/blob/fileblob"
@@ -100,7 +101,8 @@ func BlobExists(ctx context.Context, bucketURL, key string) (bool, error) {
 	defer bucket.Close()
 
 	ret, err := bucket.Exists(ctx, key)
-	if err != nil {
+	// TODO(https://github.com/ossf/scorecard/issues/4636)
+	if err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
 		return ret, fmt.Errorf("error during bucket.Exists: %w", err)
 	}
 	return ret, nil

--- a/go.mod
+++ b/go.mod
@@ -159,7 +159,7 @@ require (
 require (
 	cloud.google.com/go v0.121.0 // indirect
 	cloud.google.com/go/iam v1.5.2 // indirect
-	cloud.google.com/go/storage v1.53.0 // indirect
+	cloud.google.com/go/storage v1.53.0
 	github.com/Microsoft/go-winio v0.6.2 // indirect
 	github.com/ProtonMail/go-crypto v1.1.6 // indirect
 	github.com/aws/aws-sdk-go v1.55.5 // indirect


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
https://github.com/ossf/scorecard/issues/4626#issuecomment-2902376370

Our indirect GCS dependency began wrapping an object not found error in v1.51.0, which broke our calls to `bucket.Exists`. While gocloud.dev was updated for the comparison (v0.41.0), it also requires Go 1.24 which we can't upgrade to yet due to our Go version policy.

#### What is the new behavior (if this is a feature change)?**
We check for the wrapped error ourselves, so we don't need to upgrade to Go 1.24 yet.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #4626
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

Tested using the local cron environment: https://github.com/ossf/scorecard/tree/e51d93e9022b61976836d584f4e1de0564235860/cron/internal/emulator

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
