### PR TITLE
:seedling: enable jsonv2 experiment in the cron worker

### DIFF
--- a/cron/internal/worker/Dockerfile
+++ b/cron/internal/worker/Dockerfile
@@ -22,6 +22,7 @@ COPY . ./
 FROM base AS worker
 ARG TARGETOS
 ARG TARGETARCH
+ENV GOEXPERIMENT=jsonv2
 RUN CGO_ENABLED=0 make build-worker
 
 FROM gcr.io/distroless/base:nonroot@sha256:06c713c675e983c5aea030592b1d635954218d29c4db2f8ec66912da1b87e228


### PR DESCRIPTION




#### What kind of change does this PR introduce?

cron update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
JSON decoding represents 15% of our heap allocations according to a pprof sample taken in the scorecard-batch-worker-releasetest deployment.

```
Showing nodes accounting for 275.42MB, 93.55% of 294.42MB total
Dropped 99 nodes (cum <= 1.47MB)
Showing top 10 nodes out of 43
      flat  flat%   sum%        cum   cum%
   88.74MB 30.14% 30.14%    88.74MB 30.14%  github.com/google/osv-scanner/internal/local.(*ZipDB).Vulnerabilities
   43.52MB 14.78% 44.93%    43.52MB 14.78%  encoding/json.(*decodeState).literalStore
   38.51MB 13.08% 58.01%    38.51MB 13.08%  reflect.mapassign_faststr0
   28.51MB  9.68% 67.69%    46.01MB 15.63%  encoding/json.(*decodeState).objectInterface
      28MB  9.51% 77.20%       28MB  9.51%  reflect.growslice
   21.93MB  7.45% 84.65%   189.98MB 64.53%  github.com/google/osv-scanner/internal/local.(*ZipDB).loadZipFile
   11.50MB  3.91% 88.55%    11.50MB  3.91%  encoding/json.unquote (inline)
       6MB  2.04% 90.59%    12.50MB  4.25%  encoding/json.(*decodeState).literalInterface
       5MB  1.70% 92.29%        5MB  1.70%  reflect.MakeMapWithSize
    3.71MB  1.26% 93.55%     3.71MB  1.26%  github.com/goccy/go-json/internal/decoder.init.0
```

#### What is the new behavior (if this is a feature change)?**
We try the jsonv2 experiment, where the Go Blog shows a potential for 10x improvements in unmarshaling:

	The Unmarshal performance of v2 is significantly faster than v1,
	with benchmarks demonstrating improvements of up to 10x

https://go.dev/blog/jsonv2-exp#performance-optimizations
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
* unit tests and e2e tests both pass with `GOEXPERIMENT=jsonv2` set (after changing a minor error string phrasing change)
* running `scdiff` to compare setting/unsetting`GOEXPERIMENT=jsonv2` were identical.
#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
