### PR TITLE
:bug: localdir: log and skip dangling symlinks

### DIFF
--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -171,8 +171,7 @@ func (client *Client) ListFiles(predicate func(string) (bool, error)) ([]string,
 
 func getFile(clientpath, filename string) (*os.File, error) {
 	// Note: the filenames do not contain the original path - see ListFiles().
-	fn := path.Join(clientpath, filename)
-	f, err := os.Open(fn)
+	f, err := os.OpenInRoot(clientpath, filename)
 	if err != nil {
 		return nil, fmt.Errorf("open file: %w", err)
 	}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bugfix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

- Dangling symlinks fail whole runs
- Symlinks could traverse the local directory

#### What is the new behavior (if this is a feature change)?**

- Dangling symlinks are logged to stderr and skipped
- symlinks are rooted using Go 1.24's os.root https://go.dev/blog/osroot


- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #4654
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Scorecard now skips dangling symlinks and detects symlink path traversal when run on local files. Note: Scorecard has always skipped all symlinks when run against a remote repository.
```
