### PR TITLE
:sparkles: Add npm package registry detection to Packaging check

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -85,8 +85,17 @@ type Package struct {
 	Job  *WorkflowJob
 	File *File
 	// Note: Msg is populated only for debug messages.
-	Msg  *string
-	Runs []Run
+	Msg      *string
+	Registry *PackageRegistry
+	Runs     []Run
+}
+
+// PackageRegistry contains information about a package's registry status.
+type PackageRegistry struct {
+	RepositoryURL *string
+	Error         *string
+	Type          string
+	Published     bool
 }
 
 type PackageProvenance struct {

--- a/checks/evaluation/packaging.go
+++ b/checks/evaluation/packaging.go
@@ -19,6 +19,7 @@ import (
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
 	"github.com/ossf/scorecard/v5/probes/packagedWithAutomatedWorkflow"
+	"github.com/ossf/scorecard/v5/probes/packagedWithNpm"
 )
 
 // Packaging applies the score policy for the Packaging check.
@@ -28,6 +29,7 @@ func Packaging(name string,
 ) checker.CheckResult {
 	expectedProbes := []string{
 		packagedWithAutomatedWorkflow.Probe,
+		packagedWithNpm.Probe,
 	}
 
 	if !finding.UniqueProbesEqual(findings, expectedProbes) {
@@ -55,7 +57,7 @@ func Packaging(name string,
 		checker.LogFinding(dl, f, logLevel)
 	}
 	if maxScore {
-		return checker.CreateMaxScoreResult(name, "packaging workflow detected")
+		return checker.CreateMaxScoreResult(name, "packaging (workflow) detected")
 	}
-	return checker.CreateInconclusiveResult(name, "packaging workflow not detected")
+	return checker.CreateInconclusiveResult(name, "packaging (workflow) not detected")
 }

--- a/checks/evaluation/packaging_test.go
+++ b/checks/evaluation/packaging_test.go
@@ -36,10 +36,15 @@ func TestPackaging(t *testing.T) {
 					Probe:   "packagedWithAutomatedWorkflow",
 					Outcome: finding.OutcomeTrue,
 				},
+				{
+					Probe:   "packagedWithNpm",
+					Outcome: finding.OutcomeFalse,
+				},
 			},
 			result: scut.TestReturn{
 				Score:        checker.MaxResultScore,
 				NumberOfInfo: 1,
+				NumberOfWarn: 1,
 			},
 		},
 		{
@@ -56,16 +61,55 @@ func TestPackaging(t *testing.T) {
 			},
 		},
 		{
+			name: "test both probes true outcome",
+			findings: []finding.Finding{
+				{
+					Probe:   "packagedWithAutomatedWorkflow",
+					Outcome: finding.OutcomeTrue,
+				},
+				{
+					Probe:   "packagedWithNpm",
+					Outcome: finding.OutcomeTrue,
+				},
+			},
+			result: scut.TestReturn{
+				Score:        checker.MaxResultScore,
+				NumberOfInfo: 2,
+			},
+		},
+		{
+			name: "test npm true workflow false",
+			findings: []finding.Finding{
+				{
+					Probe:   "packagedWithAutomatedWorkflow",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "packagedWithNpm",
+					Outcome: finding.OutcomeTrue,
+				},
+			},
+			result: scut.TestReturn{
+				Score:        checker.MaxResultScore,
+				NumberOfInfo: 1,
+				NumberOfWarn: 1,
+			},
+		},
+		{
 			name: "test inconclusive outcome",
 			findings: []finding.Finding{
 				{
 					Probe:   "packagedWithAutomatedWorkflow",
 					Outcome: finding.OutcomeFalse,
 				},
+				{
+					Probe:   "packagedWithNpm",
+					Outcome: finding.OutcomeFalse,
+				},
 			},
 			result: scut.TestReturn{
 				Score:        checker.InconclusiveResultScore,
-				NumberOfWarn: 1,
+				NumberOfWarn: 2,
 			},
 		},
 		{

--- a/checks/packaging.go
+++ b/checks/packaging.go
@@ -15,6 +15,8 @@
 package checks
 
 import (
+	"fmt"
+
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/checks/evaluation"
 	"github.com/ossf/scorecard/v5/checks/raw/github"
@@ -99,7 +101,7 @@ func Packaging(c *checker.CheckRequest) checker.CheckResult {
 	return ret
 }
 
-// runIndependentPackagingProbes runs independent probes related to packaging
+// runIndependentPackagingProbes runs independent probes related to packaging.
 func runIndependentPackagingProbes(c *checker.CheckRequest) ([]finding.Finding, error) {
 	var allFindings []finding.Finding
 
@@ -121,7 +123,7 @@ func runIndependentPackagingProbes(c *checker.CheckRequest) ([]finding.Finding, 
 
 		findings, _, err := probe.IndependentImplementation(c)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("probe %s failed: %w", probeName, err)
 		}
 
 		allFindings = append(allFindings, findings...)

--- a/checks/raw/packaging.go
+++ b/checks/raw/packaging.go
@@ -1,0 +1,47 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/internal/packagemanager"
+)
+
+// PackageRegistries checks for packages in various registries (npm, PyPI, etc.).
+// This is platform-independent - it works the same for GitHub, GitLab, or any Git host.
+func PackageRegistries(c *checker.CheckRequest) (checker.PackagingData, error) {
+	var data checker.PackagingData
+
+	registryChecker := packagemanager.NewRegistryChecker()
+	registryPackages, err := registryChecker.CheckAllRegistries(c)
+	if err != nil {
+		// Don't fail the entire check if registry queries fail
+		// Just log the error and continue with empty results
+		pkg := checker.Package{
+			Msg: stringPointer(fmt.Sprintf("Failed to check package registries: %v", err)),
+		}
+		data.Packages = append(data.Packages, pkg)
+		return data, nil
+	}
+
+	data.Packages = registryPackages
+	return data, nil
+}
+
+func stringPointer(s string) *string {
+	return &s
+}

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -396,6 +396,22 @@ The probe returns 1 true outcome if the project has no workflows "write" permiss
 If the project doesn't use automated packaing we can detect, the outcome is negative.
 
 
+## packagedWithNpm
+
+**Lifecycle**: stable
+
+**Description**: Check if the project is published to npm registry
+
+**Motivation**: Packaging a project and publishing it to npm demonstrates that the project maintainers care about distributing the project to users. It shows the project is mature and ready for consumption. Projects published to npm are easily discoverable and installable by users via the npm registry.
+
+**Implementation**: The probe first checks for the presence of a package.json file in the repository root. If found, it parses the file to extract the package name. It then queries the npm registry to verify if the package is actually published and available for installation. The probe also extracts repository information from the npm registry to provide additional context.
+
+**Outcomes**: If the project has a package.json file with a valid name and the package exists on npm registry, the probe returns OutcomeTrue.
+If no package.json file is found, the probe returns OutcomeFalse.
+If package.json exists but the package is not published to npm, the probe returns OutcomeFalse.
+If package.json exists but has invalid JSON or missing name, the probe returns OutcomeFalse.
+
+
 ## pinsDependencies
 
 **Lifecycle**: stable

--- a/e2e/packaging_test.go
+++ b/e2e/packaging_test.go
@@ -45,7 +45,7 @@ var _ = Describe("E2E TEST:"+checks.CheckPackaging, func() {
 			expected := scut.TestReturn{
 				Error:         nil,
 				Score:         checker.InconclusiveResultScore,
-				NumberOfWarn:  1,
+				NumberOfWarn:  2,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}

--- a/internal/packagemanager/npm.go
+++ b/internal/packagemanager/npm.go
@@ -1,0 +1,135 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagemanager
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+)
+
+var errMissingPackageName = errors.New("package.json does not contain a name field")
+
+// NPMRegistry provides npm registry functionality.
+type NPMRegistry struct {
+	client *http.Client
+}
+
+// NewNPMRegistry creates a new NPM registry checker.
+func NewNPMRegistry() *NPMRegistry {
+	return &NPMRegistry{
+		client: &http.Client{
+			Timeout: 10 * time.Second,
+		},
+	}
+}
+
+type npmPackageJSON struct {
+	Repository map[string]string `json:"repository"`
+	Name       string            `json:"name"`
+}
+
+type npmRegistryResponse struct {
+	Repository map[string]string `json:"repository"`
+	Name       string            `json:"name"`
+}
+
+// CheckPackageExists checks if a package exists in the npm registry.
+func (n *NPMRegistry) CheckPackageExists(ctx context.Context, packageName string) (*checker.PackageRegistry, error) {
+	url := fmt.Sprintf("https://registry.npmjs.org/%s", packageName)
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to create request: %v", err)
+		return &checker.PackageRegistry{
+			Type:      "npm",
+			Published: false,
+			Error:     &errMsg,
+		}, nil
+	}
+
+	resp, err := n.client.Do(req)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to query npm registry: %v", err)
+		return &checker.PackageRegistry{
+			Type:      "npm",
+			Published: false,
+			Error:     &errMsg,
+		}, nil
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return &checker.PackageRegistry{
+			Type:      "npm",
+			Published: false,
+		}, nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		errMsg := fmt.Sprintf("npm registry returned status: %d", resp.StatusCode)
+		return &checker.PackageRegistry{
+			Type:      "npm",
+			Published: false,
+			Error:     &errMsg,
+		}, nil
+	}
+
+	var npmResp npmRegistryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&npmResp); err != nil {
+		errMsg := fmt.Sprintf("failed to parse npm registry response: %v", err)
+		return &checker.PackageRegistry{
+			Type:      "npm",
+			Published: false,
+			Error:     &errMsg,
+		}, nil
+	}
+
+	var repoURL *string
+	if npmResp.Repository != nil {
+		if url, ok := npmResp.Repository["url"]; ok {
+			// Clean up git+ prefix and .git suffix
+			cleanURL := strings.TrimPrefix(url, "git+")
+			cleanURL = strings.TrimSuffix(cleanURL, ".git")
+			repoURL = &cleanURL
+		}
+	}
+
+	return &checker.PackageRegistry{
+		Type:          "npm",
+		Published:     true,
+		RepositoryURL: repoURL,
+	}, nil
+}
+
+// ParsePackageJSON parses a package.json file and extracts the package name.
+func ParsePackageJSON(content []byte) (string, error) {
+	var pkg npmPackageJSON
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		return "", fmt.Errorf("failed to parse package.json: %w", err)
+	}
+
+	if pkg.Name == "" {
+		return "", errMissingPackageName
+	}
+
+	return pkg.Name, nil
+}

