### PR TITLE
🌱 bump go to v1.24

### DIFF
--- a/checker/client_test.go
+++ b/checker/client_test.go
@@ -44,7 +44,7 @@ func TestGetClients(t *testing.T) {
 		{
 			name: "localURI is not empty",
 			args: args{
-				ctx:      context.Background(),
+				ctx:      t.Context(),
 				repoURI:  "",
 				localURI: "foo",
 			},
@@ -57,7 +57,7 @@ func TestGetClients(t *testing.T) {
 		{
 			name: "repoURI is not empty",
 			args: args{
-				ctx:      context.Background(),
+				ctx:      t.Context(),
 				repoURI:  "foo",
 				localURI: "",
 			},
@@ -70,7 +70,7 @@ func TestGetClients(t *testing.T) {
 		{
 			name: "repoURI is gitlab which is supported",
 			args: args{
-				ctx:      context.Background(),
+				ctx:      t.Context(),
 				repoURI:  "https://gitlab.com/ossf-test/scorecard",
 				localURI: "",
 			},
@@ -83,7 +83,7 @@ func TestGetClients(t *testing.T) {
 		{
 			name: "repoURI is corp github host",
 			args: args{
-				ctx:      context.Background(),
+				ctx:      t.Context(),
 				repoURI:  "https://github.corp.com/ossf/scorecard",
 				localURI: "",
 			},

--- a/checks/binary_artifact_test.go
+++ b/checks/binary_artifact_test.go
@@ -15,7 +15,6 @@
 package checks
 
 import (
-	"context"
 	"io"
 	"os"
 	"testing"
@@ -80,7 +79,7 @@ func TestBinaryArtifacts(t *testing.T) {
 				return os.Open("./" + tt.inputFolder + "/" + file)
 			}).AnyTimes()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			dl := scut.TestDetailLogger{}
 

--- a/checks/dangerous_workflow_test.go
+++ b/checks/dangerous_workflow_test.go
@@ -15,7 +15,6 @@
 package checks
 
 import (
-	"context"
 	"io"
 	"os"
 	"testing"
@@ -85,7 +84,7 @@ func TestDangerousWorkflow(t *testing.T) {
 			}).AnyTimes()
 
 			req := &checker.CheckRequest{
-				Ctx:        context.Background(),
+				Ctx:        t.Context(),
 				RepoClient: mockRepoClient,
 				Dlogger:    &dl,
 			}

--- a/checks/license_test.go
+++ b/checks/license_test.go
@@ -15,7 +15,6 @@
 package checks
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -90,7 +89,7 @@ func TestLicenseFileSubdirectory(t *testing.T) {
 			//     if that functionality is ever changed, this mock needs to be updated accordingly
 			mockRepoClient.EXPECT().ListLicenses().Return(nil, fmt.Errorf("ListLicenses: %w", clients.ErrUnsupportedFeature)).AnyTimes()
 
-			ctx := context.Background()
+			ctx := t.Context()
 
 			dl := scut.TestDetailLogger{}
 

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -15,7 +15,6 @@
 package raw
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -162,7 +161,7 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 			})
 
 			req := &checker.CheckRequest{
-				Ctx:        context.Background(),
+				Ctx:        t.Context(),
 				RepoClient: mockRepoClient,
 			}
 

--- a/checks/raw/maintained_test.go
+++ b/checks/raw/maintained_test.go
@@ -14,7 +14,6 @@
 package raw
 
 import (
-	"context"
 	"fmt"
 	"testing"
 	"time"
@@ -33,7 +32,7 @@ func TestMaintained(t *testing.T) {
 
 	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
 
-	ctx := context.Background()
+	ctx := t.Context()
 	req := &checker.CheckRequest{
 		Ctx:        ctx,
 		RepoClient: mockRepoClient,

--- a/checks/raw/sbom_test.go
+++ b/checks/raw/sbom_test.go
@@ -15,7 +15,6 @@
 package raw
 
 import (
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -110,7 +109,7 @@ func TestSbom(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			req := checker.CheckRequest{
 				RepoClient: mockRepo,
-				Ctx:        context.Background(),
+				Ctx:        t.Context(),
 				Dlogger:    &dl,
 			}
 			res, err := SBOM(&req)

--- a/checks/raw/vulnerabilities_test.go
+++ b/checks/raw/vulnerabilities_test.go
@@ -88,7 +88,7 @@ func TestVulnerabilities(t *testing.T) {
 			}).AnyTimes()
 
 			mockVulnClient := mockrepo.NewMockVulnerabilitiesClient(ctrl)
-			mockVulnClient.EXPECT().ListUnfixedVulnerabilities(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+			mockVulnClient.EXPECT().ListUnfixedVulnerabilities(t.Context(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ctx context.Context, commit string, localPath string) (clients.VulnerabilitiesResponse, error) {
 					if tt.vulnsError {
 						return clients.VulnerabilitiesResponse{}, errors.New("error")
@@ -99,7 +99,7 @@ func TestVulnerabilities(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			req := checker.CheckRequest{
 				RepoClient:            mockRepo,
-				Ctx:                   context.TODO(),
+				Ctx:                   t.Context(),
 				VulnerabilitiesClient: mockVulnClient,
 				Dlogger:               &dl,
 			}

--- a/checks/raw/webhooks_test.go
+++ b/checks/raw/webhooks_test.go
@@ -15,7 +15,6 @@
 package raw
 
 import (
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -109,7 +108,7 @@ func TestWebhooks(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			req := checker.CheckRequest{
 				RepoClient: mockRepo,
-				Ctx:        context.TODO(),
+				Ctx:        t.Context(),
 				Dlogger:    &dl,
 			}
 			got, err := WebHook(&req)

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -15,7 +15,6 @@
 package checks
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -329,7 +328,7 @@ func Test_SAST(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			req := checker.CheckRequest{
 				RepoClient: mockRepoClient,
-				Ctx:        context.TODO(),
+				Ctx:        t.Context(),
 				Dlogger:    &dl,
 			}
 			res := SAST(&req)

--- a/checks/sbom_test.go
+++ b/checks/sbom_test.go
@@ -15,7 +15,6 @@
 package checks
 
 import (
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -99,7 +98,7 @@ func TestSbom(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			req := checker.CheckRequest{
 				RepoClient: mockRepo,
-				Ctx:        context.Background(),
+				Ctx:        t.Context(),
 				Dlogger:    &dl,
 			}
 			res := SBOM(&req)

--- a/checks/vulnerabilities_test.go
+++ b/checks/vulnerabilities_test.go
@@ -59,14 +59,14 @@ func TestVulnerabilities(t *testing.T) {
 			}).AnyTimes()
 
 			mockVulnClient := mockrepo.NewMockVulnerabilitiesClient(ctrl)
-			mockVulnClient.EXPECT().ListUnfixedVulnerabilities(context.TODO(), gomock.Any(), gomock.Any()).DoAndReturn(
+			mockVulnClient.EXPECT().ListUnfixedVulnerabilities(t.Context(), gomock.Any(), gomock.Any()).DoAndReturn(
 				func(ctx context.Context, commit string, localPath string) (clients.VulnerabilitiesResponse, error) {
 					return tt.expected, tt.err
 				}).MinTimes(1)
 
 			req := checker.CheckRequest{
 				RepoClient:            mockRepo,
-				Ctx:                   context.TODO(),
+				Ctx:                   t.Context(),
 				VulnerabilitiesClient: mockVulnClient,
 			}
 			res := Vulnerabilities(&req)

--- a/checks/webhook_test.go
+++ b/checks/webhook_test.go
@@ -15,7 +15,6 @@
 package checks
 
 import (
-	"context"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -109,7 +108,7 @@ func TestWebhooks(t *testing.T) {
 			dl := scut.TestDetailLogger{}
 			req := checker.CheckRequest{
 				RepoClient: mockRepo,
-				Ctx:        context.TODO(),
+				Ctx:        t.Context(),
 				Dlogger:    &dl,
 			}
 			res := WebHooks(&req)

--- a/clients/azuredevopsrepo/commits_test.go
+++ b/clients/azuredevopsrepo/commits_test.go
@@ -118,7 +118,7 @@ func Test_listStatuses(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := &commitsHandler{
-				ctx: context.Background(),
+				ctx: t.Context(),
 				repourl: &Repo{
 					id: "id",
 				},

--- a/clients/azuredevopsrepo/contributors_test.go
+++ b/clients/azuredevopsrepo/contributors_test.go
@@ -110,7 +110,7 @@ func Test_listContributors(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			c := contributorsHandler{
-				ctx:  context.Background(),
+				ctx:  t.Context(),
 				once: new(sync.Once),
 				repourl: &Repo{
 					organization: "testOrg",

--- a/clients/azuredevopsrepo/languages_test.go
+++ b/clients/azuredevopsrepo/languages_test.go
@@ -108,7 +108,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			t.Parallel()
 			l := &languagesHandler{
 				once: new(sync.Once),
-				ctx:  context.Background(),
+				ctx:  t.Context(),
 				repourl: &Repo{
 					id:      uuid.Nil.String(),
 					project: "project",

--- a/clients/azuredevopsrepo/policy_test.go
+++ b/clients/azuredevopsrepo/policy_test.go
@@ -72,7 +72,7 @@ func Test_listCheckRunsForRef(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			p := policyHandler{
-				ctx: context.Background(),
+				ctx: t.Context(),
 				repourl: &Repo{
 					id: "1",
 				},

--- a/clients/azuredevopsrepo/search_commits_test.go
+++ b/clients/azuredevopsrepo/search_commits_test.go
@@ -88,7 +88,7 @@ func Test_searchCommits(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			s := searchCommitsHandler{
-				ctx:                 context.Background(),
+				ctx:                 t.Context(),
 				repourl:             &Repo{},
 				getCommits:          tt.getCommits,
 				getPullRequestQuery: tt.getPullRequestQuery,

--- a/clients/azuredevopsrepo/webhooks_test.go
+++ b/clients/azuredevopsrepo/webhooks_test.go
@@ -83,7 +83,7 @@ func Test_listWebhooks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			s := servicehooksHandler{
-				ctx:               context.Background(),
+				ctx:               t.Context(),
 				once:              new(sync.Once),
 				repourl:           &Repo{},
 				listSubscriptions: tt.listSubscriptions,

--- a/clients/azuredevopsrepo/work_items_test.go
+++ b/clients/azuredevopsrepo/work_items_test.go
@@ -157,7 +157,7 @@ func Test_listIssues(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			w := &workItemsHandler{
-				ctx:     context.Background(),
+				ctx:     t.Context(),
 				once:    new(sync.Once),
 				repourl: &Repo{project: "test-project"},
 			}

--- a/clients/cii_blob_client.go
+++ b/clients/cii_blob_client.go
@@ -21,8 +21,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
-	// Needed to link GCP drivers.
-	_ "gocloud.dev/blob/gcsblob"
+	_ "gocloud.dev/blob/gcsblob" // Needed to link GCP drivers.
 )
 
 // blobClientCIIBestPractices implements the CIIBestPracticesClient interface.

--- a/clients/githubrepo/checkruns_test.go
+++ b/clients/githubrepo/checkruns_test.go
@@ -15,7 +15,6 @@
 package githubrepo
 
 import (
-	"context"
 	"testing"
 
 	sce "github.com/ossf/scorecard/v5/errors"
@@ -24,7 +23,7 @@ import (
 func Test_init_clearsErr(t *testing.T) {
 	t.Parallel()
 	handler := &checkrunsHandler{errSetup: sce.ErrScorecardInternal}
-	handler.init(context.Background(), nil, 0)
+	handler.init(t.Context(), nil, 0)
 	if handler.errSetup != nil {
 		t.Errorf("expected nil error, got %v", handler.errSetup)
 	}

--- a/clients/githubrepo/graphql_test.go
+++ b/clients/githubrepo/graphql_test.go
@@ -15,7 +15,6 @@
 package githubrepo
 
 import (
-	"context"
 	"net/http"
 	"testing"
 
@@ -43,7 +42,7 @@ func Test_getCommits_retry(t *testing.T) {
 			Transport: rt,
 		}),
 	}
-	handler.init(context.Background(), &Repo{}, 1)
+	handler.init(t.Context(), &Repo{}, 1)
 	_, err := handler.getCommits()
 	if err == nil {
 		t.Error("expected error")

--- a/clients/githubrepo/roundtripper/rate_limit_test.go
+++ b/clients/githubrepo/roundtripper/rate_limit_test.go
@@ -14,7 +14,6 @@
 package roundtripper
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -63,7 +62,7 @@ func TestRoundTrip(t *testing.T) {
 
 	t.Run("Successful response", func(t *testing.T) {
 		t.Parallel()
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+"/success", nil)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/success", nil)
 		if err != nil {
 			t.Fatalf("Failed to create request: %v", err)
 		}
@@ -80,7 +79,7 @@ func TestRoundTrip(t *testing.T) {
 
 	t.Run("Retry-After header set", func(t *testing.T) {
 		t.Parallel()
-		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, ts.URL+"/retry", nil)
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, ts.URL+"/retry", nil)
 		if err != nil {
 			t.Fatalf("Failed to create request: %v", err)
 		}

--- a/clients/githubrepo/tarball_test.go
+++ b/clients/githubrepo/tarball_test.go
@@ -16,7 +16,6 @@ package githubrepo
 
 import (
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -232,7 +231,7 @@ func Test_setup_empty_repo(t *testing.T) {
 			}
 			var buf bytes.Buffer
 			setLogOutput(t, &buf)
-			h.init(context.Background(), &r, clients.HeadSHA)
+			h.init(t.Context(), &r, clients.HeadSHA)
 			err := h.setup()
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)

--- a/clients/githubrepo/webhook_test.go
+++ b/clients/githubrepo/webhook_test.go
@@ -15,7 +15,6 @@
 package githubrepo
 
 import (
-	"context"
 	"net/http"
 	"os"
 	"testing"
@@ -65,7 +64,7 @@ func Test_listWebhooks(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			httpClient := &http.Client{
 				Transport: stubTripper{
 					responsePath: tt.responsePath,

--- a/clients/gitlabrepo/branches.go
+++ b/clients/gitlabrepo/branches.go
@@ -200,7 +200,7 @@ func makeBranchRefFrom(branch *gitlab.Branch, protectedBranch *gitlab.ProtectedB
 	}
 
 	if projectApprovalRule != nil {
-		requiredApprovalNum := int32(projectApprovalRule.ApprovalsBeforeMerge)
+		requiredApprovalNum := int32(projectApprovalRule.ApprovalsBeforeMerge) //nolint:staticcheck
 		pullRequestReviewRule.RequiredApprovingReviewCount = &requiredApprovalNum
 	}
 

--- a/clients/gitlabrepo/client_test.go
+++ b/clients/gitlabrepo/client_test.go
@@ -15,7 +15,6 @@
 package gitlabrepo
 
 import (
-	"context"
 	"errors"
 	"net/http"
 	"testing"
@@ -123,7 +122,7 @@ func TestListCommits(t *testing.T) {
 			gqlhandler := graphqlHandler{
 				client: httpClient,
 			}
-			gqlhandler.init(context.Background(), &repoURL)
+			gqlhandler.init(t.Context(), &repoURL)
 
 			client := &Client{glClient: glclient, commits: commitshandler, graphql: &gqlhandler}
 

--- a/clients/localdir/client_test.go
+++ b/clients/localdir/client_test.go
@@ -15,7 +15,6 @@
 package localdir
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -62,7 +61,7 @@ func TestClient_CreationAndCaching(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := t.Context()
 			logger := log.NewLogger(log.DebugLevel)
 
 			// Create repo.

--- a/clients/ossfuzz/client_test.go
+++ b/clients/ossfuzz/client_test.go
@@ -15,7 +15,6 @@
 package ossfuzz
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -257,7 +256,7 @@ func TestAllClientMethods(t *testing.T) {
 
 	// Test GetOrgRepoClient
 	{
-		_, err := c.GetOrgRepoClient(context.Background())
+		_, err := c.GetOrgRepoClient(t.Context())
 		if !errors.Is(err, clients.ErrUnsupportedFeature) {
 			t.Errorf("GetOrgRepoClient: Expected %v, but got %v", clients.ErrUnsupportedFeature, err)
 		}

--- a/clients/osv_test.go
+++ b/clients/osv_test.go
@@ -14,7 +14,6 @@
 package clients
 
 import (
-	"context"
 	"reflect"
 	"testing"
 )
@@ -52,7 +51,7 @@ func TestEmptyProject(t *testing.T) {
 	var client osvClient
 	var commit string
 	emptyDir := t.TempDir()
-	_, err := client.ListUnfixedVulnerabilities(context.Background(), commit, emptyDir)
+	_, err := client.ListUnfixedVulnerabilities(t.Context(), commit, emptyDir)
 	if err != nil {
 		t.Fatalf("empty directory shouldn't throw an error: %v", err)
 	}

--- a/cmd/internal/scdiff/app/runner/runner_test.go
+++ b/cmd/internal/scdiff/app/runner/runner_test.go
@@ -15,7 +15,6 @@
 package runner
 
 import (
-	"context"
 	"errors"
 	"testing"
 
@@ -48,7 +47,7 @@ func TestRunner_Run(t *testing.T) {
 	mockRepo.EXPECT().GetFileReader(gomock.Any()).Return(nil, errors.New("reading files unsupported for this test")).AnyTimes()
 	mockRepo.EXPECT().LocalPath().Return(".", nil)
 	r := Runner{
-		ctx: context.Background(),
+		ctx: t.Context(),
 		// use a check which works locally, but we declare no files above so no-op
 		enabledChecks: []string{checknames.BinaryArtifacts},
 		githubClient:  mockRepo,

--- a/cron/data/blob.go
+++ b/cron/data/blob.go
@@ -24,10 +24,8 @@ import (
 
 	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
-	// Needed to read file:/// buckets. Intended primarily for testing, though needed here for tests outside the package.
-	_ "gocloud.dev/blob/fileblob"
-	// Needed to link in GCP drivers.
-	_ "gocloud.dev/blob/gcsblob"
+	_ "gocloud.dev/blob/fileblob" // Needed to read file:/// buckets. Intended primarily for testing, though needed here for tests outside the package.
+	_ "gocloud.dev/blob/gcsblob"  // Needed to link in GCP drivers.
 
 	"github.com/ossf/scorecard/v5/cron/config"
 )

--- a/cron/data/blob_test.go
+++ b/cron/data/blob_test.go
@@ -15,7 +15,6 @@
 package data
 
 import (
-	"context"
 	"errors"
 	"reflect"
 	"testing"
@@ -156,7 +155,7 @@ func TestBlobKeysPrefix(t *testing.T) {
 		t.Errorf("Failed to create a file blob for %s", dir)
 	}
 	defer bucket.Close()
-	ctx := context.Background()
+	ctx := t.Context()
 
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {

--- a/cron/data/summary_test.go
+++ b/cron/data/summary_test.go
@@ -15,7 +15,6 @@
 package data
 
 import (
-	"context"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -122,7 +121,7 @@ func TestGetBucketSummary(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			summary, err := GetBucketSummary(context.Background(), "file:///"+testdataPath)
+			summary, err := GetBucketSummary(t.Context(), "file:///"+testdataPath)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getBucketSummary() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/cron/internal/controller/bucket_test.go
+++ b/cron/internal/controller/bucket_test.go
@@ -15,7 +15,6 @@
 package main
 
 import (
-	"context"
 	"path/filepath"
 	"testing"
 )
@@ -80,7 +79,7 @@ func TestGetPrefix(t *testing.T) {
 			if err != nil {
 				t.Errorf("unexpected error: %v", err)
 			}
-			got, err := getPrefix(context.Background(), "file:///"+testdataPath)
+			got, err := getPrefix(t.Context(), "file:///"+testdataPath)
 			if (err != nil) != testcase.wantErr {
 				t.Errorf("unexpected error produced: %v", err)
 			}

--- a/cron/internal/pubsub/publisher_test.go
+++ b/cron/internal/pubsub/publisher_test.go
@@ -62,7 +62,7 @@ func TestPublish(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			publisher := publisherImpl{
 				ctx:   ctx,
 				topic: testcase.topic,

--- a/cron/internal/pubsub/subscriber_gocloud_test.go
+++ b/cron/internal/pubsub/subscriber_gocloud_test.go
@@ -83,7 +83,7 @@ func TestSubscriber(t *testing.T) {
 	for _, testcase := range testcases {
 		t.Run(testcase.name, func(t *testing.T) {
 			t.Parallel()
-			ctx := context.Background()
+			ctx := t.Context()
 			msgBody, err := protojson.Marshal(testcase.msg)
 			if err != nil {
 				t.Errorf("testcase parsing failed during protojson.Marshal: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ossf/scorecard/v5
 
-go 1.23.0
+go 1.24.0
 
 require (
 	cloud.google.com/go/bigquery v1.68.0

--- a/internal/gitfile/gitfile_test.go
+++ b/internal/gitfile/gitfile_test.go
@@ -15,7 +15,6 @@
 package gitfile
 
 import (
-	"context"
 	"errors"
 	"io"
 	"os"
@@ -38,7 +37,7 @@ func TestHandler(t *testing.T) {
 	dir := setupGitRepo(t)
 
 	var h Handler
-	h.Init(context.Background(), dir, "HEAD")
+	h.Init(t.Context(), dir, "HEAD")
 
 	files, err := h.ListFiles(allFiles)
 	if err != nil {
@@ -75,7 +74,7 @@ func TestHandlerPathTraversal(t *testing.T) {
 	dir := setupGitRepo(t)
 
 	var h Handler
-	h.Init(context.Background(), dir, "HEAD")
+	h.Init(t.Context(), dir, "HEAD")
 
 	_, err := h.GetFile("../example.txt")
 	if !errors.Is(err, errPathTraversal) {

--- a/pkg/scorecard/scorecard_test.go
+++ b/pkg/scorecard/scorecard_test.go
@@ -14,7 +14,6 @@
 package scorecard
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"slices"
@@ -102,7 +101,7 @@ func Test_getRepoCommitHashLocal(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			logger := log.NewLogger(log.DebugLevel)
-			localDirClient := localdir.CreateLocalDirClient(context.Background(), logger)
+			localDirClient := localdir.CreateLocalDirClient(t.Context(), logger)
 			localRepo, err := localdir.MakeLocalDirRepo("testdata")
 			if err != nil {
 				t.Errorf("MakeLocalDirRepo: %v", err)
@@ -184,7 +183,7 @@ func TestRun(t *testing.T) {
 					},
 				}, nil
 			})
-			got, err := Run(context.Background(), repo,
+			got, err := Run(t.Context(), repo,
 				WithCommitSHA(tt.args.commitSHA),
 				WithRepoClient(mockRepoClient),
 			)
@@ -323,7 +322,7 @@ func TestRun_WithProbes(t *testing.T) {
 			mockRepoClient.EXPECT().GetDefaultBranchName().Return("main", nil).AnyTimes()
 			mockOSSFuzzClient := mockrepo.NewMockRepoClient(ctrl)
 			mockOSSFuzzClient.EXPECT().Search(gomock.Any()).Return(clients.SearchResponse{}, nil).AnyTimes()
-			got, err := Run(context.Background(), repo,
+			got, err := Run(t.Context(), repo,
 				WithRepoClient(mockRepoClient),
 				WithOSSFuzzClient(mockOSSFuzzClient),
 				WithCommitSHA(tt.args.commitSHA),

--- a/probes/hasDangerousWorkflowScriptInjection/internal/patch/impl_test.go
+++ b/probes/hasDangerousWorkflowScriptInjection/internal/patch/impl_test.go
@@ -15,7 +15,6 @@
 package patch
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -213,7 +212,7 @@ func detectDangerousWorkflows(t *testing.T, filePath string) []checker.Dangerous
 	}).AnyTimes()
 
 	req := &checker.CheckRequest{
-		Ctx:        context.Background(),
+		Ctx:        t.Context(),
 		RepoClient: mockRepoClient,
 	}
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This bumps go to 1.24 and addresses lints that seem to have appeared with this upgrade. 

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
scorecard uses go v1.23

#### What is the new behavior (if this is a feature change)?**
N/A. No changes, ust bumping to go v1.24

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4636 


#### Special notes for your reviewer
There was a single lint that I added a //nolint to as it requires addressing a deprecated Gitlab API, which feels out of the scope of this PR

#### Does this PR introduce a user-facing change?
No

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
