### PR TITLE
:sparkles: recognize escaped emails in security policy documents

### DIFF
--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -199,7 +199,7 @@ func collectPolicyHits(policyContent []byte) []checker.SecurityPolicyInformation
 	// pattern for URLs
 	reURL := regexp.MustCompile(`(http|https)://[a-zA-Z0-9./?=_%:-]*`)
 	// pattern for emails
-	reEML := regexp.MustCompile(`\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,6}\b`)
+	reEML := regexp.MustCompile(`\b[A-Za-z0-9._%+-]+(@|\\?\[at\\?\])[A-Za-z0-9.-]+\.[A-Za-z]{2,6}\b`)
 	// pattern for 1 to 4 digit numbers
 	// or
 	// strings 'disclos' as in "disclosure" or 'vuln' as in "vulnerability"

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -204,13 +204,41 @@ func Test_collectPolicyHits(t *testing.T) {
 		},
 		// Email regex
 		{
-			name:  "Email positive",
+			name:  "Email positive with @",
 			input: "Contact us at security@example.org.",
 			expected: []checker.SecurityPolicyInformation{
 				{
 					InformationType: checker.SecurityPolicyInformationTypeEmail,
 					InformationValue: checker.SecurityPolicyValueType{
 						Match:      "security@example.org",
+						LineNumber: 1,
+						Offset:     14,
+					},
+				},
+			},
+		},
+		{
+			name:  "Email positive with [at] unescaped",
+			input: "Contact us at security[at]example.org.",
+			expected: []checker.SecurityPolicyInformation{
+				{
+					InformationType: checker.SecurityPolicyInformationTypeEmail,
+					InformationValue: checker.SecurityPolicyValueType{
+						Match:      "security[at]example.org",
+						LineNumber: 1,
+						Offset:     14,
+					},
+				},
+			},
+		},
+		{
+			name:  "Email positive with [at] escaped",
+			input: "Contact us at security\\[at\\]example.org.",
+			expected: []checker.SecurityPolicyInformation{
+				{
+					InformationType: checker.SecurityPolicyInformationTypeEmail,
+					InformationValue: checker.SecurityPolicyValueType{
+						Match:      "security\\[at\\]example.org",
 						LineNumber: 1,
 						Offset:     14,
 					},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

I think this counts as a feature (a micro feature).

Some security policy documents may include an email address partially
obfuscated in the form security[at]example.org or, especially in
markdown, escaped like security\\[at\\]example.org.

This change updates the regex to recognize those two forms, with the
tests expanded to cover those cases as well.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Only emails of the form security@example.org are recognized.

#### What is the new behavior (if this is a feature change)?**

Emails of the form security[at]example.org and security\[at\]example.org are recognized.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE

#### Special notes for your reviewer
This depends first on https://github.com/ossf/scorecard/pull/4674 being merged.

#### Does this PR introduce a user-facing change?

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Start recognizing escaped emails in security policy documents
```