--- a/internal/packagemanager/registry.go
+++ b/internal/packagemanager/registry.go
@@ -1,0 +1,156 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packagemanager
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+// RegistryChecker provides platform-independent package registry checking.
+type RegistryChecker struct {
+	npmRegistry *NPMRegistry
+	// Future: pypiRegistry *PyPIRegistry
+	// Future: cargoRegistry *CargoRegistry
+}
+
+// NewRegistryChecker creates a new registry checker.
+func NewRegistryChecker() *RegistryChecker {
+	return &RegistryChecker{
+		npmRegistry: NewNPMRegistry(),
+	}
+}
+
+// CheckAllRegistries checks all supported package registries for the given repository.
+func (r *RegistryChecker) CheckAllRegistries(c *checker.CheckRequest) ([]checker.Package, error) {
+	var packages []checker.Package
+
+	// Check npm registry
+	npmPackages, err := r.checkNPMRegistry(c)
+	if err != nil {
+		return nil, fmt.Errorf("npm registry check failed: %w", err)
+	}
+	packages = append(packages, npmPackages...)
+
+	// Future: Add other package managers here
+	// pypiPackages, err := r.checkPyPIRegistry(c)
+	// if err != nil {
+	//     return nil, fmt.Errorf("PyPI registry check failed: %w", err)
+	// }
+	// packages = append(packages, pypiPackages...)
+
+	return packages, nil
+}
+
+// checkNPMRegistry checks for package.json and queries npm registry.
+func (r *RegistryChecker) checkNPMRegistry(c *checker.CheckRequest) ([]checker.Package, error) {
+	var packages []checker.Package
+
+	// Look for package.json files
+	matchedFiles, err := c.RepoClient.ListFiles(func(path string) (bool, error) {
+		return path == "package.json", nil
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to list files: %w", err)
+	}
+
+	if len(matchedFiles) == 0 {
+		// No package.json found - add a debug package indicating no npm package
+		pkg := checker.Package{
+			Msg: stringPointer("No package.json file found"),
+			Registry: &checker.PackageRegistry{
+				Type:      "npm",
+				Published: false,
+			},
+		}
+		packages = append(packages, pkg)
+		return packages, nil
+	}
+
+	// Read and parse package.json
+	reader, err := c.RepoClient.GetFileReader(matchedFiles[0])
+	if err != nil {
+		return nil, fmt.Errorf("failed to read package.json: %w", err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read package.json content: %w", err)
+	}
+
+	packageName, err := ParsePackageJSON(content)
+	if err != nil {
+		// Invalid package.json
+		errMsg := err.Error()
+		pkg := checker.Package{
+			Name: nil,
+			File: &checker.File{
+				Path:   matchedFiles[0],
+				Type:   finding.FileTypeSource,
+				Offset: checker.OffsetDefault,
+			},
+			Msg: stringPointer(fmt.Sprintf("Found package.json but parsing failed: %v", err)),
+			Registry: &checker.PackageRegistry{
+				Type:      "npm",
+				Published: false,
+				Error:     &errMsg,
+			},
+		}
+		packages = append(packages, pkg)
+		return packages, nil
+	}
+
+	// Query npm registry
+	registryInfo, err := r.npmRegistry.CheckPackageExists(c.Ctx, packageName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to check npm registry: %w", err)
+	}
+
+	// Create package with registry information
+	pkg := checker.Package{
+		Name: &packageName,
+		File: &checker.File{
+			Path:   matchedFiles[0],
+			Type:   finding.FileTypeSource,
+			Offset: checker.OffsetDefault,
+		},
+		Registry: registryInfo,
+	}
+
+	// Add appropriate message based on registry status
+	switch {
+	case registryInfo.Published:
+		msg := fmt.Sprintf("Package '%s' is published on npm registry", packageName)
+		if registryInfo.RepositoryURL != nil {
+			msg += fmt.Sprintf(" (repository: %s)", *registryInfo.RepositoryURL)
+		}
+		pkg.Msg = &msg
+	case registryInfo.Error != nil:
+		pkg.Msg = stringPointer(fmt.Sprintf("Package '%s' registry check failed: %s", packageName, *registryInfo.Error))
+	default:
+		pkg.Msg = stringPointer(fmt.Sprintf("Package '%s' not found on npm registry", packageName))
+	}
+
+	packages = append(packages, pkg)
+	return packages, nil
+}
+
+func stringPointer(s string) *string {
+	return &s
+}

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -95,6 +95,7 @@ var (
 	}
 	Packaging = []ProbeImpl{
 		packagedWithAutomatedWorkflow.Run,
+		packagedWithNpm.Run,
 	}
 	License = []ProbeImpl{
 		hasLicenseFile.Run,
@@ -177,7 +178,6 @@ var (
 	// Probes which don't use pre-computed raw data but rather collect it themselves.
 	Independent = []IndependentProbeImpl{
 		unsafeblock.Run,
-		packagedWithNpm.Run,
 	}
 )
 

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -45,6 +45,7 @@ import (
 	"github.com/ossf/scorecard/v5/probes/issueActivityByProjectMember"
 	"github.com/ossf/scorecard/v5/probes/jobLevelPermissions"
 	"github.com/ossf/scorecard/v5/probes/packagedWithAutomatedWorkflow"
+	"github.com/ossf/scorecard/v5/probes/packagedWithNpm"
 	"github.com/ossf/scorecard/v5/probes/pinsDependencies"
 	"github.com/ossf/scorecard/v5/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveProvenance"
@@ -176,6 +177,7 @@ var (
 	// Probes which don't use pre-computed raw data but rather collect it themselves.
 	Independent = []IndependentProbeImpl{
 		unsafeblock.Run,
+		packagedWithNpm.Run,
 	}
 )
 

--- a/probes/packagedWithNpm/def.yml
+++ b/probes/packagedWithNpm/def.yml
@@ -1,0 +1,52 @@
+# Copyright 2025 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: packagedWithNpm
+lifecycle: stable
+short: Check if the project is published to npm registry
+motivation: >
+  Packaging a project and publishing it to npm demonstrates that the project maintainers
+  care about distributing the project to users. It shows the project
+  is mature and ready for consumption. Projects published to npm
+  are easily discoverable and installable by users via the npm registry.
+implementation: >
+  The probe first checks for the presence of a package.json file in the repository root.
+  If found, it parses the file to extract the package name. It then queries the npm
+  registry to verify if the package is actually published and available for installation.
+  The probe also extracts repository information from the npm registry to provide
+  additional context.
+outcome:
+  - If the project has a package.json file with a valid name and the package exists on npm registry, the probe returns OutcomeTrue.
+  - If no package.json file is found, the probe returns OutcomeFalse.
+  - If package.json exists but the package is not published to npm, the probe returns OutcomeFalse.
+  - If package.json exists but has invalid JSON or missing name, the probe returns OutcomeFalse.
+remediation:
+  onOutcome: False
+  effort: Medium
+  text:
+    - Create a package.json file in your repository root with appropriate metadata including a unique package name.
+    - Publish your package to npm registry using 'npm publish' command.
+    - Ensure your package name is not already taken on npm registry.
+  markdown:
+    - Create a `package.json` file in your repository root with appropriate metadata including a unique package name.
+    - Publish your package to npm registry using `npm publish` command.
+    - Ensure your package name is not already taken on npm registry.
+ecosystem:
+  languages:
+    - javascript
+    - typescript
+  clients:
+    - github
+    - gitlab
+    - localdir

--- a/probes/packagedWithNpm/impl.go
+++ b/probes/packagedWithNpm/impl.go
@@ -1,0 +1,210 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:stylecheck
+package packagedWithNpm
+
+import (
+	"embed"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/probes"
+)
+
+func init() {
+	probes.MustRegisterIndependent(Probe, Run)
+}
+
+//go:embed *.yml
+var fs embed.FS
+
+const Probe = "packagedWithNpm"
+
+type packageJSON struct {
+	Name       string            `json:"name"`
+	Repository map[string]string `json:"repository"`
+}
+
+type npmRegistryResponse struct {
+	Name       string            `json:"name"`
+	Repository map[string]string `json:"repository"`
+}
+
+func Run(c *checker.CheckRequest) ([]finding.Finding, string, error) {
+	if c == nil {
+		return nil, "", fmt.Errorf("nil check request")
+	}
+
+	var findings []finding.Finding
+
+	// Check if package.json exists in the repository root
+	matchedFiles, err := c.RepoClient.ListFiles(func(path string) (bool, error) {
+		return path == "package.json", nil
+	})
+	if err != nil {
+		return nil, Probe, fmt.Errorf("failed to list files: %w", err)
+	}
+
+	if len(matchedFiles) == 0 {
+		// No package.json found
+		f, err := finding.NewWith(fs, Probe,
+			"No package.json file found. Project does not appear to be an npm package.", nil,
+			finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+
+		return []finding.Finding{*f}, Probe, nil
+	}
+
+	// Read package.json file
+	reader, err := c.RepoClient.GetFileReader(matchedFiles[0])
+	if err != nil {
+		return nil, Probe, fmt.Errorf("failed to read package.json: %w", err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("failed to read package.json content: %w", err)
+	}
+
+	var pkg packageJSON
+	if err := json.Unmarshal(content, &pkg); err != nil {
+		f, err := finding.NewWith(fs, Probe,
+			"Found package.json but failed to parse it. Invalid JSON format.", nil,
+			finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		loc := &finding.Location{
+			Path: matchedFiles[0],
+			Type: finding.FileTypeSource,
+		}
+		f = f.WithLocation(loc)
+		return []finding.Finding{*f}, Probe, nil
+	}
+
+	if pkg.Name == "" {
+		f, err := finding.NewWith(fs, Probe,
+			"Found package.json but no package name specified.", nil,
+			finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		loc := &finding.Location{
+			Path: matchedFiles[0],
+			Type: finding.FileTypeSource,
+		}
+		f = f.WithLocation(loc)
+		return []finding.Finding{*f}, Probe, nil
+	}
+
+	// Check if package exists on npm registry
+	exists, repoURL, err := checkNpmPackageExists(pkg.Name)
+	if err != nil {
+		f, err := finding.NewWith(fs, Probe,
+			fmt.Sprintf("Found package.json with name '%s' but failed to check npm registry: %v", pkg.Name, err), nil,
+			finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		loc := &finding.Location{
+			Path: matchedFiles[0],
+			Type: finding.FileTypeSource,
+		}
+		f = f.WithLocation(loc)
+		return []finding.Finding{*f}, Probe, nil
+	}
+
+	if !exists {
+		f, err := finding.NewWith(fs, Probe,
+			fmt.Sprintf("Package '%s' not found on npm registry. Project is not published to npm.", pkg.Name), nil,
+			finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		loc := &finding.Location{
+			Path: matchedFiles[0],
+			Type: finding.FileTypeSource,
+		}
+		f = f.WithLocation(loc)
+		return []finding.Finding{*f}, Probe, nil
+	}
+
+	// Package exists on npm
+	message := fmt.Sprintf("Package '%s' is published on npm registry.", pkg.Name)
+	if repoURL != "" {
+		message += fmt.Sprintf(" Repository URL: %s", repoURL)
+	}
+
+	f, err := finding.NewWith(fs, Probe, message, nil, finding.OutcomeTrue)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("create finding: %w", err)
+	}
+
+	loc := &finding.Location{
+		Path: matchedFiles[0],
+		Type: finding.FileTypeSource,
+	}
+	f = f.WithLocation(loc)
+	findings = append(findings, *f)
+
+	return findings, Probe, nil
+}
+
+func checkNpmPackageExists(packageName string) (bool, string, error) {
+	url := fmt.Sprintf("https://registry.npmjs.org/%s", packageName)
+
+	client := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
+	resp, err := client.Get(url)
+	if err != nil {
+		return false, "", fmt.Errorf("failed to query npm registry: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == http.StatusNotFound {
+		return false, "", nil
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return false, "", fmt.Errorf("npm registry returned status: %d", resp.StatusCode)
+	}
+
+	var npmResp npmRegistryResponse
+	if err := json.NewDecoder(resp.Body).Decode(&npmResp); err != nil {
+		return false, "", fmt.Errorf("failed to parse npm registry response: %w", err)
+	}
+
+	repoURL := ""
+	if npmResp.Repository != nil {
+		if url, ok := npmResp.Repository["url"]; ok {
+			// Clean up git+ prefix and .git suffix
+			repoURL = strings.TrimPrefix(url, "git+")
+			repoURL = strings.TrimSuffix(repoURL, ".git")
+		}
+	}
+
+	return true, repoURL, nil
+}

--- a/probes/packagedWithNpm/impl_test.go
+++ b/probes/packagedWithNpm/impl_test.go
@@ -1,0 +1,154 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//nolint:stylecheck
+package packagedWithNpm
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ossf/scorecard/v5/checker"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+type nopCloser struct {
+	io.Reader
+}
+
+func (nopCloser) Close() error { return nil }
+
+func Test_Run(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		files          []string
+		packageContent string
+		outcomes       []finding.Outcome
+		err            string
+		expectError    bool
+		expectFileRead bool
+	}{
+		{
+			name:        "nil check request",
+			expectError: true,
+			err:         "nil check request",
+		},
+		{
+			name:     "no package.json found",
+			files:    []string{"src/main.js", "README.md"},
+			outcomes: []finding.Outcome{finding.OutcomeFalse},
+		},
+		{
+			name:     "package.json in subdirectory (should not match)",
+			files:    []string{"frontend/package.json", "README.md"},
+			outcomes: []finding.Outcome{finding.OutcomeFalse},
+		},
+		{
+			name:           "package.json with invalid JSON",
+			files:          []string{"package.json"},
+			packageContent: `{"name": "test-package",`,
+			outcomes:       []finding.Outcome{finding.OutcomeFalse},
+			expectFileRead: true,
+		},
+		{
+			name:           "package.json without name",
+			files:          []string{"package.json"},
+			packageContent: `{"version": "1.0.0"}`,
+			outcomes:       []finding.Outcome{finding.OutcomeFalse},
+			expectFileRead: true,
+		},
+		{
+			name:           "package.json with empty name",
+			files:          []string{"package.json"},
+			packageContent: `{"name": "", "version": "1.0.0"}`,
+			outcomes:       []finding.Outcome{finding.OutcomeFalse},
+			expectFileRead: true,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var request *checker.CheckRequest
+			if !tt.expectError {
+				ctrl := gomock.NewController(t)
+				defer ctrl.Finish()
+				mockClient := mockrepo.NewMockRepoClient(ctrl)
+
+				// Set up expectations for ListFiles call
+				mockClient.EXPECT().ListFiles(gomock.Any()).DoAndReturn(func(predicate func(string) (bool, error)) ([]string, error) {
+					var matchedFiles []string
+					for _, file := range tt.files {
+						match, err := predicate(file)
+						if err != nil {
+							return nil, err
+						}
+						if match {
+							matchedFiles = append(matchedFiles, file)
+						}
+					}
+					return matchedFiles, nil
+				})
+
+				// Set up expectations for file reading if needed
+				if tt.expectFileRead {
+					reader := nopCloser{strings.NewReader(tt.packageContent)}
+					mockClient.EXPECT().GetFileReader("package.json").Return(reader, nil)
+				}
+
+				request = &checker.CheckRequest{
+					RepoClient: mockClient,
+				}
+			}
+
+			findings, s, err := Run(request)
+			if tt.expectError {
+				if err == nil {
+					t.Errorf("expected error %q, got nil", tt.err)
+				} else if err.Error() != tt.err {
+					t.Errorf("expected error %q, got %q", tt.err, err.Error())
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+			if s != Probe {
+				t.Errorf("expected probe name %q, got %q", Probe, s)
+			}
+			if len(findings) != len(tt.outcomes) {
+				t.Errorf("expected %d findings, got %d", len(tt.outcomes), len(findings))
+				return
+			}
+			for i, f := range findings {
+				if i >= len(tt.outcomes) {
+					break
+				}
+				if diff := cmp.Diff(tt.outcomes[i], f.Outcome, cmpopts.EquateEmpty()); diff != "" {
+					t.Errorf("mismatch (-want +got):\n%s", diff)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

It's a feature.
(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The Packaging check currently only detects packaging workflows in GitHub Actions pipelines.

#### What is the new behavior (if this is a feature change)?**

 This change adds a new `packagedWithNpm` probe that performs actual npm registry verification:

  1. Find package.json: Searches for package.json file in repository root
  2. Parse package metadata: Extracts the package name from the JSON file
  3. Query npm registry: Makes HTTP request to https://registry.npmjs.org/{package-name}
  4. Verify package exists: Confirms the package is actually published and available for installation
  5. Extract repository info: Retrieves repository URL from npm registry for cross-reference.
 
- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #688

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Yes, it will change the packaging check score for repos that published their package in npm.

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
feat: Add npm package registry detection to Packaging check.
```
