### PR TITLE
📖 Added a note explaining if you get a runtime error for Branch Protection

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -194,6 +194,10 @@ For public repos, classic personal access tokens need the following scopes:
 
 - `public_repo` - Read/write access to public repositories. Needed for branch protection
 
+Note: The `branch-protection` internal error will appear if a Personal Access Token (PAT) is not provided, because the default GitHub token lacks the necessary admin permissions to access certain branch protection settings.
+
+You can find instructions for setting the token in the README under Using Scorecard – Authentication.
+
 ## Where the CI Tests are configured
 
 1.  See the [action files](.github/workflows) to check its tests, and the


### PR DESCRIPTION
#### What kind of change does this PR introduce?
This PR introduce a doc update.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
In the documentation in the CONTRIBUTING.md under Permission for GitHub personal access tokens, it doesn't have a clear warning telling people that if you get a runtime error, it because you didn't put in your personal access token.
#### What is the new behavior (if this is a feature change)?
Added a note explaining that you will need to put in a personal access token if the user gets that error. Also where to look for the command to implement the access token.
- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
#2946 
