### PR TITLE
🌱 implement GetPackage for depsdev client

### DIFF
--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -465,6 +465,12 @@ func TestSignedRelease(t *testing.T) {
 					return &v, nil
 				},
 			).AnyTimes()
+			mockPkgC.EXPECT().GetPackage(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, host, project string) (*packageclient.Package, error) {
+					v := packageclient.Package{}
+					return &v, nil
+				},
+			).AnyTimes()
 
 			req := checker.CheckRequest{
 				RepoClient:    mockRepoC,

--- a/clients/mockclients/projectpackageclient.go
+++ b/clients/mockclients/projectpackageclient.go
@@ -61,5 +61,21 @@ func (m *MockProjectPackageClient) GetProjectPackageVersions(ctx context.Context
 // GetProjectPackageVersions indicates an expected call of GetProjectPackageVersions.
 func (mr *MockProjectPackageClientMockRecorder) GetProjectPackageVersions(ctx, host, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectPackageVersions", reflect.TypeOf((*MockProjectPackageClient)(nil).GetProjectPackageVersions), ctx, host, project)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectPackageVersions", reflect.TypeOf((*MockProjectPackageClient)(nil).GetPackage), ctx, host, project)
+}
+
+
+// GetPackage mocks base method.
+func (m *MockProjectPackageClient) GetPackage(ctx context.Context, host, project string) (*packageclient.Package, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPackage", ctx, host, project)
+	ret0, _ := ret[0].(*packageclient.Package)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPackage indicates an expected call of GetPackage.
+func (mr *MockProjectPackageClientMockRecorder) GetPackage(ctx, host, project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPackage", reflect.TypeOf((*MockProjectPackageClient)(nil).GetPackage), ctx, host, project)
 }

--- a/internal/packageclient/depsdev.go
+++ b/internal/packageclient/depsdev.go
@@ -27,6 +27,7 @@ import (
 // This interface lets Scorecard look up package manager metadata for a project.
 type ProjectPackageClient interface {
 	GetProjectPackageVersions(ctx context.Context, host, project string) (*ProjectPackageVersions, error)
+	GetPackage(ctx context.Context, systemName, packageName string) (*Package, error)
 }
 
 type depsDevClient struct {
@@ -34,22 +35,42 @@ type depsDevClient struct {
 }
 
 type ProjectPackageVersions struct {
-	// field alignment
-	//nolint:govet
-	Versions []struct {
-		VersionKey struct {
-			System  string `json:"system"`
-			Name    string `json:"name"`
-			Version string `json:"version"`
-		} `json:"versionKey"`
-		SLSAProvenances []struct {
-			SourceRepository string `json:"sourceRepository"`
-			Commit           string `json:"commit"`
-			Verified         bool   `json:"verified"`
-		} `json:"slsaProvenances"`
-		RelationType       string `json:"relationType"`
-		RelationProvenance string `json:"relationProvenance"`
-	} `json:"versions"`
+	Versions []Version `json:"versions"`
+}
+
+type Package struct {
+	PackageKey PackageKey `json:"packageKey"`
+	Purl       string     `json:"purl"`
+	Versions   []Version  `json:"versions"`
+}
+
+type PackageKey struct {
+	PackageSystem string `json:"system"`
+	PackageName   string `json:"name"`
+}
+
+type VersionKey struct {
+	System          string           `json:"system"`
+	Name            string           `json:"name"`
+	Version         string           `json:"version"`
+	SLSAProvenances []SLSAProvenance `json:"slsaProvenances"`
+}
+
+type SLSAProvenance struct {
+	SourceRepository string `json:"sourceRepository"`
+	Commit           string `json:"commit"`
+	Verified         bool   `json:"verified"`
+}
+
+type Version struct {
+	RelationType       string           `json:"relationType"`
+	RelationProvenance string           `json:"relationProvenance"`
+	Purl               string           `json:"purl"`
+	PublishedAt        string           `json:"publishedAt"`
+	VersionKey         VersionKey       `json:"versionKey"`
+	SLSAProvenances    []SLSAProvenance `json:"slsaProvenances"`
+	IsDefault          bool             `json:"isDefault"`
+	IsDeprecated       bool             `json:"isDeprecated"`
 }
 
 func CreateDepsDevClient() ProjectPackageClient {
@@ -81,6 +102,42 @@ func (d depsDevClient) GetProjectPackageVersions(
 	defer resp.Body.Close()
 
 	var res ProjectPackageVersions
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, ErrProjNotFoundInDepsDev
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("%w: %s", ErrDepsDevAPI, resp.Status)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("resp.Body.Read: %w", err)
+	}
+
+	err = json.Unmarshal(body, &res)
+	if err != nil {
+		return nil, fmt.Errorf("deps.dev json.Unmarshal: %w", err)
+	}
+
+	return &res, nil
+}
+
+func (d depsDevClient) GetPackage(ctx context.Context, systemName, packageName string) (*Package, error) {
+	query := fmt.Sprintf("https://api.deps.dev/v3alpha/systems/%s/packages/%s", systemName, packageName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, query, nil)
+	if err != nil {
+		return nil, fmt.Errorf("http.NewRequestWithContext: %w", err)
+	}
+
+	resp, err := d.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("deps.dev GetPackage: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var res Package
 	if resp.StatusCode == http.StatusNotFound {
 		return nil, ErrProjNotFoundInDepsDev
 	}

--- a/internal/packageclient/depsdev_test.go
+++ b/internal/packageclient/depsdev_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packageclient
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: fn,
+	}
+}
+
+func TestGetPackage(t *testing.T) {
+	t.Parallel()
+	resp := `{
+  "packageKey": {
+    "system": "NPM",
+    "name": "@colors/colors"
+  },
+  "purl": "pkg:npm/%40colors/colors",
+  "versions": [
+    {
+      "versionKey": {
+        "system": "NPM",
+        "name": "@colors/colors",
+        "version": "1.4.0"
+      },
+      "purl": "pkg:npm/%40colors/colors@1.4.0",
+      "publishedAt": "2022-02-12T06:40:43Z",
+      "isDefault": false,
+      "isDeprecated": false
+    },
+    {
+      "versionKey": {
+        "system": "NPM",
+        "name": "@colors/colors",
+        "version": "1.5.0"
+      },
+      "purl": "pkg:npm/%40colors/colors@1.5.0",
+      "publishedAt": "2022-02-12T07:39:04Z",
+      "isDefault": false,
+      "isDeprecated": false
+    },
+    {
+      "versionKey": {
+        "system": "NPM",
+        "name": "@colors/colors",
+        "version": "1.6.0"
+      },
+      "purl": "pkg:npm/%40colors/colors@1.6.0",
+      "publishedAt": "2023-07-10T05:16:15Z",
+      "isDefault": true,
+      "isDeprecated": false
+    }
+  ]
+}`
+	expected := &Package{
+		PackageKey: PackageKey{
+			PackageSystem: "NPM",
+			PackageName:   "@colors/colors",
+		},
+		Purl: "pkg:npm/%40colors/colors",
+		Versions: []Version{
+			{
+				VersionKey: VersionKey{
+					System:  "NPM",
+					Name:    "@colors/colors",
+					Version: "1.4.0",
+				},
+				Purl:         "pkg:npm/%40colors/colors@1.4.0",
+				PublishedAt:  "2022-02-12T06:40:43Z",
+				IsDefault:    false,
+				IsDeprecated: false,
+			},
+			{
+				VersionKey: VersionKey{
+					System:  "NPM",
+					Name:    "@colors/colors",
+					Version: "1.5.0",
+				},
+				Purl:         "pkg:npm/%40colors/colors@1.5.0",
+				PublishedAt:  "2022-02-12T07:39:04Z",
+				IsDefault:    false,
+				IsDeprecated: false,
+			},
+			{
+				VersionKey: VersionKey{
+					System:  "NPM",
+					Name:    "@colors/colors",
+					Version: "1.6.0",
+				},
+				Purl:         "pkg:npm/%40colors/colors@1.6.0",
+				PublishedAt:  "2023-07-10T05:16:15Z",
+				IsDefault:    true,
+				IsDeprecated: false,
+			},
+		},
+	}
+
+	// Create test client that does not call the deps.dev api
+	testClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Send response to be tested
+			Body: io.NopCloser(bytes.NewBufferString(resp)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+	depsClient := depsDevClient{
+		client: testClient,
+	}
+	depsClient.client = testClient
+
+	r, err := depsClient.GetPackage(context.Background(), "npm", "@colors/colors")
+	if err != nil {
+		t.Errorf("GetPackage returned an error: %v", err)
+	}
+	if diff := cmp.Diff(r, expected); diff != "" {
+		t.Errorf("setDefaultCommitData() mismatch (-want +got):\n%s", diff)
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This implements GetPackage for the Deps.dev client. GetPackage has data about when each version of a package was published which is necessary for https://github.com/ossf/scorecard/issues/2458 and https://github.com/ossf/scorecard/issues/2458#issuecomment-1318924157.

The PR also restructures the existing structs a bit to reuse parts of them.

More info about GetPackage [here](https://docs.deps.dev/api/v3alpha/#getpackage).

(Is it a bug fix, feature, docs update, something else?)

feature 

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The Deps.dev client cannot retrieve info about when packages have been published.

#### What is the new behavior (if this is a feature change)?**

The Deps.dev client can retrieve info about when packages have been published.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

This is ongoing work for: https://github.com/ossf/scorecard/issues/2458

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
