### PR TITLE
🐛 do not allow unsupported `ListReleases` to fail a run

### DIFF
--- a/checks/raw/branch_protection.go
+++ b/checks/raw/branch_protection.go
@@ -15,6 +15,7 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 	"reflect"
 	"regexp"
@@ -65,7 +66,7 @@ func BranchProtection(cr *checker.CheckRequest) (checker.BranchProtectionsData, 
 
 	// Get release branches.
 	releases, err := c.ListReleases()
-	if err != nil {
+	if err != nil && !errors.Is(err, clients.ErrUnsupportedFeature) {
 		return checker.BranchProtectionsData{}, fmt.Errorf("%w", err)
 	}
 	for _, release := range releases {

--- a/checks/raw/sbom.go
+++ b/checks/raw/sbom.go
@@ -15,6 +15,7 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 	"regexp"
 
@@ -37,7 +38,7 @@ func SBOM(c *checker.CheckRequest) (checker.SBOMData, error) {
 	var results checker.SBOMData
 
 	releases, lerr := c.RepoClient.ListReleases()
-	if lerr != nil {
+	if lerr != nil && !errors.Is(lerr, clients.ErrUnsupportedFeature) {
 		return results, fmt.Errorf("RepoClient.ListReleases: %w", lerr)
 	}
 

--- a/checks/raw/signed_releases.go
+++ b/checks/raw/signed_releases.go
@@ -15,15 +15,17 @@
 package raw
 
 import (
+	"errors"
 	"fmt"
 
 	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
 )
 
 // SignedReleases checks for presence of signed release check.
 func SignedReleases(c *checker.CheckRequest) (checker.SignedReleasesData, error) {
 	releases, err := c.RepoClient.ListReleases()
-	if err != nil {
+	if err != nil && !errors.Is(err, clients.ErrUnsupportedFeature) {
 		return checker.SignedReleasesData{}, fmt.Errorf("%w", err)
 	}
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This check allows clients which currently do not support `ListReleases` to complete a Scorecard run. Currently `azuredevopsrepo`, `localdir`, and `git` do not support `ListReleases`.

This is a follow-up from #4533, with PR comments addressed, after I let that PR go stale.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Currently, running `scorecard` against a client that does not support `ListReleases` results in a non-zero exit code, and an error printed to the console:

```
Error: check runtime error: Branch-Protection: internal error: unsupported feature
2025/06/26 20:08:25 error during command execution: check runtime error: Branch-Protection: internal error: unsupported feature
```

#### What is the new behavior (if this is a feature change)?**

Partial results for the checks that partially rely on `ListReleases` (`Branch-Protection`, `SBOM`) and no results for `Signed-Releases`.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Prevent unimplemented ListReleases from failing a run
```
