### PR TITLE
🌱 Add tagsHandler to githubrepo client

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -29,6 +29,7 @@ import (
 type RawResults struct {
 	BinaryArtifactResults       BinaryArtifactData
 	BranchProtectionResults     BranchProtectionsData
+	TagProtectionResults        TagProtectionsData
 	CIIBestPracticesResults     CIIBestPracticesData
 	CITestResults               CITestData
 	CodeReviewResults           CodeReviewData
@@ -332,7 +333,14 @@ type WebhooksData struct {
 // BranchProtectionsData contains the raw results
 // for the Branch-Protection check.
 type BranchProtectionsData struct {
-	Branches        []clients.BranchRef
+	Branches        []clients.RepoRef
+	CodeownersFiles []string
+}
+
+// TagProtectionsData contains the raw results
+// for the Tag-Protection check.
+type TagProtectionsData struct {
+	Tags            []clients.RepoRef
 	CodeownersFiles []string
 }
 

--- a/checks/branch_protection_test.go
+++ b/checks/branch_protection_test.go
@@ -26,14 +26,14 @@ import (
 	scut "github.com/ossf/scorecard/v5/utests"
 )
 
-func getBranchName(branch *clients.BranchRef) string {
+func getBranchName(branch *clients.RepoRef) string {
 	if branch == nil || branch.Name == nil {
 		return ""
 	}
 	return *branch.Name
 }
 
-func getBranch(branches []*clients.BranchRef, name string, isNonAdmin bool) *clients.BranchRef {
+func getBranch(branches []*clients.RepoRef, name string, isNonAdmin bool) *clients.RepoRef {
 	for _, branch := range branches {
 		branchName := getBranchName(branch)
 		if branchName == name {
@@ -46,9 +46,9 @@ func getBranch(branches []*clients.BranchRef, name string, isNonAdmin bool) *cli
 	return nil
 }
 
-func scrubBranch(branch *clients.BranchRef) *clients.BranchRef {
+func scrubBranch(branch *clients.RepoRef) *clients.RepoRef {
 	ret := branch
-	ret.BranchProtectionRule = clients.BranchProtectionRule{}
+	ret.ProtectionRule = clients.ProtectionRule{}
 	return ret
 }
 
@@ -67,7 +67,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 	tests := []struct {
 		name          string
 		defaultBranch string
-		branches      []*clients.BranchRef
+		branches      []*clients.RepoRef
 		releases      []string
 		repoFiles     []string
 		expected      scut.TestReturn
@@ -83,10 +83,10 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
-			branches: []*clients.BranchRef{
+			branches: []*clients.RepoRef{
 				{
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &trueVal,
@@ -106,7 +106,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				},
 				{
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &falseVal,
@@ -138,7 +138,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
-			branches: []*clients.BranchRef{
+			branches: []*clients.RepoRef{
 				{
 					Name:      &rel1,
 					Protected: &falseVal,
@@ -146,7 +146,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				{
 					Name:      &main,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &falseVal,
@@ -178,11 +178,11 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
-			branches: []*clients.BranchRef{
+			branches: []*clients.RepoRef{
 				{
 					Name:      &main,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &trueVal,
@@ -204,7 +204,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				{
 					Name:      &rel1,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &falseVal,
@@ -236,11 +236,11 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				NumberOfDebug: 0,
 			},
 			defaultBranch: main,
-			branches: []*clients.BranchRef{
+			branches: []*clients.RepoRef{
 				{
 					Name:      &main,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &trueVal,
@@ -262,7 +262,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				{
 					Name:      &rel1,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &trueVal,
@@ -295,11 +295,11 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			},
 			defaultBranch: main,
 			releases:      []string{sha},
-			branches: []*clients.BranchRef{
+			branches: []*clients.RepoRef{
 				{
 					Name:      &main,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &falseVal,
@@ -334,11 +334,11 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			},
 			defaultBranch: main,
 			releases:      []string{""},
-			branches: []*clients.BranchRef{
+			branches: []*clients.RepoRef{
 				{
 					Name:      &main,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &falseVal,
@@ -371,11 +371,11 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			defaultBranch: main,
 			// branches:      []*string{&rel1, &main},
 			releases: []string{rel1},
-			branches: []*clients.BranchRef{
+			branches: []*clients.RepoRef{
 				{
 					Name:      &main,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &trueVal,
@@ -386,7 +386,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 				{
 					Name:      &rel1,
 					Protected: &trueVal,
-					BranchProtectionRule: clients.BranchProtectionRule{
+					ProtectionRule: clients.ProtectionRule{
 						CheckRules: clients.StatusChecksRule{
 							RequiresStatusChecks: &trueVal,
 							UpToDateBeforeMerge:  &trueVal,
@@ -405,7 +405,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
 			mockRepoClient.EXPECT().GetDefaultBranch().
-				DoAndReturn(func() (*clients.BranchRef, error) {
+				DoAndReturn(func() (*clients.RepoRef, error) {
 					defaultBranch := getBranch(tt.branches, tt.defaultBranch, tt.nonadmin)
 					return defaultBranch, nil
 				}).AnyTimes()
@@ -420,7 +420,7 @@ func TestReleaseAndDevBranchProtected(t *testing.T) {
 					return ret, nil
 				}).AnyTimes()
 			mockRepoClient.EXPECT().GetBranch(gomock.Any()).
-				DoAndReturn(func(b string) (*clients.BranchRef, error) {
+				DoAndReturn(func(b string) (*clients.RepoRef, error) {
 					return getBranch(tt.branches, b, tt.nonadmin), nil
 				}).AnyTimes()
 			mockRepoClient.EXPECT().ListFiles(gomock.Any()).AnyTimes().Return(tt.repoFiles, nil)

--- a/checks/permissions_test.go
+++ b/checks/permissions_test.go
@@ -434,7 +434,7 @@ func TestGithubTokenPermissions(t *testing.T) {
 
 			main := "main"
 			mockRepo.EXPECT().URI().Return("github.com/ossf/scorecard").AnyTimes()
-			mockRepo.EXPECT().GetDefaultBranch().Return(&clients.BranchRef{Name: &main}, nil).AnyTimes()
+			mockRepo.EXPECT().GetDefaultBranch().Return(&clients.RepoRef{Name: &main}, nil).AnyTimes()
 			mockRepo.EXPECT().ListFiles(gomock.Any()).DoAndReturn(func(predicate func(string) (bool, error)) ([]string, error) {
 				files := []string{}
 				for _, fn := range tt.filenames {

--- a/checks/raw/branch_protection.go
+++ b/checks/raw/branch_protection.go
@@ -31,10 +31,10 @@ var commit = regexp.MustCompile("^[a-f0-9]{40}$")
 
 type branchSet struct {
 	exists map[string]bool
-	set    []clients.BranchRef
+	set    []clients.RepoRef
 }
 
-func (set *branchSet) add(branch *clients.BranchRef) bool {
+func (set *branchSet) add(branch *clients.RepoRef) bool {
 	if branch != nil &&
 		branch.Name != nil &&
 		*branch.Name != "" &&

--- a/checks/raw/branch_protection_test.go
+++ b/checks/raw/branch_protection_test.go
@@ -37,13 +37,13 @@ var (
 type branchArg struct {
 	err           error
 	name          string
-	branchRef     *clients.BranchRef
+	branchRef     *clients.RepoRef
 	defaultBranch bool
 }
 
 type branchesArg []branchArg
 
-func (ba branchesArg) getDefaultBranch() (*clients.BranchRef, error) {
+func (ba branchesArg) getDefaultBranch() (*clients.RepoRef, error) {
 	for _, branch := range ba {
 		if branch.defaultBranch {
 			return branch.branchRef, branch.err
@@ -52,7 +52,7 @@ func (ba branchesArg) getDefaultBranch() (*clients.BranchRef, error) {
 	return nil, nil
 }
 
-func (ba branchesArg) getBranch(b string) (*clients.BranchRef, error) {
+func (ba branchesArg) getBranch(b string) (*clients.RepoRef, error) {
 	for _, branch := range ba {
 		if branch.name == b {
 			return branch.branchRef, branch.err
@@ -104,13 +104,13 @@ func TestBranchProtection(t *testing.T) {
 				{
 					name:          defaultBranchName,
 					defaultBranch: true,
-					branchRef: &clients.BranchRef{
+					branchRef: &clients.RepoRef{
 						Name: &defaultBranchName,
 					},
 				},
 			},
 			want: checker.BranchProtectionsData{
-				Branches: []clients.BranchRef{
+				Branches: []clients.RepoRef{
 					{
 						Name: &defaultBranchName,
 					},
@@ -180,13 +180,13 @@ func TestBranchProtection(t *testing.T) {
 			branches: branchesArg{
 				{
 					name: releaseBranchName,
-					branchRef: &clients.BranchRef{
+					branchRef: &clients.RepoRef{
 						Name: &releaseBranchName,
 					},
 				},
 			},
 			want: checker.BranchProtectionsData{
-				Branches: []clients.BranchRef{
+				Branches: []clients.RepoRef{
 					{
 						Name: &releaseBranchName,
 					},
@@ -204,13 +204,13 @@ func TestBranchProtection(t *testing.T) {
 			branches: branchesArg{
 				{
 					name: mainBranchName,
-					branchRef: &clients.BranchRef{
+					branchRef: &clients.RepoRef{
 						Name: &mainBranchName,
 					},
 				},
 			},
 			want: checker.BranchProtectionsData{
-				Branches: []clients.BranchRef{
+				Branches: []clients.RepoRef{
 					{
 						Name: &mainBranchName,
 					},
@@ -229,19 +229,19 @@ func TestBranchProtection(t *testing.T) {
 				{
 					name:          defaultBranchName,
 					defaultBranch: true,
-					branchRef: &clients.BranchRef{
+					branchRef: &clients.RepoRef{
 						Name: &defaultBranchName,
 					},
 				},
 				{
 					name: releaseBranchName,
-					branchRef: &clients.BranchRef{
+					branchRef: &clients.RepoRef{
 						Name: &releaseBranchName,
 					},
 				},
 			},
 			want: checker.BranchProtectionsData{
-				Branches: []clients.BranchRef{
+				Branches: []clients.RepoRef{
 					{
 						Name: &defaultBranchName,
 					},
@@ -260,11 +260,11 @@ func TestBranchProtection(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
 			mockRepoClient.EXPECT().GetDefaultBranch().
-				AnyTimes().DoAndReturn(func() (*clients.BranchRef, error) {
+				AnyTimes().DoAndReturn(func() (*clients.RepoRef, error) {
 				return tt.branches.getDefaultBranch()
 			})
 			mockRepoClient.EXPECT().GetBranch(gomock.Any()).AnyTimes().
-				DoAndReturn(func(branch string) (*clients.BranchRef, error) {
+				DoAndReturn(func(branch string) (*clients.RepoRef, error) {
 					return tt.branches.getBranch(branch)
 				})
 			mockRepoClient.EXPECT().ListReleases().AnyTimes().

--- a/checks/raw/tag_protection.go
+++ b/checks/raw/tag_protection.go
@@ -1,0 +1,71 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+type tagSet struct {
+	exists map[string]bool
+	set    []clients.RepoRef
+}
+
+func (set *tagSet) add(tag *clients.RepoRef) bool {
+	if tag != nil &&
+		tag.Name != nil &&
+		*tag.Name != "" &&
+		!set.exists[*tag.Name] {
+		set.set = append(set.set, *tag)
+		set.exists[*tag.Name] = true
+		return true
+	}
+	return false
+}
+
+// TagProtection retrieves the raw data for the Tag-Protection check.
+func TagProtection(cr *checker.CheckRequest) (checker.TagProtectionsData, error) {
+	c := cr.RepoClient
+	tags := tagSet{
+		exists: make(map[string]bool),
+	}
+	repoTags, err := c.ListTags()
+	if err != nil && !errors.Is(err, clients.ErrUnsupportedFeature) {
+		return checker.TagProtectionsData{}, fmt.Errorf("%w", err)
+	}
+	for _, tag := range repoTags {
+		tagRef, err := c.GetTag(*tag.Name)
+		if err != nil {
+			return checker.TagProtectionsData{},
+				fmt.Errorf("error during GetTag(): %w", err)
+		}
+		tags.add(tagRef)
+	}
+
+	codeownersFiles := []string{}
+	if err := collectCodeownersFiles(c, &codeownersFiles); err != nil {
+		return checker.TagProtectionsData{}, err
+	}
+
+	// No error, return the data.
+	return checker.TagProtectionsData{
+		Tags:            tags.set,
+		CodeownersFiles: codeownersFiles,
+	}, nil
+}

--- a/checks/raw/tag_protection_test.go
+++ b/checks/raw/tag_protection_test.go
@@ -1,0 +1,116 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
+)
+
+var tagv01 = "v01"
+
+//nolint:govet
+type tagArg struct {
+	err    error
+	name   string
+	tagRef *clients.RepoRef
+}
+
+type tagsArg []tagArg
+
+func (ba tagsArg) getTag(b string) (*clients.RepoRef, error) {
+	for _, tag := range ba {
+		if tag.name == b {
+			return tag.tagRef, tag.err
+		}
+	}
+	return nil, nil
+}
+
+func TestTagProtection(t *testing.T) {
+	t.Parallel()
+	//nolint:govet
+	tests := []struct {
+		name        string
+		tags        tagsArg
+		repoFiles   []string
+		repoTags    []*clients.RepoRef
+		releasesErr error
+		want        checker.TagProtectionsData
+		wantErr     error
+	}{
+		{
+			name: "v01",
+			repoTags: []*clients.RepoRef{
+				{
+					Name: &tagv01,
+				},
+			},
+			tags: tagsArg{
+				{
+					name: "v01",
+					tagRef: &clients.RepoRef{
+						Name: &tagv01,
+					},
+				},
+			},
+			want: checker.TagProtectionsData{
+				Tags: []clients.RepoRef{
+					{
+						Name: &tagv01,
+					},
+				},
+				CodeownersFiles: []string{},
+			},
+			releasesErr: nil,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+			mockRepoClient.EXPECT().GetTag(gomock.Any()).AnyTimes().
+				DoAndReturn(func(tag string) (*clients.RepoRef, error) {
+					return tt.tags.getTag(tag)
+				})
+			mockRepoClient.EXPECT().ListTags().AnyTimes().
+				DoAndReturn(func() ([]*clients.RepoRef, error) {
+					return tt.repoTags, tt.releasesErr
+				})
+			mockRepoClient.EXPECT().ListFiles(gomock.Any()).AnyTimes().Return(tt.repoFiles, nil)
+
+			c := &checker.CheckRequest{
+				RepoClient: mockRepoClient,
+			}
+			rawData, err := TagProtection(c)
+			if !errors.Is(err, tt.wantErr) {
+				t.Errorf("failed. expected: %v, got: %v", tt.wantErr, err)
+				t.Fail()
+			}
+			if !cmp.Equal(rawData, tt.want) {
+				t.Errorf("failed. expected: %v, got: %v", tt.want, rawData)
+				t.Fail()
+			}
+		})
+	}
+}

--- a/clients/azuredevopsrepo/branches.go
+++ b/clients/azuredevopsrepo/branches.go
@@ -31,7 +31,7 @@ type branchesHandler struct {
 	once                    *sync.Once
 	errSetup                error
 	repourl                 *Repo
-	defaultBranchRef        *clients.BranchRef
+	defaultBranchRef        *clients.RepoRef
 	queryBranch             fnQueryBranch
 	getPolicyConfigurations fnGetPolicyConfigurations
 }
@@ -64,7 +64,7 @@ func (b *branchesHandler) setup() error {
 			b.errSetup = fmt.Errorf("request for default branch failed with error %w", err)
 			return
 		}
-		b.defaultBranchRef = &clients.BranchRef{
+		b.defaultBranchRef = &clients.RepoRef{
 			Name: branch.Name,
 		}
 
@@ -73,7 +73,7 @@ func (b *branchesHandler) setup() error {
 	return b.errSetup
 }
 
-func (b *branchesHandler) getDefaultBranch() (*clients.BranchRef, error) {
+func (b *branchesHandler) getDefaultBranch() (*clients.RepoRef, error) {
 	if err := b.setup(); err != nil {
 		return nil, fmt.Errorf("error during branchesHandler.setup: %w", err)
 	}
@@ -81,7 +81,7 @@ func (b *branchesHandler) getDefaultBranch() (*clients.BranchRef, error) {
 	return b.defaultBranchRef, nil
 }
 
-func (b *branchesHandler) getBranch(branchName string) (*clients.BranchRef, error) {
+func (b *branchesHandler) getBranch(branchName string) (*clients.RepoRef, error) {
 	branch, err := b.queryBranch(b.ctx, git.GetBranchArgs{
 		RepositoryId: &b.repourl.id,
 		Name:         &branchName,
@@ -110,7 +110,7 @@ func (b *branchesHandler) getBranch(branchName string) (*clients.BranchRef, erro
 	}
 
 	// TODO: map Azure DevOps branch protection to Scorecard branch protection
-	return &clients.BranchRef{
+	return &clients.RepoRef{
 		Name:      branch.Name,
 		Protected: &isBranchProtected,
 	}, nil

--- a/clients/azuredevopsrepo/branches_test.go
+++ b/clients/azuredevopsrepo/branches_test.go
@@ -81,7 +81,7 @@ func Test_getBranch(t *testing.T) {
 	tests := []struct {
 		getBranch               fnQueryBranch
 		getPolicyConfigurations fnGetPolicyConfigurations
-		expected                *clients.BranchRef
+		expected                *clients.RepoRef
 		name                    string
 		branchName              string
 		expectedError           bool
@@ -97,7 +97,7 @@ func Test_getBranch(t *testing.T) {
 					PolicyConfigurations: &[]policy.PolicyConfiguration{},
 				}, nil
 			},
-			expected: &clients.BranchRef{
+			expected: &clients.RepoRef{
 				Name:      toPtr("main"),
 				Protected: toPtr(false),
 			},

--- a/clients/azuredevopsrepo/client.go
+++ b/clients/azuredevopsrepo/client.go
@@ -145,7 +145,7 @@ func (c *Client) GetFileReader(filename string) (io.ReadCloser, error) {
 	return c.zip.getFile(filename)
 }
 
-func (c *Client) GetBranch(branch string) (*clients.BranchRef, error) {
+func (c *Client) GetBranch(branch string) (*clients.RepoRef, error) {
 	return c.branches.getBranch(branch)
 }
 
@@ -170,7 +170,7 @@ func (c *Client) GetDefaultBranchName() (string, error) {
 	return "", errDefaultBranchNotFound
 }
 
-func (c *Client) GetDefaultBranch() (*clients.BranchRef, error) {
+func (c *Client) GetDefaultBranch() (*clients.RepoRef, error) {
 	return c.branches.getDefaultBranch()
 }
 
@@ -231,6 +231,16 @@ func (c *Client) SearchCommits(request clients.SearchCommitsOptions) ([]clients.
 
 func (c *Client) Close() error {
 	return c.zip.cleanup()
+}
+
+// GetBranch implements RepoClient.GetTag.
+func (client *Client) GetTag(tag string) (*clients.RepoRef, error) {
+	return &clients.RepoRef{}, fmt.Errorf("GetTag: %w", clients.ErrUnsupportedFeature)
+}
+
+func (client *Client) ListTags() ([]*clients.RepoRef, error) {
+	tags := make([]*clients.RepoRef, 0)
+	return tags, fmt.Errorf("ListTags: %w", clients.ErrUnsupportedFeature)
 }
 
 func CreateAzureDevOpsClient(ctx context.Context, repo clients.Repo) (*Client, error) {

--- a/clients/branch.go
+++ b/clients/branch.go
@@ -14,15 +14,15 @@
 
 package clients
 
-// BranchRef represents a single branch reference and its protection rules.
-type BranchRef struct {
-	Name                 *string
-	Protected            *bool
-	BranchProtectionRule BranchProtectionRule
+// RepoRef represents either a single branch or tag reference and its protection rules.
+type RepoRef struct {
+	Name           *string
+	Protected      *bool
+	ProtectionRule ProtectionRule
 }
 
-// BranchProtectionRule captures the settings enabled on a branch for security.
-type BranchProtectionRule struct {
+// ProtectionRule captures the settings enabled on a branch for security.
+type ProtectionRule struct {
 	PullRequestRule         PullRequestRule
 	AllowDeletions          *bool
 	AllowForcePushes        *bool

--- a/clients/git/client.go
+++ b/clients/git/client.go
@@ -266,7 +266,7 @@ func (c *Client) Close() error {
 	return nil
 }
 
-func (c *Client) GetBranch(branch string) (*clients.BranchRef, error) {
+func (c *Client) GetBranch(branch string) (*clients.RepoRef, error) {
 	// Get the branch reference
 	ref, err := c.gitRepo.Branch(branch)
 	if err != nil {
@@ -279,7 +279,7 @@ func (c *Client) GetBranch(branch string) (*clients.BranchRef, error) {
 	}
 	f := false
 	// Create the BranchRef object
-	branchRef := &clients.BranchRef{
+	branchRef := &clients.RepoRef{
 		Name:      &ref.Name,
 		Protected: &f,
 	}
@@ -328,7 +328,17 @@ func (c *Client) GetDefaultBranchName() (string, error) {
 	return string(defaultBranch), nil
 }
 
-func (c *Client) GetDefaultBranch() (*clients.BranchRef, error) {
+// GetBranch implements RepoClient.GetTag.
+func (client *Client) GetTag(tag string) (*clients.RepoRef, error) {
+	return &clients.RepoRef{}, clients.ErrUnsupportedFeature
+}
+
+func (client *Client) ListTags() ([]*clients.RepoRef, error) {
+	tags := make([]*clients.RepoRef, 0)
+	return tags, clients.ErrUnsupportedFeature
+}
+
+func (c *Client) GetDefaultBranch() (*clients.RepoRef, error) {
 	// TODO: Implement this
 	return nil, clients.ErrUnsupportedFeature
 }

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -51,6 +51,7 @@ type Client struct {
 	graphClient   *graphqlHandler
 	contributors  *contributorsHandler
 	branches      *branchesHandler
+	tags          *tagsHandler
 	releases      *releasesHandler
 	workflows     *workflowsHandler
 	checkruns     *checkrunsHandler
@@ -129,6 +130,9 @@ func (client *Client) InitRepo(inputRepo clients.Repo, commitSHA string, commitD
 
 	// Setup branchesHandler.
 	client.branches.init(client.ctx, client.repourl)
+
+	// Setup tagsHandler.
+	client.tags.init(client.ctx, client.repourl)
 
 	// Setup releasesHandler.
 	client.releases.init(client.ctx, client.repourl)
@@ -240,7 +244,7 @@ func (client *Client) IsArchived() (bool, error) {
 }
 
 // GetDefaultBranch implements RepoClient.GetDefaultBranch.
-func (client *Client) GetDefaultBranch() (*clients.BranchRef, error) {
+func (client *Client) GetDefaultBranch() (*clients.RepoRef, error) {
 	return client.branches.getDefaultBranch()
 }
 
@@ -254,8 +258,17 @@ func (client *Client) GetDefaultBranchName() (string, error) {
 }
 
 // GetBranch implements RepoClient.GetBranch.
-func (client *Client) GetBranch(branch string) (*clients.BranchRef, error) {
+func (client *Client) GetBranch(branch string) (*clients.RepoRef, error) {
 	return client.branches.getBranch(branch)
+}
+
+// GetBranch implements RepoClient.GetTag.
+func (client *Client) GetTag(tag string) (*clients.RepoRef, error) {
+	return client.tags.getTag(tag)
+}
+
+func (client *Client) ListTags() ([]*clients.RepoRef, error) {
+	return client.tags.getTags()
 }
 
 // GetCreatedAt is a getter for repo.CreatedAt.
@@ -392,6 +405,10 @@ func NewRepoClient(ctx context.Context, opts ...Option) (clients.RepoClient, err
 			ghClient: client,
 		},
 		branches: &branchesHandler{
+			ghClient:    client,
+			graphClient: graphClient,
+		},
+		tags: &tagsHandler{
 			ghClient:    client,
 			graphClient: graphClient,
 		},

--- a/clients/githubrepo/internal/fnmatch/fnmatch_test.go
+++ b/clients/githubrepo/internal/fnmatch/fnmatch_test.go
@@ -54,6 +54,7 @@ func TestMatch(t *testing.T) {
 		{"releases/**/**/*", "releases/v2", true},
 		{"releases/**/bar/**/qux", "releases/foo/bar/baz/qux", true},
 		{"users/**/*", "users/foo/bar", true},
+		{"v1*", "v1.2.3", true},
 	}
 	for _, tt := range tests {
 		got, err := Match(tt.pattern, tt.path)

--- a/clients/githubrepo/tags.go
+++ b/clients/githubrepo/tags.go
@@ -1,0 +1,120 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubrepo
+
+import (
+	"context"
+	"fmt"
+	"sync"
+
+	"github.com/google/go-github/v53/github"
+	"github.com/shurcooL/githubv4"
+
+	"github.com/ossf/scorecard/v5/clients"
+	sce "github.com/ossf/scorecard/v5/errors"
+)
+
+// GraphQL query to load tag refs.
+type tagsQuery struct {
+	Repository struct {
+		Refs struct {
+			Nodes []*ref
+		} `graphql:"refs(refPrefix: \"refs/tags/\", first: 100)"`
+	} `graphql:"repository(owner: $owner, name: $name)"`
+}
+
+type tagsHandler struct {
+	ctx         context.Context
+	ghClient    *github.Client
+	graphClient *githubv4.Client
+	repourl     *Repo
+
+	once     *sync.Once
+	errSetup error
+
+	ruleSets []*repoRuleSet
+	tags     []*ref
+}
+
+func (h *tagsHandler) init(ctx context.Context, repourl *Repo) {
+	h.ctx = ctx
+	h.repourl = repourl
+	h.errSetup = nil
+	h.once = new(sync.Once)
+	h.ruleSets = nil
+}
+
+func (h *tagsHandler) setup() error {
+	h.once.Do(func() {
+		vars := map[string]interface{}{
+			"owner": githubv4.String(h.repourl.owner),
+			"name":  githubv4.String(h.repourl.repo),
+		}
+		rulesData := new(ruleSetData)
+		if err := h.graphClient.Query(h.ctx, rulesData, vars); err != nil {
+			h.errSetup = sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("githubv4.Query: %v", err))
+			return
+		}
+		h.ruleSets = getActiveRuleSetsFrom(rulesData)
+
+		var q tagsQuery
+		if err := h.graphClient.Query(h.ctx, &q, vars); err != nil {
+			h.errSetup = sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("githubv4.Query tags: %v", err))
+			return
+		}
+		h.tags = q.Repository.Refs.Nodes
+	})
+	return h.errSetup
+}
+
+func (h *tagsHandler) query(tagName string) (*clients.RepoRef, error) {
+	if err := h.setup(); err != nil {
+		return nil, fmt.Errorf("error during branchesHandler.setup: %w", err)
+	}
+	rules, err := rulesMatchingBranch(h.ruleSets, tagName, false, "TAG")
+	if err != nil {
+		return nil, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("rulesMatchingBranch: %v", err))
+	}
+
+	for _, r := range h.tags {
+		if *r.Name == tagName {
+			return getBranchRefFrom(r, rules), nil
+		}
+	}
+	return nil, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("tag not found: %s", tagName))
+}
+
+func (h *tagsHandler) getTags() ([]*clients.RepoRef, error) {
+	if err := h.setup(); err != nil {
+		return nil, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("error during tagsHandler.setup: %v", err))
+	}
+	var out []*clients.RepoRef
+	for _, tag := range h.tags {
+		tag, err := h.getTag(*tag.Name)
+		if err != nil {
+			return nil, fmt.Errorf("getTag: %w", err)
+		}
+		out = append(out, tag)
+	}
+	return out, nil
+}
+
+func (h *tagsHandler) getTag(tag string) (*clients.RepoRef, error) {
+	branchRef, err := h.query(tag)
+	if err != nil {
+		return nil, fmt.Errorf("error during branchesHandler.query: %w", err)
+	}
+	return branchRef, nil
+}

--- a/clients/githubrepo/tags_e2e_test.go
+++ b/clients/githubrepo/tags_e2e_test.go
@@ -1,0 +1,59 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubrepo
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("E2E TEST: githubrepo.tagsHandler", func() {
+	var tagshandler *tagsHandler
+
+	BeforeEach(func() {
+		tagshandler = &tagsHandler{
+			graphClient: graphClient,
+		}
+	})
+	Context("E2E TEST: getTag", func() {
+		It("Should return a tag", func() {
+			skipIfTokenIsNot(patTokenType, "PAT only")
+
+			repourl := &Repo{
+				owner: "AdamKorcz",
+				repo:  "scorecard-testing",
+			}
+			tagshandler.init(context.Background(), repourl)
+			err := tagshandler.setup()
+			Expect(err).Should(BeNil())
+			tagRef, err := tagshandler.getTag("test-tag1")
+			Expect(err).Should(BeNil())
+			Expect(tagRef).ShouldNot(BeNil())
+			Expect(tagRef.ProtectionRule).ShouldNot(BeNil())
+			Expect(tagRef.ProtectionRule.AllowForcePushes).ShouldNot(BeNil())
+			Expect(tagRef.ProtectionRule.AllowDeletions).ShouldNot(BeNil())
+			Expect(tagRef.ProtectionRule.RequireLinearHistory).ShouldNot(BeNil())
+			Expect(tagRef.ProtectionRule.EnforceAdmins).ShouldNot(BeNil())
+			Expect(tagRef.ProtectionRule.RequireLastPushApproval).Should(BeNil())
+			Expect(tagRef.ProtectionRule.PullRequestRule.Required).To(Equal(asPtr(false)))
+			Expect(tagRef.ProtectionRule.PullRequestRule.DismissStaleReviews).Should(BeNil())
+			Expect(tagRef.ProtectionRule.PullRequestRule.RequireCodeOwnerReviews).Should(BeNil())
+			Expect(tagRef.ProtectionRule.AllowDeletions).To(Equal(asPtr(false)))
+			Expect(tagRef.ProtectionRule.AllowForcePushes).To(Equal(asPtr(false)))
+		})
+	})
+})

--- a/clients/githubrepo/tags_test.go
+++ b/clients/githubrepo/tags_test.go
@@ -1,0 +1,611 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubrepo
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/shurcooL/githubv4"
+)
+
+// RoundTripper that returns canned GraphQL responses in order.
+type seqRT struct {
+	bodies [][]byte
+	i      int
+	code   int
+}
+
+func (s *seqRT) RoundTrip(req *http.Request) (*http.Response, error) {
+	if s.i >= len(s.bodies) {
+		return nil, fmt.Errorf("seqRT: no more responses (call #%d)", s.i)
+	}
+	b := s.bodies[s.i]
+	s.i++
+	return &http.Response{
+		StatusCode: s.code,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(bytes.NewReader(b)),
+		Request:    req,
+	}, nil
+}
+
+func newGraphQLClientWith(jsonBodies ...string) *githubv4.Client {
+	bufs := make([][]byte, 0, len(jsonBodies))
+	for _, s := range jsonBodies {
+		bufs = append(bufs, []byte(s))
+	}
+	return githubv4.NewClient(&http.Client{Transport: &seqRT{bodies: bufs, code: 200}})
+}
+
+func TestTagsHandler_GetTag_TableDriven(t *testing.T) {
+	t.Parallel()
+
+	rulesJSONCase1 := `
+{
+  "data": {
+    "repository": {
+      "rulesets": {
+        "nodes": [
+          {
+            "name": "Tag PR + checks",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["v1.*"], "exclude": [] } },
+            "bypassActors": { "nodes": [
+              { "bypassMode": "ALWAYS", "organizationAdmin": true, "repositoryRoleName": "maintainer" }
+            ]},
+            "rules": { "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "parameters": {
+                  "dismissStaleReviewsOnPush": true,
+                  "requireCodeOwnerReview": true,
+                  "requireLastPushApproval": true,
+                  "requiredApprovingReviewCount": 2,
+                  "requiredReviewThreadResolution": true
+                }
+              },
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": true,
+                  "requiredStatusChecks": [
+                    { "context": "build", "integrationID": 1 },
+                    { "context": "test",  "integrationID": 1 }
+                  ]
+                }
+              }
+            ]}
+          }
+        ]
+      }
+    }
+  }
+}`
+
+	// Tag refs (must ONLY include fields that `branch` selected via tagsQuery2 -> name)
+	tagsJSONCase1 := `
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "nodes": [
+          { "name": "v1.2.3" },
+          { "name": "v0.9.0" }
+        ]
+      }
+    }
+  }
+}`
+
+	// CASE 2 — Another tag with only status checks via a matching ruleset (no PR rule).
+	// Strict=false and single context "ci".
+	rulesJSONCase2 := `
+{
+  "data": {
+    "repository": {
+      "rulesets": {
+        "nodes": [
+          {
+            "name": "Release checks",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["release-*"], "exclude": [] } },
+            "bypassActors": { "nodes": [] },
+            "rules": { "nodes": [
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": false,
+                  "requiredStatusChecks": [
+                    { "context": "ci", "integrationID": 1 }
+                  ]
+                }
+              }
+            ]}
+          }
+        ]
+      }
+    }
+  }
+}`
+
+	tagsJSONCase2 := `
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "nodes": [
+          { "name": "release-2024.10" }
+        ]
+      }
+    }
+  }
+}`
+
+	// CASE 3 — No ruleset matches tag "v1.9.9"; ≥3 rulesets present; each ruleset has 2 rules.
+	rulesJSONCase3 := `
+{
+  "data": {
+    "repository": {
+      "rulesets": {
+        "nodes": [
+          {
+            "name": "Only v2 tags",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["v2.*"], "exclude": [] } },
+            "bypassActors": { "nodes": [] },
+            "rules": { "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "parameters": {
+                  "requiredApprovingReviewCount": 2
+                }
+              },
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": true,
+                  "requiredStatusChecks": [
+                    { "context": "build", "integrationID": 1 }
+                  ]
+                }
+              }
+            ] }
+          },
+          {
+            "name": "Beta rules",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["beta-*"], "exclude": [] } },
+            "bypassActors": { "nodes": [] },
+            "rules": { "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "parameters": {
+                  "requireCodeOwnerReview": true
+                }
+              },
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": false,
+                  "requiredStatusChecks": [
+                    { "context": "ci", "integrationID": 1 }
+                  ]
+                }
+              }
+            ] }
+          },
+          {
+            "name": "Exclude v1 series",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["*"], "exclude": ["v1.*"] } },
+            "bypassActors": { "nodes": [] },
+            "rules": { "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "parameters": {
+                  "dismissStaleReviewsOnPush": true
+                }
+              },
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": true,
+                  "requiredStatusChecks": [
+                    { "context": "lint", "integrationID": 1 }
+                  ]
+                }
+              }
+            ] }
+          }
+        ]
+      }
+    }
+  }
+}`
+
+	tagsJSONCase3 := `
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "nodes": [
+          { "name": "v1.9.9" }
+        ]
+      }
+    }
+  }
+}`
+
+	// CASE 4 — PR-only ruleset applies to "beta-2025.01"; ≥3 rulesets total; matching ruleset has 2 PR rules.
+	rulesJSONCase4 := `
+{
+  "data": {
+    "repository": {
+      "rulesets": {
+        "nodes": [
+          {
+            "name": "Beta PR gate",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["beta-*"], "exclude": [] } },
+            "bypassActors": { "nodes": [] },
+            "rules": { "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "parameters": {
+                  "requiredApprovingReviewCount": 1
+                }
+              },
+              {
+                "type": "PULL_REQUEST",
+                "parameters": {
+                  "dismissStaleReviewsOnPush": true
+                }
+              }
+            ] }
+          },
+          {
+            "name": "General checks for v2",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["v2.*"], "exclude": [] } },
+            "bypassActors": { "nodes": [] },
+            "rules": { "nodes": [
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": true,
+                  "requiredStatusChecks": [
+                    { "context": "unit", "integrationID": 1 }
+                  ]
+                }
+              },
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": true,
+                  "requiredStatusChecks": [
+                    { "context": "integration", "integrationID": 1 }
+                  ]
+                }
+              }
+            ] }
+          },
+          {
+            "name": "Exclude betas",
+            "enforcement": "ACTIVE",
+            "target": "TAG",
+            "conditions": { "refName": { "include": ["*"], "exclude": ["beta-*"] } },
+            "bypassActors": { "nodes": [] },
+            "rules": { "nodes": [
+              {
+                "type": "PULL_REQUEST",
+                "parameters": {
+                  "requireCodeOwnerReview": true
+                }
+              },
+              {
+                "type": "REQUIRED_STATUS_CHECKS",
+                "parameters": {
+                  "strictRequiredStatusChecksPolicy": true,
+                  "requiredStatusChecks": [
+                    { "context": "lint", "integrationID": 1 }
+                  ]
+                }
+              }
+            ] }
+          }
+        ]
+      }
+    }
+  }
+}`
+
+	tagsJSONCase4 := `
+{
+  "data": {
+    "repository": {
+      "refs": {
+        "nodes": [
+          { "name": "beta-2025.01" }
+        ]
+      }
+    }
+  }
+}`
+
+	tests := []struct {
+		wantCodeOwners                    *bool
+		wantRequireLinearHistory          *bool
+		wantStatusChecksStrictUpToDate    *bool
+		wantStatusChecksRequired          *bool
+		wantRequireLastPushApproval       *bool
+		wantEnforceAdmins                 *bool
+		wantDismissStale                  *bool
+		wantPRApprovals                   *int32
+		wantAllowDeletions                *bool
+		wantAllowForcePushes              *bool
+		wantPRRequired                    *bool
+		tag                               string
+		rulesJSON                         string
+		wantName                          string
+		name                              string
+		repo                              string
+		owner                             string
+		tagsJSON                          string
+		wantStatusChecksContextsUnordered []string
+		wantProtected                     bool
+	}{
+		{
+			name:      "ruleset-applies-v1.2.3",
+			rulesJSON: rulesJSONCase1,
+			tagsJSON:  tagsJSONCase1,
+			owner:     "o",
+			repo:      "r",
+			tag:       "v1.2.3",
+
+			wantName:      "v1.2.3",
+			wantProtected: true,
+			// No BPR/RUR in tags JSON -> these toggles remain nil
+			wantEnforceAdmins:        nil,
+			wantAllowDeletions:       nil,
+			wantAllowForcePushes:     nil,
+			wantRequireLinearHistory: nil,
+
+			// From ruleset:
+			wantPRRequired:                    boolPtr(true),
+			wantPRApprovals:                   int32Ptr(2),
+			wantDismissStale:                  boolPtr(true),
+			wantCodeOwners:                    boolPtr(true),
+			wantRequireLastPushApproval:       boolPtr(true),
+			wantStatusChecksRequired:          boolPtr(true),
+			wantStatusChecksStrictUpToDate:    boolPtr(true),
+			wantStatusChecksContextsUnordered: []string{"build", "test"},
+		},
+		{
+			name:      "release-tag-status-checks-only",
+			rulesJSON: rulesJSONCase2,
+			tagsJSON:  tagsJSONCase2,
+			owner:     "o",
+			repo:      "r",
+			tag:       "release-2024.10",
+
+			wantName:                 "release-2024.10",
+			wantProtected:            true,
+			wantEnforceAdmins:        nil,
+			wantAllowDeletions:       nil,
+			wantAllowForcePushes:     nil,
+			wantRequireLinearHistory: nil,
+
+			// From ruleset (no PR rules):
+			wantPRRequired:                    nil,
+			wantPRApprovals:                   nil,
+			wantDismissStale:                  nil,
+			wantCodeOwners:                    nil,
+			wantRequireLastPushApproval:       nil,
+			wantStatusChecksRequired:          boolPtr(true),
+			wantStatusChecksStrictUpToDate:    boolPtr(false),
+			wantStatusChecksContextsUnordered: []string{"ci"},
+		},
+		{
+			name:      "no-ruleset-match-unprotected",
+			rulesJSON: rulesJSONCase3,
+			tagsJSON:  tagsJSONCase3,
+			owner:     "o",
+			repo:      "r",
+			tag:       "v1.9.9",
+
+			wantName:                 "v1.9.9",
+			wantProtected:            false, // none of the 3 rulesets apply
+			wantEnforceAdmins:        nil,
+			wantAllowDeletions:       nil,
+			wantAllowForcePushes:     nil,
+			wantRequireLinearHistory: nil,
+
+			wantPRRequired:                    nil,
+			wantPRApprovals:                   nil,
+			wantDismissStale:                  nil,
+			wantCodeOwners:                    nil,
+			wantRequireLastPushApproval:       nil,
+			wantStatusChecksRequired:          nil,
+			wantStatusChecksStrictUpToDate:    nil,
+			wantStatusChecksContextsUnordered: nil,
+		},
+		{
+			name:      "pr-only-two-rules-beta",
+			rulesJSON: rulesJSONCase4,
+			tagsJSON:  tagsJSONCase4,
+			owner:     "o",
+			repo:      "r",
+			tag:       "beta-2025.01",
+
+			wantName:                 "beta-2025.01",
+			wantProtected:            true,
+			wantEnforceAdmins:        nil,
+			wantAllowDeletions:       nil,
+			wantAllowForcePushes:     nil,
+			wantRequireLinearHistory: nil,
+
+			// From matching ruleset's two PR rules:
+			wantPRRequired:              boolPtr(true),
+			wantPRApprovals:             nil,
+			wantDismissStale:            boolPtr(true),
+			wantCodeOwners:              nil,
+			wantRequireLastPushApproval: nil,
+
+			wantStatusChecksRequired:          nil,
+			wantStatusChecksStrictUpToDate:    nil,
+			wantStatusChecksContextsUnordered: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			graph := newGraphQLClientWith(tc.rulesJSON, tc.tagsJSON)
+
+			var h tagsHandler
+			h.graphClient = graph
+			ctx := context.Background()
+			h.init(ctx, &Repo{owner: tc.owner, repo: tc.repo})
+
+			if err := h.setup(); err != nil {
+				t.Fatalf("setup() error: %v", err)
+			}
+
+			got, err := h.getTag(tc.tag)
+			if err != nil {
+				t.Fatalf("getTag(%q) error: %v", tc.tag, err)
+			}
+			if got == nil {
+				t.Fatalf("nil RepoRef")
+			}
+
+			// Name / Protected
+			if got.Name == nil || *got.Name != tc.wantName {
+				t.Fatalf("Name = %v, want %q", derefStr(got.Name), tc.wantName)
+			}
+			if got.Protected == nil || *got.Protected != tc.wantProtected {
+				t.Fatalf("Protected = %v, want %v", derefBool(got.Protected), tc.wantProtected)
+			}
+
+			// Low-level toggles (should stay nil without BPR/RUR in the JSON)
+			assertOptBool(t, "EnforceAdmins", got.ProtectionRule.EnforceAdmins, tc.wantEnforceAdmins)
+			assertOptBool(t, "AllowDeletions", got.ProtectionRule.AllowDeletions, tc.wantAllowDeletions)
+			assertOptBool(t, "AllowForcePushes", got.ProtectionRule.AllowForcePushes, tc.wantAllowForcePushes)
+			assertOptBool(t, "RequireLinearHistory", got.ProtectionRule.RequireLinearHistory, tc.wantRequireLinearHistory)
+
+			// PR Rule expectations
+			assertOptBool(t, "PR.Required", got.ProtectionRule.PullRequestRule.Required, tc.wantPRRequired)
+			assertOptInt32(t, "PR.RequiredApprovingReviewCount", got.ProtectionRule.PullRequestRule.RequiredApprovingReviewCount, tc.wantPRApprovals)
+			assertOptBool(t, "PR.DismissStaleReviews", got.ProtectionRule.PullRequestRule.DismissStaleReviews, tc.wantDismissStale)
+			assertOptBool(t, "PR.RequireCodeOwnerReviews", got.ProtectionRule.PullRequestRule.RequireCodeOwnerReviews, tc.wantCodeOwners)
+			assertOptBool(t, "RequireLastPushApproval", got.ProtectionRule.RequireLastPushApproval, tc.wantRequireLastPushApproval)
+
+			// Status checks expectations
+			assertOptBool(t, "Checks.RequiresStatusChecks", got.ProtectionRule.CheckRules.RequiresStatusChecks, tc.wantStatusChecksRequired)
+			assertOptBool(t, "Checks.UpToDateBeforeMerge", got.ProtectionRule.CheckRules.UpToDateBeforeMerge, tc.wantStatusChecksStrictUpToDate)
+
+			// Contexts (order-insensitive)
+			if tc.wantStatusChecksContextsUnordered != nil {
+				gotCtx := append([]string(nil), got.ProtectionRule.CheckRules.Contexts...)
+				want := set(tc.wantStatusChecksContextsUnordered...)
+				if !sameSet(gotCtx, want) {
+					t.Fatalf("Checks.Contexts = %v, want set %v", gotCtx, tc.wantStatusChecksContextsUnordered)
+				}
+			}
+		})
+	}
+}
+
+/**********************
+ * Small helpers
+ **********************/
+
+func boolPtr(b bool) *bool    { return &b }
+func int32Ptr(i int32) *int32 { return &i }
+
+func derefStr(p *string) string {
+	if p == nil {
+		return ""
+	}
+	return *p
+}
+
+func derefBool(p *bool) bool {
+	if p == nil {
+		return false
+	}
+	return *p
+}
+
+func assertOptBool(t *testing.T, field string, got, want *bool) {
+	t.Helper()
+	// If we don't care (want is nil), don't assert.
+	if want == nil {
+		return
+	}
+	if got == nil {
+		t.Fatalf("%s = <nil>, want %v", field, *want)
+	}
+	if *got != *want {
+		t.Fatalf("%s = %v, want %v", field, *got, *want)
+	}
+}
+
+func assertOptInt32(t *testing.T, field string, got, want *int32) {
+	t.Helper()
+	// If we don't care (want is nil), don't assert.
+	if want == nil {
+		return
+	}
+	if got == nil {
+		t.Fatalf("%s = <nil>, want %v", field, *want)
+	}
+	if *got != *want {
+		t.Fatalf("%s = %v, want %v", field, *got, *want)
+	}
+}
+
+func set(ss ...string) map[string]struct{} {
+	m := make(map[string]struct{}, len(ss))
+	for _, s := range ss {
+		m[s] = struct{}{}
+	}
+	return m
+}
+
+func sameSet(got []string, want map[string]struct{}) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for _, s := range got {
+		if _, ok := want[s]; !ok {
+			return false
+		}
+	}
+	return true
+}

--- a/clients/gitlabrepo/client.go
+++ b/clients/gitlabrepo/client.go
@@ -220,7 +220,7 @@ func (client *Client) IsArchived() (bool, error) {
 	return client.project.isArchived()
 }
 
-func (client *Client) GetDefaultBranch() (*clients.BranchRef, error) {
+func (client *Client) GetDefaultBranch() (*clients.RepoRef, error) {
 	return client.branches.getDefaultBranch()
 }
 
@@ -228,7 +228,7 @@ func (client *Client) GetDefaultBranchName() (string, error) {
 	return client.repourl.defaultBranch, nil
 }
 
-func (client *Client) GetBranch(branch string) (*clients.BranchRef, error) {
+func (client *Client) GetBranch(branch string) (*clients.RepoRef, error) {
 	return client.branches.getBranch(branch)
 }
 
@@ -275,6 +275,16 @@ func (client *Client) SearchCommits(request clients.SearchCommitsOptions) ([]cli
 
 func (client *Client) Close() error {
 	return nil
+}
+
+// GetBranch implements RepoClient.GetTag.
+func (client *Client) GetTag(tag string) (*clients.RepoRef, error) {
+	return &clients.RepoRef{}, fmt.Errorf("GetTag: %w", clients.ErrUnsupportedFeature)
+}
+
+func (client *Client) ListTags() ([]*clients.RepoRef, error) {
+	tags := make([]*clients.RepoRef, 0)
+	return tags, fmt.Errorf("ListTags: %w", clients.ErrUnsupportedFeature)
 }
 
 func CreateGitlabClient(ctx context.Context, host string) (clients.RepoClient, error) {

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -180,13 +180,23 @@ func (client *Client) GetFileReader(filename string) (io.ReadCloser, error) {
 }
 
 // GetBranch implements RepoClient.GetBranch.
-func (client *Client) GetBranch(branch string) (*clients.BranchRef, error) {
+func (client *Client) GetBranch(branch string) (*clients.RepoRef, error) {
 	return nil, fmt.Errorf("ListBranches: %w", clients.ErrUnsupportedFeature)
 }
 
 // GetDefaultBranch implements RepoClient.GetDefaultBranch.
-func (client *Client) GetDefaultBranch() (*clients.BranchRef, error) {
+func (client *Client) GetDefaultBranch() (*clients.RepoRef, error) {
 	return nil, fmt.Errorf("GetDefaultBranch: %w", clients.ErrUnsupportedFeature)
+}
+
+// GetBranch implements RepoClient.GetTag.
+func (client *Client) GetTag(tag string) (*clients.RepoRef, error) {
+	return &clients.RepoRef{}, fmt.Errorf("GetTag: %w", clients.ErrUnsupportedFeature)
+}
+
+func (client *Client) ListTags() ([]*clients.RepoRef, error) {
+	tags := make([]*clients.RepoRef, 0)
+	return tags, fmt.Errorf("ListTags: %w", clients.ErrUnsupportedFeature)
 }
 
 // GetDefaultBranchName implements RepoClient.GetDefaultBranchName.

--- a/clients/mockclients/repo_client.go
+++ b/clients/mockclients/repo_client.go
@@ -73,10 +73,10 @@ func (mr *MockRepoClientMockRecorder) Close() *gomock.Call {
 }
 
 // GetBranch mocks base method.
-func (m *MockRepoClient) GetBranch(branch string) (*clients.BranchRef, error) {
+func (m *MockRepoClient) GetBranch(branch string) (*clients.RepoRef, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBranch", branch)
-	ret0, _ := ret[0].(*clients.BranchRef)
+	ret0, _ := ret[0].(*clients.RepoRef)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -103,10 +103,10 @@ func (mr *MockRepoClientMockRecorder) GetCreatedAt() *gomock.Call {
 }
 
 // GetDefaultBranch mocks base method.
-func (m *MockRepoClient) GetDefaultBranch() (*clients.BranchRef, error) {
+func (m *MockRepoClient) GetDefaultBranch() (*clients.RepoRef, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetDefaultBranch")
-	ret0, _ := ret[0].(*clients.BranchRef)
+	ret0, _ := ret[0].(*clients.RepoRef)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -160,6 +160,21 @@ func (m *MockRepoClient) GetOrgRepoClient(arg0 context.Context) (clients.RepoCli
 func (mr *MockRepoClientMockRecorder) GetOrgRepoClient(arg0 any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgRepoClient", reflect.TypeOf((*MockRepoClient)(nil).GetOrgRepoClient), arg0)
+}
+
+// GetTag mocks base method.
+func (m *MockRepoClient) GetTag(tag string) (*clients.RepoRef, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetTag", tag)
+	ret0, _ := ret[0].(*clients.RepoRef)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTag indicates an expected call of GetTag.
+func (mr *MockRepoClientMockRecorder) GetTag(tag any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTag", reflect.TypeOf((*MockRepoClient)(nil).GetTag), tag)
 }
 
 // InitRepo mocks base method.
@@ -339,6 +354,21 @@ func (m *MockRepoClient) ListSuccessfulWorkflowRuns(filename string) ([]clients.
 func (mr *MockRepoClientMockRecorder) ListSuccessfulWorkflowRuns(filename any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListSuccessfulWorkflowRuns", reflect.TypeOf((*MockRepoClient)(nil).ListSuccessfulWorkflowRuns), filename)
+}
+
+// ListTags mocks base method.
+func (m *MockRepoClient) ListTags() ([]*clients.RepoRef, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTags")
+	ret0, _ := ret[0].([]*clients.RepoRef)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTags indicates an expected call of ListTags.
+func (mr *MockRepoClientMockRecorder) ListTags() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockRepoClient)(nil).ListTags))
 }
 
 // ListWebhooks mocks base method.

--- a/clients/ossfuzz/client.go
+++ b/clients/ossfuzz/client.go
@@ -162,6 +162,16 @@ func (c *client) URI() string {
 	return c.statusURL
 }
 
+// GetBranch implements RepoClient.GetTag.
+func (client *client) GetTag(tag string) (*clients.RepoRef, error) {
+	return &clients.RepoRef{}, fmt.Errorf("GetTag: %w", clients.ErrUnsupportedFeature)
+}
+
+func (client *client) ListTags() ([]*clients.RepoRef, error) {
+	tags := make([]*clients.RepoRef, 0)
+	return tags, fmt.Errorf("ListTags: %w", clients.ErrUnsupportedFeature)
+}
+
 // InitRepo implements RepoClient.InitRepo.
 func (c *client) InitRepo(inputRepo clients.Repo, commitSHA string, commitDepth int) error {
 	return fmt.Errorf("InitRepo: %w", clients.ErrUnsupportedFeature)
@@ -188,12 +198,12 @@ func (c *client) GetFileReader(filename string) (io.ReadCloser, error) {
 }
 
 // GetBranch implements RepoClient.GetBranch.
-func (c *client) GetBranch(branch string) (*clients.BranchRef, error) {
+func (c *client) GetBranch(branch string) (*clients.RepoRef, error) {
 	return nil, fmt.Errorf("GetBranch: %w", clients.ErrUnsupportedFeature)
 }
 
 // GetDefaultBranch implements RepoClient.GetDefaultBranch.
-func (c *client) GetDefaultBranch() (*clients.BranchRef, error) {
+func (c *client) GetDefaultBranch() (*clients.RepoRef, error) {
 	return nil, fmt.Errorf("GetDefaultBranch: %w", clients.ErrUnsupportedFeature)
 }
 

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -34,16 +34,18 @@ type RepoClient interface {
 	URI() string
 	IsArchived() (bool, error)
 	ListFiles(predicate func(string) (bool, error)) ([]string, error)
+	ListTags() ([]*RepoRef, error)
 	// Returns an absolute path to the local repository
 	// in the format that matches the local OS
 	LocalPath() (string, error)
 	// GetFileReader returns an io.ReadCloser corresponding to the desired file.
 	// Callers should ensure to Close the Reader when finished.
 	GetFileReader(filename string) (io.ReadCloser, error)
-	GetBranch(branch string) (*BranchRef, error)
+	GetBranch(branch string) (*RepoRef, error)
+	GetTag(tag string) (*RepoRef, error)
 	GetCreatedAt() (time.Time, error)
 	GetDefaultBranchName() (string, error)
-	GetDefaultBranch() (*BranchRef, error)
+	GetDefaultBranch() (*RepoRef, error)
 	GetOrgRepoClient(context.Context) (RepoClient, error)
 	ListCommits() ([]Commit, error)
 	ListIssues() ([]Issue, error)

--- a/cron/internal/format/json_raw_results.go
+++ b/cron/internal/format/json_raw_results.go
@@ -208,16 +208,16 @@ func addBranchProtectionRawResults(r *jsonScorecardRawResult, bp *checker.Branch
 		var bp *jsonBranchProtectionSettings
 		if v.Protected != nil && *v.Protected {
 			bp = &jsonBranchProtectionSettings{
-				AllowsDeletions:                     v.BranchProtectionRule.AllowDeletions,
-				AllowsForcePushes:                   v.BranchProtectionRule.AllowForcePushes,
-				RequiresCodeOwnerReviews:            v.BranchProtectionRule.PullRequestRule.RequireCodeOwnerReviews,
-				RequiresLinearHistory:               v.BranchProtectionRule.RequireLinearHistory,
-				DismissesStaleReviews:               v.BranchProtectionRule.PullRequestRule.DismissStaleReviews,
-				EnforcesAdmins:                      v.BranchProtectionRule.EnforceAdmins,
-				RequiresStatusChecks:                v.BranchProtectionRule.CheckRules.RequiresStatusChecks,
-				RequiresUpToDateBranchBeforeMerging: v.BranchProtectionRule.CheckRules.UpToDateBeforeMerge,
-				RequiredApprovingReviewCount:        v.BranchProtectionRule.PullRequestRule.RequiredApprovingReviewCount,
-				StatusCheckContexts:                 v.BranchProtectionRule.CheckRules.Contexts,
+				AllowsDeletions:                     v.ProtectionRule.AllowDeletions,
+				AllowsForcePushes:                   v.ProtectionRule.AllowForcePushes,
+				RequiresCodeOwnerReviews:            v.ProtectionRule.PullRequestRule.RequireCodeOwnerReviews,
+				RequiresLinearHistory:               v.ProtectionRule.RequireLinearHistory,
+				DismissesStaleReviews:               v.ProtectionRule.PullRequestRule.DismissStaleReviews,
+				EnforcesAdmins:                      v.ProtectionRule.EnforceAdmins,
+				RequiresStatusChecks:                v.ProtectionRule.CheckRules.RequiresStatusChecks,
+				RequiresUpToDateBranchBeforeMerging: v.ProtectionRule.CheckRules.UpToDateBeforeMerge,
+				RequiredApprovingReviewCount:        v.ProtectionRule.PullRequestRule.RequiredApprovingReviewCount,
+				StatusCheckContexts:                 v.ProtectionRule.CheckRules.Contexts,
 			}
 		}
 		r.Results.BranchProtections = append(r.Results.BranchProtections, jsonBranchProtection{

--- a/go.mod
+++ b/go.mod
@@ -47,6 +47,7 @@ require (
 	github.com/mcuadros/go-jsonschema-generator v0.0.0-20200330054847-ba7a369d4303
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/otiai10/copy v1.14.1
+	github.com/stretchr/testify v1.10.0
 	gitlab.com/gitlab-org/api/client-go v0.134.0
 	sigs.k8s.io/release-utils v0.8.4
 )
@@ -116,6 +117,7 @@ require (
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pjbgf/sha1cd v0.3.2 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20240319094008-0393e58bdf10 // indirect
+	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/prometheus v0.54.0 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
 	github.com/skeema/knownhosts v1.3.1 // indirect

--- a/pkg/scorecard/json_raw_results.go
+++ b/pkg/scorecard/json_raw_results.go
@@ -710,16 +710,16 @@ func (r *jsonScorecardRawResult) addBranchProtectionRawResults(bp *checker.Branc
 		var bp *jsonBranchProtectionSettings
 		if v.Protected != nil && *v.Protected {
 			bp = &jsonBranchProtectionSettings{
-				AllowsDeletions:                     v.BranchProtectionRule.AllowDeletions,
-				AllowsForcePushes:                   v.BranchProtectionRule.AllowForcePushes,
-				RequiresCodeOwnerReviews:            v.BranchProtectionRule.PullRequestRule.RequireCodeOwnerReviews,
-				RequiresLinearHistory:               v.BranchProtectionRule.RequireLinearHistory,
-				DismissesStaleReviews:               v.BranchProtectionRule.PullRequestRule.DismissStaleReviews,
-				EnforcesAdmins:                      v.BranchProtectionRule.EnforceAdmins,
-				RequiresStatusChecks:                v.BranchProtectionRule.CheckRules.RequiresStatusChecks,
-				RequiresUpToDateBranchBeforeMerging: v.BranchProtectionRule.CheckRules.UpToDateBeforeMerge,
-				RequiredApprovingReviewCount:        v.BranchProtectionRule.PullRequestRule.RequiredApprovingReviewCount,
-				StatusCheckContexts:                 v.BranchProtectionRule.CheckRules.Contexts,
+				AllowsDeletions:                     v.ProtectionRule.AllowDeletions,
+				AllowsForcePushes:                   v.ProtectionRule.AllowForcePushes,
+				RequiresCodeOwnerReviews:            v.ProtectionRule.PullRequestRule.RequireCodeOwnerReviews,
+				RequiresLinearHistory:               v.ProtectionRule.RequireLinearHistory,
+				DismissesStaleReviews:               v.ProtectionRule.PullRequestRule.DismissStaleReviews,
+				EnforcesAdmins:                      v.ProtectionRule.EnforceAdmins,
+				RequiresStatusChecks:                v.ProtectionRule.CheckRules.RequiresStatusChecks,
+				RequiresUpToDateBranchBeforeMerging: v.ProtectionRule.CheckRules.UpToDateBeforeMerge,
+				RequiredApprovingReviewCount:        v.ProtectionRule.PullRequestRule.RequiredApprovingReviewCount,
+				StatusCheckContexts:                 v.ProtectionRule.CheckRules.Contexts,
 			}
 		}
 		branches = append(branches, jsonBranchProtection{

--- a/pkg/scorecard/json_raw_results_test.go
+++ b/pkg/scorecard/json_raw_results_test.go
@@ -1097,11 +1097,11 @@ func TestJsonScorecardRawResult(t *testing.T) {
 		},
 	}
 	bp := &checker.BranchProtectionsData{
-		Branches: []clients.BranchRef{
+		Branches: []clients.RepoRef{
 			{
 				Name:      stringPtr("main"),
 				Protected: boolPtr(true),
-				BranchProtectionRule: clients.BranchProtectionRule{
+				ProtectionRule: clients.ProtectionRule{
 					AllowDeletions:   boolPtr(true),
 					AllowForcePushes: boolPtr(false),
 					PullRequestRule: clients.PullRequestRule{
@@ -1298,11 +1298,11 @@ func TestAddBranchProtectionRawResults(t *testing.T) {
 		{
 			name: "one protected branch",
 			input: &checker.BranchProtectionsData{
-				Branches: []clients.BranchRef{
+				Branches: []clients.RepoRef{
 					{
 						Name:      stringPtr("main"),
 						Protected: boolPtr(true),
-						BranchProtectionRule: clients.BranchProtectionRule{
+						ProtectionRule: clients.ProtectionRule{
 							AllowDeletions: boolPtr(false),
 						},
 					},
@@ -1370,7 +1370,7 @@ func TestFillJSONRawResults(t *testing.T) {
 			},
 		},
 		BranchProtectionResults: checker.BranchProtectionsData{
-			Branches: []clients.BranchRef{
+			Branches: []clients.RepoRef{
 				{Name: stringPtr("main"), Protected: boolPtr(true)},
 			},
 		},

--- a/probes/blocksDeleteOnBranches/impl.go
+++ b/probes/blocksDeleteOnBranches/impl.go
@@ -61,13 +61,13 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		var text string
 		var outcome finding.Outcome
 		switch {
-		case branch.BranchProtectionRule.AllowDeletions == nil:
+		case branch.ProtectionRule.AllowDeletions == nil:
 			text = "could not determine whether branch is protected against deletion"
 			outcome = finding.OutcomeNotAvailable
-		case *branch.BranchProtectionRule.AllowDeletions:
+		case *branch.ProtectionRule.AllowDeletions:
 			text = fmt.Sprintf("'allow deletion' enabled on branch '%s'", *branch.Name)
 			outcome = finding.OutcomeFalse
-		case !*branch.BranchProtectionRule.AllowDeletions:
+		case !*branch.ProtectionRule.AllowDeletions:
 			text = fmt.Sprintf("'allow deletion' disabled on branch '%s'", *branch.Name)
 			outcome = finding.OutcomeTrue
 		default:

--- a/probes/blocksDeleteOnBranches/impl_test.go
+++ b/probes/blocksDeleteOnBranches/impl_test.go
@@ -45,10 +45,10 @@ func Test_Run(t *testing.T) {
 			name: "One branch blocks branch deletion should result in one true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &falseVal,
 							},
 						},
@@ -63,16 +63,16 @@ func Test_Run(t *testing.T) {
 			name: "Two branches that block branch deletions should result in two true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &falseVal,
 							},
 						},
@@ -87,16 +87,16 @@ func Test_Run(t *testing.T) {
 			name: "Two branches in total: One blocks branch deletion and one doesn't = 1 true & 1 false",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &trueVal,
 							},
 						},
@@ -111,16 +111,16 @@ func Test_Run(t *testing.T) {
 			name: "Two branches in total: One blocks branch deletion and one doesn't = 1 false & 1 true",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &falseVal,
 							},
 						},
@@ -135,16 +135,16 @@ func Test_Run(t *testing.T) {
 			name: "Two branches in total: One blocks branch deletion and one lacks data = 1 false & 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: nil,
 							},
 						},

--- a/probes/blocksForcePushOnBranches/impl.go
+++ b/probes/blocksForcePushOnBranches/impl.go
@@ -61,13 +61,13 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		var text string
 		var outcome finding.Outcome
 		switch {
-		case branch.BranchProtectionRule.AllowForcePushes == nil:
+		case branch.ProtectionRule.AllowForcePushes == nil:
 			text = "could not determine whether for push is allowed"
 			outcome = finding.OutcomeNotAvailable
-		case *branch.BranchProtectionRule.AllowForcePushes:
+		case *branch.ProtectionRule.AllowForcePushes:
 			text = fmt.Sprintf("'force pushes' enabled on branch '%s'", *branch.Name)
 			outcome = finding.OutcomeFalse
-		case !*branch.BranchProtectionRule.AllowForcePushes:
+		case !*branch.ProtectionRule.AllowForcePushes:
 			text = fmt.Sprintf("'force pushes' disabled on branch '%s'", *branch.Name)
 			outcome = finding.OutcomeTrue
 		default:

--- a/probes/blocksForcePushOnBranches/impl_test.go
+++ b/probes/blocksForcePushOnBranches/impl_test.go
@@ -45,10 +45,10 @@ func Test_Run(t *testing.T) {
 			name: "Blocks Force Push on 1/1 branches = 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &falseVal,
 							},
 						},
@@ -63,16 +63,16 @@ func Test_Run(t *testing.T) {
 			name: "Blocks Force Push on 2/2 branches = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &falseVal,
 							},
 						},
@@ -87,16 +87,16 @@ func Test_Run(t *testing.T) {
 			name: "Blocks Force Push on 1/2 branches = 1 true and 1 false outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &trueVal,
 							},
 						},
@@ -111,16 +111,16 @@ func Test_Run(t *testing.T) {
 			name: "Blocks Force Push on 1/2 branches = 1 false and 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &falseVal,
 							},
 						},
@@ -135,16 +135,16 @@ func Test_Run(t *testing.T) {
 			name: "Blocks Force Push on 0/2 branches, 1 branch lacks data = 1 false and 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowForcePushes: nil,
 							},
 						},

--- a/probes/branchProtectionAppliesToAdmins/impl.go
+++ b/probes/branchProtectionAppliesToAdmins/impl.go
@@ -59,7 +59,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	for i := range r.Branches {
 		branch := &r.Branches[i]
 
-		p := branch.BranchProtectionRule.EnforceAdmins
+		p := branch.ProtectionRule.EnforceAdmins
 		text, outcome, err := branchprotection.GetTextOutcomeFromBool(p,
 			"branch protection settings apply to administrators",
 			*branch.Name)

--- a/probes/branchProtectionAppliesToAdmins/impl_test.go
+++ b/probes/branchProtectionAppliesToAdmins/impl_test.go
@@ -45,10 +45,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch enforces protection rules on admins = 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &trueVal,
 							},
 						},
@@ -63,16 +63,16 @@ func Test_Run(t *testing.T) {
 			name: "1 branch enforces protection rules on admins = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &trueVal,
 							},
 						},
@@ -87,16 +87,16 @@ func Test_Run(t *testing.T) {
 			name: "1 branch enforces protection rules on admins and 1 doesn't = 1 true & 1 false",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &falseVal,
 							},
 						},
@@ -111,16 +111,16 @@ func Test_Run(t *testing.T) {
 			name: "1 branch does not enforce protection rules on admins and 1 does = 1 false & 1 true",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &trueVal,
 							},
 						},
@@ -135,16 +135,16 @@ func Test_Run(t *testing.T) {
 			name: "1 branch does not enforce protection rules on admins and 1 doesn't have data = 1 false & 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								EnforceAdmins: nil,
 							},
 						},

--- a/probes/branchesAreProtected/impl_test.go
+++ b/probes/branchesAreProtected/impl_test.go
@@ -44,7 +44,7 @@ func Test_Run(t *testing.T) {
 			name: "One branch. Protection unknown",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name:      &branchVal1,
 							Protected: nil,
@@ -60,7 +60,7 @@ func Test_Run(t *testing.T) {
 			name: "Two protected branches",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name:      &branchVal1,
 							Protected: &trueVal,
@@ -80,7 +80,7 @@ func Test_Run(t *testing.T) {
 			name: "Two branches. First is protected",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name:      &branchVal1,
 							Protected: &trueVal,
@@ -100,7 +100,7 @@ func Test_Run(t *testing.T) {
 			name: "Two branches. Second is protected",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name:      &branchVal1,
 							Protected: &falseVal,
@@ -120,14 +120,14 @@ func Test_Run(t *testing.T) {
 			name: "Two branches. First one is not protected, second unknown",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name:      &branchVal1,
 							Protected: &falseVal,
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								AllowDeletions: nil,
 							},
 						},

--- a/probes/dismissesStaleReviews/impl.go
+++ b/probes/dismissesStaleReviews/impl.go
@@ -59,7 +59,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	for i := range r.Branches {
 		branch := &r.Branches[i]
 
-		p := branch.BranchProtectionRule.PullRequestRule.DismissStaleReviews
+		p := branch.ProtectionRule.PullRequestRule.DismissStaleReviews
 		text, outcome, err := branchprotection.GetTextOutcomeFromBool(p,
 			"stale review dismissal",
 			*branch.Name)

--- a/probes/dismissesStaleReviews/impl_test.go
+++ b/probes/dismissesStaleReviews/impl_test.go
@@ -45,10 +45,10 @@ func Test_Run(t *testing.T) {
 			name: "Dismisses stale reviews on 1/1 branches",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &trueVal,
 								},
@@ -65,10 +65,10 @@ func Test_Run(t *testing.T) {
 			name: "Dismisses stale reviews on 2/2 branches",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &trueVal,
 								},
@@ -76,7 +76,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &trueVal,
 								},
@@ -93,10 +93,10 @@ func Test_Run(t *testing.T) {
 			name: "Dismisses stale reviews on 1/2 branches - 1",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &trueVal,
 								},
@@ -104,7 +104,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &falseVal,
 								},
@@ -121,10 +121,10 @@ func Test_Run(t *testing.T) {
 			name: "Dismisses stale reviews on 1/2 branches - 2",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &falseVal,
 								},
@@ -132,7 +132,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &trueVal,
 								},
@@ -149,10 +149,10 @@ func Test_Run(t *testing.T) {
 			name: "Dismisses stale reviews on 0/2 branches",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: &falseVal,
 								},
@@ -160,7 +160,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									DismissStaleReviews: nil,
 								},

--- a/probes/requiresApproversForPullRequests/impl.go
+++ b/probes/requiresApproversForPullRequests/impl.go
@@ -66,7 +66,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		nilMsg := fmt.Sprintf("could not determine whether branch '%s' has required approving review count", *branch.Name)
 		falseMsg := fmt.Sprintf("branch '%s' does not require approvers", *branch.Name)
 
-		p := branch.BranchProtectionRule.PullRequestRule.RequiredApprovingReviewCount
+		p := branch.ProtectionRule.PullRequestRule.RequiredApprovingReviewCount
 
 		f, err := finding.NewWith(fs, Probe, "", nil, finding.OutcomeNotAvailable)
 		if err != nil {

--- a/probes/requiresApproversForPullRequests/impl_test.go
+++ b/probes/requiresApproversForPullRequests/impl_test.go
@@ -45,10 +45,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires 1 reviewer = 1 true outcome = 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &oneVal,
 								},
@@ -65,10 +65,10 @@ func Test_Run(t *testing.T) {
 			name: "2 branch require 1 reviewer each = 2 true outcomes = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &oneVal,
 								},
@@ -76,7 +76,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &oneVal,
 								},
@@ -93,10 +93,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires 1 reviewer and 1 branch requires 0 reviewers = 1 true and 1 false",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &oneVal,
 								},
@@ -104,7 +104,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &zeroVal,
 								},
@@ -121,10 +121,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires 0 reviewers and 1 branch requires 1 reviewer = 1 false and 1 true",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &zeroVal,
 								},
@@ -132,7 +132,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &oneVal,
 								},
@@ -149,10 +149,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires 0 reviewers and 1 branch lacks data = 1 false and 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: &zeroVal,
 								},
@@ -160,7 +160,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequiredApprovingReviewCount: nil,
 								},

--- a/probes/requiresCodeOwnersReview/impl.go
+++ b/probes/requiresCodeOwnersReview/impl.go
@@ -58,7 +58,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	for i := range r.Branches {
 		branch := &r.Branches[i]
 
-		reqOwnerReviews := branch.BranchProtectionRule.PullRequestRule.RequireCodeOwnerReviews
+		reqOwnerReviews := branch.ProtectionRule.PullRequestRule.RequireCodeOwnerReviews
 		var text string
 		var outcome finding.Outcome
 

--- a/probes/requiresCodeOwnersReview/impl_test.go
+++ b/probes/requiresCodeOwnersReview/impl_test.go
@@ -44,10 +44,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires code owner reviews with files = 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -65,10 +65,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires code owner reviews without files = 1 false outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -86,10 +86,10 @@ func Test_Run(t *testing.T) {
 			name: "2 branches require code owner reviews with files = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -97,7 +97,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -115,10 +115,10 @@ func Test_Run(t *testing.T) {
 			name: "2 branches require code owner reviews with files = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -126,7 +126,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -144,10 +144,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branches require code owner reviews and 1 branch doesn't with files = 1 true 1 false",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -155,7 +155,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &falseVal,
 								},
@@ -173,10 +173,10 @@ func Test_Run(t *testing.T) {
 			name: "Requires code owner reviews on 1/2 branches - without files = 1 true and 1 false",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -184,7 +184,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &falseVal,
 								},
@@ -202,10 +202,10 @@ func Test_Run(t *testing.T) {
 			name: "Requires code owner reviews on 1/2 branches - with files = 1 false and 1 true",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &falseVal,
 								},
@@ -213,7 +213,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -231,10 +231,10 @@ func Test_Run(t *testing.T) {
 			name: "Requires code owner reviews on 1/2 branches - without files = 2 false",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &falseVal,
 								},
@@ -242,7 +242,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &trueVal,
 								},
@@ -260,10 +260,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch does not require code owner review and 1 lacks data = 1 false and 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: &falseVal,
 								},
@@ -271,7 +271,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									RequireCodeOwnerReviews: nil,
 								},

--- a/probes/requiresLastPushApproval/impl.go
+++ b/probes/requiresLastPushApproval/impl.go
@@ -59,7 +59,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	for i := range r.Branches {
 		branch := &r.Branches[i]
 
-		p := branch.BranchProtectionRule.RequireLastPushApproval
+		p := branch.ProtectionRule.RequireLastPushApproval
 		text, outcome, err := branchprotection.GetTextOutcomeFromBool(p, "last push approval", *branch.Name)
 		if err != nil {
 			return nil, Probe, fmt.Errorf("create finding: %w", err)

--- a/probes/requiresLastPushApproval/impl_test.go
+++ b/probes/requiresLastPushApproval/impl_test.go
@@ -44,10 +44,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires last push approval = 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &trueVal,
 							},
 						},
@@ -62,16 +62,16 @@ func Test_Run(t *testing.T) {
 			name: "2 branches requires last push approval = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &trueVal,
 							},
 						},
@@ -86,16 +86,16 @@ func Test_Run(t *testing.T) {
 			name: "Last push approval enabled on 1/2 branches = 1 true and 1 false outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &trueVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &falseVal,
 							},
 						},
@@ -110,16 +110,16 @@ func Test_Run(t *testing.T) {
 			name: "Last push approval enabled on 1/2 branches = 1 false and 1 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &trueVal,
 							},
 						},
@@ -134,16 +134,16 @@ func Test_Run(t *testing.T) {
 			name: "1 branch does not require last push approval and 1 lacks data = 1 false and 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: &falseVal,
 							},
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								RequireLastPushApproval: nil,
 							},
 						},

--- a/probes/requiresPRsToChangeCode/impl.go
+++ b/probes/requiresPRsToChangeCode/impl.go
@@ -68,7 +68,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 			"If you think it might be the latter, make sure to run Scorecard with a PAT or use Repo " +
 			"Rules (that are always public) instead of Branch Protection settings"
 
-		p := branch.BranchProtectionRule.PullRequestRule.Required
+		p := branch.ProtectionRule.PullRequestRule.Required
 
 		f, err := finding.NewWith(fs, Probe, "", nil, finding.OutcomeNotAvailable)
 		if err != nil {

--- a/probes/requiresPRsToChangeCode/impl_test.go
+++ b/probes/requiresPRsToChangeCode/impl_test.go
@@ -43,10 +43,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires PRs to change code",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &trueVal,
 								},
@@ -63,10 +63,10 @@ func Test_Run(t *testing.T) {
 			name: "2 branches require PRs to change code = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &trueVal,
 								},
@@ -74,7 +74,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &trueVal,
 								},
@@ -91,10 +91,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branches require PRs to change code and 1 branch doesn't = 1 true 1 false",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &trueVal,
 								},
@@ -102,7 +102,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &falseVal,
 								},
@@ -119,10 +119,10 @@ func Test_Run(t *testing.T) {
 			name: "Requires PRs to change code on 1/2 branches = 1 false and 1 true",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &falseVal,
 								},
@@ -130,7 +130,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &trueVal,
 								},
@@ -147,10 +147,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch does not require PRs to change code and 1 lacks data = 1 false and 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: &falseVal,
 								},
@@ -158,7 +158,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								PullRequestRule: clients.PullRequestRule{
 									Required: nil,
 								},

--- a/probes/requiresUpToDateBranches/impl.go
+++ b/probes/requiresUpToDateBranches/impl.go
@@ -59,7 +59,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 	for i := range r.Branches {
 		branch := &r.Branches[i]
 
-		p := branch.BranchProtectionRule.CheckRules.UpToDateBeforeMerge
+		p := branch.ProtectionRule.CheckRules.UpToDateBeforeMerge
 		text, outcome, err := branchprotection.GetTextOutcomeFromBool(p,
 			"up-to-date branches",
 			*branch.Name)

--- a/probes/requiresUpToDateBranches/impl_test.go
+++ b/probes/requiresUpToDateBranches/impl_test.go
@@ -44,10 +44,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch requires up-to-date before merge = 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &trueVal,
 								},
@@ -64,10 +64,10 @@ func Test_Run(t *testing.T) {
 			name: "2 branches require up-to-date before merge = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &trueVal,
 								},
@@ -75,7 +75,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &trueVal,
 								},
@@ -92,10 +92,10 @@ func Test_Run(t *testing.T) {
 			name: "Requires up to date branches on 1/2 branches = 1 true and 1 false outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &trueVal,
 								},
@@ -103,7 +103,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &falseVal,
 								},
@@ -120,10 +120,10 @@ func Test_Run(t *testing.T) {
 			name: "Requires up to date branches on 1/2 branches = 1 false and 1 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &falseVal,
 								},
@@ -131,7 +131,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &trueVal,
 								},
@@ -148,10 +148,10 @@ func Test_Run(t *testing.T) {
 			name: "1 branch does no require up-to-date before merge and 1 branch lacks data= 1 true & 1 unavailable",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: &falseVal,
 								},
@@ -159,7 +159,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									UpToDateBeforeMerge: nil,
 								},

--- a/probes/runsStatusChecksBeforeMerging/impl.go
+++ b/probes/runsStatusChecksBeforeMerging/impl.go
@@ -61,7 +61,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		var err error
 
 		switch {
-		case len(branch.BranchProtectionRule.CheckRules.Contexts) > 0:
+		case len(branch.ProtectionRule.CheckRules.Contexts) > 0:
 			f, err = finding.NewWith(fs, Probe,
 				fmt.Sprintf("status check found to merge onto on branch '%s'", *branch.Name), nil,
 				finding.OutcomeTrue)

--- a/probes/runsStatusChecksBeforeMerging/impl_test.go
+++ b/probes/runsStatusChecksBeforeMerging/impl_test.go
@@ -43,10 +43,10 @@ func Test_Run(t *testing.T) {
 			name: "Runs status checks on 1/1 branches with contexts = 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{"foo"},
 								},
@@ -63,10 +63,10 @@ func Test_Run(t *testing.T) {
 			name: "Runs status checks on 2/2 branches with contexts = 2 true outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{"foo"},
 								},
@@ -74,7 +74,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{"foo"},
 								},
@@ -91,10 +91,10 @@ func Test_Run(t *testing.T) {
 			name: "Runs status checks on 1/2 branches = 1 true and 1 false outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{"foo"},
 								},
@@ -102,7 +102,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{},
 								},
@@ -119,10 +119,10 @@ func Test_Run(t *testing.T) {
 			name: "Runs status checks on 1/2 branches = 1 false and 1 true outcome",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{},
 								},
@@ -130,7 +130,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{"foo"},
 								},
@@ -147,10 +147,10 @@ func Test_Run(t *testing.T) {
 			name: "Runs status checks on 0/2 branches = 2 false outcomes",
 			raw: &checker.RawResults{
 				BranchProtectionResults: checker.BranchProtectionsData{
-					Branches: []clients.BranchRef{
+					Branches: []clients.RepoRef{
 						{
 							Name: &branchVal1,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{},
 								},
@@ -158,7 +158,7 @@ func Test_Run(t *testing.T) {
 						},
 						{
 							Name: &branchVal2,
-							BranchProtectionRule: clients.BranchProtectionRule{
+							ProtectionRule: clients.ProtectionRule{
 								CheckRules: clients.StatusChecksRule{
 									Contexts: []string{},
 								},


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This adds a `tagsHandler` to the `githubrepo` client. The `tagsHandler` follows a similar procedure as the `branchesHandler` and reuses many of its utilities. The `tagsHandler` implements the following methods:

1. `init`: Similar to `branchesHandler`'s `init`.
2. `setup`: Fetches all rulesets and tags of the repository and stores it.
3. `query`: Returns a `clients.RepoRef` of a branch.
4. `getTags`: Returns a slice of all tags as `RepoRef`'s with their rulesets.
5. `getTag`: Calls `query` and returns the `RepoRef`.

To implement this `tagsHandler`, I have had to make a number of changes:

1. I have renamed `BranchRef` to `RepoRef`. 
2. I have renamed `branch` `ref`.
3. I have renamed other similar types from being branch-specific to be logically usable for storing tag data.

Furthermore, I have added `GetTag` and `ListTags` methods to the repoclient interface and the clients that implement the repoclient. This is the most user-exposed the `tagsHandler` currently, and these two methods are not used anywhere. They are there to demonstrate the intent of how to use the `githubrepo` `tagsHandler`. 

The PR is quite large as it is now, so I'd prefer to follow up with probes for this once it is merged.

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes https://github.com/ossf/scorecard/issues/10 and https://github.com/ossf/scorecard/issues/2476

or

NONE
-->

Fixes https://github.com/ossf/scorecard/issues/10 and https://github.com/ossf/scorecard/issues/2476

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
