### PR TITLE
:seedling: remove scorecard image from Google AR promotion

### DIFF
--- a/cron/internal/webhook/main.go
+++ b/cron/internal/webhook/main.go
@@ -32,7 +32,6 @@ import (
 const stableTag = "stable"
 
 var images = []string{
-	"gcr.io/openssf/scorecard",
 	"gcr.io/openssf/scorecard-batch-controller",
 	"gcr.io/openssf/scorecard-batch-worker",
 	"gcr.io/openssf/scorecard-cii-worker",


### PR DESCRIPTION
#### What kind of change does this PR introduce?

cron fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The webhook is used to promote latest (staging) to stable (production) for the weekly cron. This process previously promoted `gcr.io/openssf/scorecard` too. We aren't hosting the base scorecard image on GAR, but rather GHCR, and Cloud Build was disabled for that image already. This causes the webhook call to return a 500 error as the container doesn't exist for the given commit.

#### What is the new behavior (if this is a feature change)?**

`gcr.io/openssf/scorecard` isn't promoted as part of the transfer

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Relates to #4626 

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
