### PR TITLE
:bug: parse docker build args when evaluating pinned containers

### DIFF
--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -382,6 +382,10 @@ func TestDockerfilePinning(t *testing.T) {
 			filename: "Dockerfile-not-pinned-with-parser-error",
 			warns:    1,
 		},
+		{
+			name:     "parser understands docker args",
+			filename: "Dockerfile-pinned-arg",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/raw/testdata/Dockerfile-pinned-arg
+++ b/checks/raw/testdata/Dockerfile-pinned-arg
@@ -1,0 +1,19 @@
+# regression for https://github.com/ossf/scorecard/issues/3684
+ARG REGISTRY=docker.io
+ARG GO_VER=1.21-alpine@sha256:110b07af87238fbdc5f1df52b00927cf58ce3de358eeeb1854f10a8b5e5e1411
+ARG SDK_VERSION=9.0
+
+FROM ${REGISTRY}/library/golang:${GO_VER} as golang
+#...
+
+FROM golang as tool1
+#...
+
+FROM golang as tool2
+#...
+
+# regression for https://github.com/ossf/scorecard/issues/4779
+FROM mcr.microsoft.com/dotnet/sdk:8.0.413@sha256:45e41fe52eb60f42bd75c83b7e8bfff0523e031e042b4c1fc7ddb9c348898c64 AS dotnet-sdk-8.0
+FROM mcr.microsoft.com/dotnet/sdk:9.0.304@sha256:840f3b62b9742dde4461a3c31e38ffd34d41d7d33afd39c378cfcfd5dcb82bd5 AS dotnet-sdk-9.0
+FROM dotnet-sdk-${SDK_VERSION} AS build
+


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Docker args aren't parsed, so some Dockerfiles are being flagged as unpinned when they are pinned (unless overridden)

#### What is the new behavior (if this is a feature change)?**
Docker args are replaced with their default value before we evaluate the rest

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #4779
Fixes #3684 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Docker args are now evaluated when determining if container images are pinned.
```
