### PR TITLE
:seedling: limit webhook payload size to 1024 bytes

### DIFF
--- a/cron/internal/webhook/main.go
+++ b/cron/internal/webhook/main.go
@@ -42,6 +42,8 @@ var images = []string{
 func scriptHandler(w http.ResponseWriter, r *http.Request) {
 	switch r.Method {
 	case http.MethodPost:
+		const maxBodySize = 1024 // must be larger than protojson serialized [data.ShardMetadata]
+		r.Body = http.MaxBytesReader(w, r.Body, maxBodySize)
 		jsonBytes, err := io.ReadAll(r.Body)
 		if err != nil {
 			http.Error(w, fmt.Sprintf("unable to read request body: %v", err),


### PR DESCRIPTION
#### What kind of change does this PR introduce?

infra update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The cron webhook will read any size request.

#### What is the new behavior (if this is a feature change)?**
The webhook will read a max of 1KiB. A typical payload is under 150 bytes, and isn't expected to increase without substantial field or bucket renaming:
```
{
    "shardLoc":"gs://ossf-scorecard-data2/2025.07.07/020002/",
    "numShard":133058,
    "commitSha":"bb9c347dff6349d986baab6578a46d68a5524c62"
}
```

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
I did do a small manual test locally:

```shell
$ curl -d '{"shardLoc":"gs://ossf-scorecard-data2/2025.07.07/020002/","numShard":133058,"commitSha":"bb9c347dff6349d986baab6578a46d68a5524c62"}' -H "Content-Type: application/json" -X POST http://localhost:8080/
successfully tagged images
$ curl -d '<more than 1024 bytes....>' -H "Content-Type: application/json" -X POST http://localhost:8080/
unable to read request body: http: request body too large
```
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
