### PR TITLE
🐛 detect dangerous patterns in toJSON() in dangerous workflows

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -52,7 +52,9 @@ func containsUntrustedContextPattern(variable string) bool {
 	if strings.Contains(variable, "github.head_ref") {
 		return true
 	}
-	return strings.Contains(variable, "github.event.") && untrustedContextPattern.MatchString(variable)
+	return strings.Contains(variable, "github.event.") &&
+		(untrustedContextPattern.MatchString(variable) ||
+			untrustedContextPattern.MatchString(fmt.Sprintf("toJSON(%s)", variable)))
 }
 
 type triggerName string

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -17,6 +17,7 @@ package raw
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"os"
 	"testing"
@@ -81,6 +82,12 @@ func TestUntrustedContextVariables(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			if r := containsUntrustedContextPattern(tt.variable); !r == tt.expected {
+				t.Fail()
+			}
+			if r := containsUntrustedContextPattern(fmt.Sprintf("toJSON(%s)", tt.variable)); !r == tt.expected {
+				t.Fail()
+			}
+			if r := containsUntrustedContextPattern(fmt.Sprintf("toJSON(  %s  )", tt.variable)); !r == tt.expected {
 				t.Fail()
 			}
 		})


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Scorecard misses dangerous patterns when they are wrapped in `toJSON()`.

#### What is the new behavior (if this is a feature change)?**

Scorecard detects dangerous patterns when they are wrapped in `toJSON()`.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

https://github.com/ossf/scorecard/issues/3554

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Yes

```release-note
Scorecard detects dangerous workflow patterns when wrapped in `toJSON()`
```
