### PR TITLE
🐛 Update Signed-Releases to support .sigstore.json signatures

### DIFF
--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -191,6 +191,25 @@ func TestSignedRelease(t *testing.T) {
 			},
 		},
 		{
+			name: "Releases with assets with signed artifacts-sigstore-json",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.sigstore.json",
+							URL:  "http://foo.com/v1.0.0/foo.sigstore.json",
+						},
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 8,
+			},
+		},
+		{
 			name: "Releases with assets with signed and unsigned artifacts",
 			releases: []clients.Release{
 				{

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -628,7 +628,7 @@ Signed releases attest to the provenance of the artifact.
 This check looks for the following filenames in the project's last five
 [release assets](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases):
 [*.minisig](https://github.com/jedisct1/minisign), *.asc (pgp),
-*.sig, *.sign, *.sigstore, [*.intoto.jsonl](https://slsa.dev).
+*.sig, *.sign, *.sigstore, *.sigstore.json, [*.intoto.jsonl](https://slsa.dev).
 
 If a signature is found in the assets for each release, a score of 8 is given.
 If a [SLSA provenance file](https://slsa.dev/spec/v0.1/index) is found in the assets for each release (*.intoto.jsonl), the maximum score of 10 is given.

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -667,7 +667,7 @@ checks:
       This check looks for the following filenames in the project's last five
       [release assets](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases):
       [*.minisig](https://github.com/jedisct1/minisign), *.asc (pgp),
-      *.sig, *.sign, *.sigstore, [*.intoto.jsonl](https://slsa.dev).
+      *.sig, *.sign, *.sigstore, *.sigstore.json, [*.intoto.jsonl](https://slsa.dev).
 
       If a signature is found in the assets for each release, a score of 8 is given.
       If a [SLSA provenance file](https://slsa.dev/spec/v0.1/index) is found in the assets for each release (*.intoto.jsonl), the maximum score of 10 is given.

--- a/probes/releasesAreSigned/impl.go
+++ b/probes/releasesAreSigned/impl.go
@@ -41,7 +41,7 @@ const (
 	releaseLookBack = 5
 )
 
-var signatureExtensions = []string{".asc", ".minisig", ".sig", ".sign", ".sigstore"}
+var signatureExtensions = []string{".asc", ".minisig", ".sig", ".sign", ".sigstore", ".sigstore.json"}
 
 func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	if raw == nil {


### PR DESCRIPTION
The offical [sigstore/gh-action-sigstore-python](https://github.com/sigstore/gh-action-sigstore-python) GitHub Action outputs signatures with a `.sigstore.json` suffix that is not detected by Signed-Releases.

This change updates Signed-Releases to support the .sigstore.json suffix, adds a new test, and updates the documentation.

#### What kind of change does this PR introduce?

Bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Signed-Releases does not detect signatures in GitHub release artifacts with the `.sigstore.json` suffix.

#### What is the new behavior (if this is a feature change)?

Signed-Releases detects signatures in GitHub release artifacts with the ".sigstore.json" suffix.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4727.

#### Does this PR introduce a user-facing change?

Yes

```release-note
Signed-Releases now detects signatures ending with `.sigstore.json`
```
