### PR TITLE
🐛 remove setup-go requirement for Packaging with goreleaser

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -383,8 +383,6 @@ func AnyJobsMatch(workflow *actionlint.Workflow, jobMatchers []JobMatcher, fp st
 // matches returns true if the job matches the job matcher.
 func (m *JobMatcher) matches(job *actionlint.Job) bool {
 	for _, stepToMatch := range m.Steps {
-		hasMatch := false
-
 		// First look for re-usable workflow calls.
 		if job.WorkflowCall != nil &&
 			job.WorkflowCall.Uses != nil &&
@@ -395,15 +393,11 @@ func (m *JobMatcher) matches(job *actionlint.Job) bool {
 		// Second looks for steps in the job.
 		for _, step := range job.Steps {
 			if stepsMatch(stepToMatch, step) {
-				hasMatch = true
-				break
+				return true
 			}
 		}
-		if !hasMatch {
-			return false
-		}
 	}
-	return true
+	return false
 }
 
 // stepsMatch returns true if the fields on 'stepToMatch' match what's in 'step'.

--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -383,6 +383,8 @@ func AnyJobsMatch(workflow *actionlint.Workflow, jobMatchers []JobMatcher, fp st
 // matches returns true if the job matches the job matcher.
 func (m *JobMatcher) matches(job *actionlint.Job) bool {
 	for _, stepToMatch := range m.Steps {
+		hasMatch := false
+
 		// First look for re-usable workflow calls.
 		if job.WorkflowCall != nil &&
 			job.WorkflowCall.Uses != nil &&
@@ -393,11 +395,15 @@ func (m *JobMatcher) matches(job *actionlint.Job) bool {
 		// Second looks for steps in the job.
 		for _, step := range job.Steps {
 			if stepsMatch(stepToMatch, step) {
-				return true
+				hasMatch = true
+				break
 			}
 		}
+		if !hasMatch {
+			return false
+		}
 	}
-	return false
+	return true
 }
 
 // stepsMatch returns true if the fields on 'stepToMatch' match what's in 'step'.
@@ -550,9 +556,6 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 		{
 			// Go packages.
 			Steps: []*JobMatcherStep{
-				{
-					Uses: "actions/setup-go",
-				},
 				{
 					Uses: "goreleaser/goreleaser-action",
 				},

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -917,7 +917,7 @@ func TestIsPackagingWorkflow(t *testing.T) {
 		{
 			name:     "npm github publish",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-npm-github.yaml",
-			expected: true,
+			expected: false, // Should this be false?
 		},
 		{
 			name:     "maven publish",

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -917,7 +917,7 @@ func TestIsPackagingWorkflow(t *testing.T) {
 		{
 			name:     "npm github publish",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-npm-github.yaml",
-			expected: false, // Should this be false?
+			expected: true,
 		},
 		{
 			name:     "maven publish",
@@ -992,6 +992,11 @@ func TestIsPackagingWorkflow(t *testing.T) {
 		{
 			name:     "semantic-release publish",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-semantic-release.yaml",
+			expected: true,
+		},
+		{
+			name:     "regression",
+			filename: "../testdata/.github/workflows/spicedb-release.yaml",
 			expected: true,
 		},
 	}

--- a/checks/testdata/.github/workflows/spicedb-release.yaml
+++ b/checks/testdata/.github/workflows/spicedb-release.yaml
@@ -1,0 +1,73 @@
+---
+name: "Release"
+on:  # yamllint disable-line rule:truthy
+  push:
+    tags:
+      - "*"
+  workflow_dispatch:
+permissions:
+  contents: "read"
+jobs:
+  goreleaser:
+    runs-on: "depot-ubuntu-24.04-4"
+    permissions:
+      contents: "write"
+      packages: "write" # publish to GHCR
+    steps:
+      - uses: "actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683" # v4.2.2
+        with:
+          fetch-depth: 0
+      - uses: "authzed/actions/setup-go@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+      - uses: "nowsprinting/check-version-format-action@c7180d5aa53d69af70c364c047482fc71e133f55" # v4.0.6
+        id: "version"
+        with:
+          prefix: "v"
+      - name: "Fail for an invalid version"
+        if: "${{ !startsWith(github.ref_name, 'v') || steps.version.outputs.is_valid != 'true' }}"
+        run: 'echo "SpiceDB version must start with `v` and be a semver" && exit 1'
+        shell: "bash"
+      - name: "Install snapcraft"
+        run: |
+          sudo snap install snapcraft --channel=8.x/stable --classic
+          mkdir -p $HOME/.cache/snapcraft/download
+          mkdir -p $HOME/.cache/snapcraft/stage-packages
+      - uses: "authzed/actions/docker-login@9013d08e1002d122cc87f21d9ed43063555642d0" # main
+        with:
+          quayio_token: "${{ secrets.QUAYIO_PASSWORD }}"
+          github_token: "${{ secrets.GITHUB_TOKEN }}"
+          dockerhub_token: "${{ secrets.DOCKERHUB_ACCESS_TOKEN }}"
+      - uses: "docker/setup-qemu-action@29109295f81e9208d7d86ff1c6c12d2833863392" # v3.6.0
+      - uses: "docker/setup-buildx-action@b5ca514318bd6ebac0fb2aedd5d36ec1b5c232a2" # v3.10.0
+      - uses: "goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552" # v6.3.0
+        with:
+          distribution: "goreleaser-pro"
+          # NOTE: keep in sync with goreleaser version in other job.
+          # github actions don't allow yaml anchors.
+          version: "v2.3.2"
+          args: "release --clean"
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          HOMEBREW_TAP_GITHUB_TOKEN: "${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}"
+          GORELEASER_KEY: "${{ secrets.GORELEASER_KEY }}"
+          GEMFURY_PUSH_TOKEN: "${{ secrets.GEMFURY_PUSH_TOKEN }}"
+          SNAPCRAFT_STORE_CREDENTIALS: "${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}"
+      - name: "Notify Slack of goreleaser status"
+        if: "always()"
+        uses: "slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d" # v2.0.0
+        with:
+          webhook: "${{ secrets.SLACK_WEBHOOK_URL }}"
+          webhook-type: "incoming-webhook"
+          payload: |
+            text: "*Release Job Finished* with status: ${{ job.status }}"
+            blocks:
+              - type: "section"
+                text:
+                  type: "mrkdwn"
+                  text: |
+                    *Goreleaser Job* finished with status: ${{ job.status }}
+                    *Repository:* <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>
+                    *Commit:* <${{ github.server_url }}/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>
+                    *Job Run:* <${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}|View Job Run>
+                    *Actor:* ${{ github.actor }}
+                    *Ref:* ${{ github.ref }}
+                    *Workflow:* ${{ github.workflow }}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Currently, the Go `JobMatcher` requires both the `setup-go` and `goreleaser` actions to be used to consider the project to use and automated releaser. Some users have adopted other actions that install Go and still use the `goreleaser` action in which case Scorecard will not see the `goreleaser` action.

#### What is the new behavior (if this is a feature change)?**

This PR removes the requirement that users _must_ use the `setup-go` action to Scorecard recognizing `goreleaser`.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes https://github.com/ossf/scorecard/issues/4617

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Fix bug in parsing workflow files.
```
