### PR TITLE
:sparkles: feat(jsx): support fuzzing in jsx files #4663

### DIFF
--- a/checks/raw/fuzzing.go
+++ b/checks/raw/fuzzing.go
@@ -113,7 +113,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 	//
 	// This is not an exhaustive list.
 	clients.JavaScript: {
-		filePatterns: []string{"*.js"},
+		filePatterns: []string{"*.js", "*.jsx"},
 		// Look for direct imports of fast-check and its test runners integrations.
 		funcPattern: `(from\s+['"](fast-check|@fast-check/(ava|jest|vitest))['"]|` +
 			`require\(\s*['"](fast-check|@fast-check/(ava|jest|vitest))['"]\s*\))`,
@@ -121,7 +121,7 @@ var languageFuzzSpecs = map[clients.LanguageName]languageFuzzConfig{
 		Desc: propertyBasedDescription("JavaScript"),
 	},
 	clients.TypeScript: {
-		filePatterns: []string{"*.ts"},
+		filePatterns: []string{"*.ts", "*.tsx"},
 		// Look for direct imports of fast-check and its test runners integrations.
 		funcPattern: `(from\s+['"](fast-check|@fast-check/(ava|jest|vitest))['"]|` +
 			`require\(\s*['"](fast-check|@fast-check/(ava|jest|vitest))['"]\s*\))`,

--- a/checks/raw/fuzzing_test.go
+++ b/checks/raw/fuzzing_test.go
@@ -512,6 +512,67 @@ func Test_checkFuzzFunc(t *testing.T) {
 			fileContent: "const fc = require('fast-other');",
 		},
 		{
+			name:     "JavaScript JSX fast-check via require",
+			want:     true,
+			fileName: []string{"main.spec.jsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.JavaScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const fc = require('fast-check');",
+		},
+		{
+			name:     "JavaScript JSX fast-check via import",
+			want:     true,
+			fileName: []string{"main.spec.jsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.JavaScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "import fc from \"fast-check\";",
+		},
+		{
+			name:     "JavaScript JSX fast-check scoped via require",
+			want:     true,
+			fileName: []string{"main.spec.jsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.JavaScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const { fc, testProp } = require('@fast-check/ava');",
+		},
+		{
+			name:     "JavaScript JSX fast-check scoped via import",
+			want:     true,
+			fileName: []string{"main.spec.jsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.JavaScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "import { fc, test } from \"@fast-check/jest\";",
+		},
+		{
+			name:     "JavaScript JSX with no property-based testing",
+			want:     false,
+			fileName: []string{"main.spec.jsx"},
+			wantErr:  true,
+			langs: []clients.Language{
+				{
+					Name:     clients.JavaScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const fc = require('fast-other');",
+		},
+		{
 			name:     "TypeScript fast-check via require",
 			want:     true,
 			fileName: []string{"main.spec.ts"},
@@ -563,6 +624,67 @@ func Test_checkFuzzFunc(t *testing.T) {
 			name:     "TypeScript with no property-based testing",
 			want:     false,
 			fileName: []string{"main.spec.ts"},
+			wantErr:  true,
+			langs: []clients.Language{
+				{
+					Name:     clients.TypeScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const fc = require('fast-other');",
+		},
+		{
+			name:     "TypeScript TSX fast-check via require",
+			want:     true,
+			fileName: []string{"main.spec.tsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.TypeScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const fc = require('fast-check');",
+		},
+		{
+			name:     "TypeScript TSX fast-check via import",
+			want:     true,
+			fileName: []string{"main.spec.tsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.TypeScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "import fc from \"fast-check\";",
+		},
+		{
+			name:     "TypeScript TSX fast-check scoped via require",
+			want:     true,
+			fileName: []string{"main.spec.tsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.TypeScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "const { fc, testProp } = require('@fast-check/ava');",
+		},
+		{
+			name:     "TypeScript TSX fast-check scoped via import",
+			want:     true,
+			fileName: []string{"main.spec.tsx"},
+			langs: []clients.Language{
+				{
+					Name:     clients.TypeScript,
+					NumLines: 50,
+				},
+			},
+			fileContent: "import { fc, test } from \"@fast-check/vitest\";",
+		},
+		{
+			name:     "TypeScript TSX with no property-based testing",
+			want:     false,
+			fileName: []string{"main.spec.tsx"},
 			wantErr:  true,
 			langs: []clients.Language{
 				{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Fuzzing supports `.js` and `.ts` files but not `.jsx` and `.tsx` files.

#### What is the new behavior (if this is a feature change)?**

Adds support for more JavaScript file types.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4663 

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
