### PR TITLE
:bug: Fix pinned check for Dockerfiles with from scratch

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -511,6 +511,9 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 		switch {
 		// scratch is no-op.
 		case len(valueList) > 0 && strings.EqualFold(valueList[0], "scratch"):
+			if len(valueList) == 3 && strings.EqualFold(valueList[1], "as") {
+				pinnedAsNames[valueList[2]] = true
+			}
 			continue
 
 		// FROM name AS newname.
@@ -521,9 +524,11 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 			// (1): name = <>@sha245:hash
 			// (2): name = XXX where XXX was pinned
 			pinned := pinnedAsNames[name]
+			// Record the asName.
 			if pinned || regex.MatchString(name) {
-				// Record the asName.
 				pinnedAsNames[asName] = true
+			} else {
+				pinnedAsNames[asName] = false
 			}
 
 			pdata.Dependencies = append(pdata.Dependencies,

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -359,6 +359,10 @@ func TestDockerfilePinning(t *testing.T) {
 			filename: "Dockerfile-pinned-as",
 		},
 		{
+			name:     "From scratch is considered pinned",
+			filename: "Dockerfile-from-scratch",
+		},
+		{
 			name:     "Non-pinned dockerfile as",
 			filename: "Dockerfile-not-pinned-as",
 			warns:    2,

--- a/checks/raw/testdata/Dockerfile-from-scratch
+++ b/checks/raw/testdata/Dockerfile-from-scratch
@@ -1,0 +1,3 @@
+FROM image@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2 as builder
+FROM scratch as export
+FROM export


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

A multi-stage Dockerfile containing a stage based off of a named stage, in turn created from scratch is marked as being unpinned.

<details>
<summary>Full example image that is currently failing</summary>

```dockerfile
FROM --platform=${BUILDPLATFORM} node:22.16.0@sha256:0b5b940c21ab03353de9042f9166c75bcfc53c4cd0508c7fd88576646adbf875 AS web-builder

WORKDIR /src

COPY .yarnrc.yml package.json yarn.lock .
COPY .yarn .yarn

RUN yarn install

COPY tsconfig.json vite.config.ts .
COPY web web

ARG CUPDATE_VERSION="development build"
RUN VITE_CUPDATE_VERSION="${CUPDATE_VERSION}" yarn build

FROM --platform=${BUILDPLATFORM} golang:1.24.3@sha256:86b4cff66e04d41821a17cea30c1031ed53e2635e2be99ae0b4a7d69336b5063 AS builder

WORKDIR /src

# Use the toolchain specified in go.mod, or newer
ENV GOTOOLCHAIN=auto

COPY go.mod go.sum .
RUN go mod download && go mod verify

COPY cmd cmd
COPY internal internal

COPY --from=web-builder /src/internal/web/public /src/internal/web/public

ARG CUPDATE_VERSION="development build"
ARG TARGETARCH
ARG TARGETOS
RUN GOARCH=${TARGETARCH} GOOS=${TARGETOS} CGO_ENABLED=0 go build -a -ldflags="-s -w -X 'main.Version=$CUPDATE_VERSION'" -o cupdate cmd/cupdate/*.go

FROM scratch AS export

COPY --from=builder /src/cupdate cupdate

FROM export

COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/

ENV PATH=/

ENTRYPOINT ["cupdate"]
```
</details>

<details>
<summary>Scorecard error</summary>

```json
{
  "details": [
    "Warn: containerImage not pinned by hash: Dockerfile:40",
    "Info:  22 out of  22 GitHub-owned GitHubAction dependencies pinned",
    "Info:  13 out of  13 third-party GitHubAction dependencies pinned",
    "Info:   2 out of   3 containerImage dependencies pinned"
  ],
  "score": 9,
  "reason": "dependency not pinned by hash detected -- score normalized to 9",
  "name": "Pinned-Dependencies",
  "documentation": {
    "url": "https://github.com/ossf/scorecard/blob/f08e8fbdb73dbde0533803fdbad3fd4186825314/docs/checks.md#pinned-dependencies",
    "short": "Determines if the project has declared and pinned the dependencies of its build process."
  }
}
```
</details>

#### What is the new behavior (if this is a feature change)?**

Such as stage is not marked as being unpinned.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
