### PR TITLE
:seedling: update e2e test to account for new vuln

### DIFF
--- a/e2e/vulnerabilities_test.go
+++ b/e2e/vulnerabilities_test.go
@@ -46,8 +46,8 @@ var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         checker.MaxResultScore - 3, // 3 vulnerabilities remove 3 points.
-				NumberOfWarn:  3,
+				Score:         checker.MaxResultScore - 4, // 4 vulnerabilities remove 4 points.
+				NumberOfWarn:  4,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}
@@ -73,8 +73,8 @@ var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         checker.MaxResultScore - 3, // 3 vulnerabilities remove 3 points.
-				NumberOfWarn:  3,
+				Score:         checker.MaxResultScore - 4, // 4 vulnerabilities remove 4 points.
+				NumberOfWarn:  4,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

e2e fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
we expect 3 vulns for this old project, but I guess OSV found another so our score is broken. This test was working a few days ago when the last commit was merged

#### What is the new behavior (if this is a feature change)?**
Update the test to expect 4 vulns.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
