### PR TITLE
🐛 check for npm package git URLs

### DIFF
--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -460,6 +460,25 @@ func isNpmUnpinnedDownload(cmd []string) bool {
 		if strings.EqualFold(cmd[i], "ci") {
 			return false
 		}
+
+		// Check if the package is of any of the
+		// following formats: https://docs.npmjs.com/about-packages-and-modules#npm-package-git-url-formats
+		if strings.HasPrefix(cmd[i], "github:") ||
+			strings.HasPrefix(cmd[i], "git:") ||
+			strings.HasPrefix(cmd[i], "http://") ||
+			strings.HasPrefix(cmd[i], "https://") {
+			// We expect the URL to only have 1 #, but
+			// we can check whether it has more and
+			// is invalid.
+			s := strings.SplitN(cmd[i], "#", 5)
+			if len(s) != 2 {
+				return false
+			}
+			// git commit hashes have 40 chars
+			if len(s[1]) == 40 {
+				return false
+			}
+		}
 	}
 	return true
 }

--- a/checks/raw/shell_download_validate_test.go
+++ b/checks/raw/shell_download_validate_test.go
@@ -456,6 +456,55 @@ func Test_isNpmUnpinnedDownload(t *testing.T) {
 			},
 			want: false,
 		},
+		{
+			name: "npm install with github: prefix and valid hash",
+			args: args{
+				cmd: []string{"npm", "install", "github:nodeca/js-yaml#2cef47bebf60da141b78b085f3dea3b5733dcc12"},
+			},
+			want: false,
+		},
+		{
+			name: "npm install with git: prefix and valid hash",
+			args: args{
+				cmd: []string{"npm", "install", "github:nodeca/js-yaml#2cef47bebf60da141b78b085f3dea3b5733dcc12"},
+			},
+			want: false,
+		},
+		{
+			name: "npm install with http: prefix and valid hash",
+			args: args{
+				cmd: []string{"npm", "install", "github:nodeca/js-yaml#2cef47bebf60da141b78b085f3dea3b5733dcc12"},
+			},
+			want: false,
+		},
+		{
+			name: "npm install with https: prefix and valid hash",
+			args: args{
+				cmd: []string{"npm", "install", "github:nodeca/js-yaml#2cef47bebf60da141b78b085f3dea3b5733dcc12"},
+			},
+			want: false,
+		},
+		{
+			name: "npm install invalid github url (has too many hash characters)",
+			args: args{
+				cmd: []string{"npm", "install", "githu#b:n#odeca/js-yaml#2cef47bebf60da141b78b085f3dea3b5733dcc12"},
+			},
+			want: true,
+		},
+		{
+			name: "npm install with wrong prefix (githu instead of github)",
+			args: args{
+				cmd: []string{"npm", "install", "githu:nodeca/js-yaml#2cef47bebf60da141b78b085f3dea3b5733dcc12"},
+			},
+			want: true,
+		},
+		{
+			name: "npm install with wrong hash length",
+			args: args{
+				cmd: []string{"npm", "install", "githu:nodeca/js-yaml#2cef47bebf60d"},
+			},
+			want: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Currently Scorecard only check for `npm ci` to determine whether packages are pinned, however, users can also do that with other URL formats like [these](https://docs.npmjs.com/about-packages-and-modules#npm-package-git-url-formats). 

#### What is the new behavior (if this is a feature change)?**
Scorecard supports [git URLs](https://docs.npmjs.com/about-packages-and-modules#npm-package-git-url-formats) for `npm install`

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes https://github.com/ossf/scorecard/issues/4589

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Support git URLs for calls to npm install.
```
