### PR TITLE
:sparkles: add support for Claude Code Security Reviewer SAST

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -288,6 +288,8 @@ const (
 	QodanaWorkflow SASTWorkflowType = "Qodana"
 	// HadolintWorkflow represents a workflow that runs Hadolint.
 	HadolintWorkflow SASTWorkflowType = "Hadolint"
+	// ClaudeCodeSecurityWorkflow represents a workflow that runs Claude Code Security Reviewer.
+	ClaudeCodeSecurityWorkflow SASTWorkflowType = "Claude Code Security"
 )
 
 // SASTWorkflow represents a SAST workflow.

--- a/checks/evaluation/sast_test.go
+++ b/checks/evaluation/sast_test.go
@@ -65,7 +65,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: "Pysa is installed. CodeQL, Snyk, Qodana and Sonar are not installed.",
+			name: "Pysa is installed. No other SAST tools are installed.",
 			findings: []finding.Finding{
 				tool(checker.PysaWorkflow),
 				{
@@ -84,7 +84,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: `Sonar is installed. CodeQL, Snyk, Pysa, Qodana are not installed.
+			name: `Sonar is installed. No other SAST tools are installed.
 					Does not have info about whether SAST runs
 					on every commit.`,
 			findings: []finding.Finding{
@@ -101,7 +101,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: "Sonar, CodeQL, Snyk, Qodana and Pysa are not installed",
+			name: "No SAST tools are installed",
 			findings: []finding.Finding{
 				{
 					Probe:   sastToolConfigured.Probe,
@@ -123,7 +123,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: "Snyk is installed, Sonar, Qodana and CodeQL are not installed",
+			name: "Snyk is installed, no other SAST tools are installed",
 			findings: []finding.Finding{
 				tool(checker.SnykWorkflow),
 				{
@@ -142,7 +142,7 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
-			name: "Qodana is installed, Snyk, Sonar, and CodeQL are not installed",
+			name: "Qodana is installed, no other SAST tools are installed",
 			findings: []finding.Finding{
 				tool(checker.QodanaWorkflow),
 				{
@@ -164,6 +164,25 @@ func TestSAST(t *testing.T) {
 			name: "Hadolint is installed, no other SAST tools are installed",
 			findings: []finding.Finding{
 				tool(checker.HadolintWorkflow),
+				{
+					Probe:   sastToolRunsOnAllCommits.Probe,
+					Outcome: finding.OutcomeTrue,
+					Values: map[string]string{
+						sastToolRunsOnAllCommits.AnalyzedPRsKey: "1",
+						sastToolRunsOnAllCommits.TotalPRsKey:    "3",
+					},
+				},
+			},
+			result: scut.TestReturn{
+				Score:        10,
+				NumberOfWarn: 0,
+				NumberOfInfo: 2,
+			},
+		},
+		{
+			name: "Claude Code Security is installed, no other SAST tools are installed",
+			findings: []finding.Finding{
+				tool(checker.ClaudeCodeSecurityWorkflow),
 				{
 					Probe:   sastToolRunsOnAllCommits.Probe,
 					Outcome: finding.OutcomeTrue,

--- a/checks/raw/sast.go
+++ b/checks/raw/sast.go
@@ -93,6 +93,13 @@ func SAST(c *checker.CheckRequest) (checker.SASTData, error) {
 	}
 	data.Workflows = append(data.Workflows, hadolintWorkflows...)
 
+	claudeCodeSecurityWorkflows, err := getSastUsesWorkflows(
+		c, "^anthropics/claude-code-security-review$", checker.ClaudeCodeSecurityWorkflow)
+	if err != nil {
+		return data, err
+	}
+	data.Workflows = append(data.Workflows, claudeCodeSecurityWorkflows...)
+
 	return data, nil
 }
 

--- a/checks/raw/sast_test.go
+++ b/checks/raw/sast_test.go
@@ -271,6 +271,29 @@ func TestSAST(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "Has Claude Code Security Reviewer",
+			files: []string{".github/workflows/github-claude-code-security.yaml"},
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number: 1,
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Workflows: []checker.SASTWorkflow{
+					{
+						Type: checker.ClaudeCodeSecurityWorkflow,
+						File: checker.File{
+							Path:   ".github/workflows/github-claude-code-security.yaml",
+							Offset: checker.OffsetDefault,
+							Type:   finding.FileTypeSource,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/raw/testdata/.github/workflows/github-claude-code-security.yaml
+++ b/checks/raw/testdata/.github/workflows/github-claude-code-security.yaml
@@ -1,0 +1,22 @@
+name: Security Review
+
+permissions:
+  pull-requests: write  # Needed for leaving PR comments
+  contents: read
+
+on:
+  pull_request:
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          fetch-depth: 2
+
+      - uses: anthropics/claude-code-security-review@main
+        with:
+          comment-pr: true
+          claude-api-key: ${{ secrets.CLAUDE_API_KEY }}

--- a/docs/checks/sast/README.md
+++ b/docs/checks/sast/README.md
@@ -1,4 +1,6 @@
 # Supported Tools
+* [Claude Code Security Reviewer](https://github.com/anthropics/claude-code-security-review)
+  * Detection is based on GitHub workflows using `anthropics/claude-code-security-review`.
 * [CodeQL](https://docs.github.com/code-security/code-scanning/enabling-code-scanning/configuring-default-setup-for-code-scanning)
   * Detection is based on GitHub workflows using `github/codeql-action/analyze`, or GitHub Action checks run against PRs.
 * [Qodona](https://github.com/JetBrains/qodana-action)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Feature: support for [Claude Code Security Reviewer](https://github.com/anthropics/claude-code-security-review) SAST.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

This tool is not detected.

#### What is the new behavior (if this is a feature change)?**

Claude Code Security Reviewer counts as a SAST tool.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

N/A

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Support Claude Code Security Reviewer SAST.
```
