### PR TITLE
:seedling: MAINTAINERS: Add Adam Korczynski (AdamKorcz), ADA Logics

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,7 @@ The current standing Steering Committee members are as follows:
 
 - Stephen Augustus ([@justaugustus](https://github.com/justaugustus)), Bloomberg
 - Raghav Kaul ([@raghavkaul](https://github.com/raghavkaul)), Google
+- Adam Korczynski ([@AdamKorcz](https://github.com/AdamKorcz)), ADA Logics
 - Spencer Schrock ([@spencerschrock](https://github.com/spencerschrock)), Google
 
 ## `scorecard-doc-maintainers`


### PR DESCRIPTION
#### What kind of change does this PR introduce?

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

The @ossf/scorecard-maintainers would like to nominate Adam Korczynski (@AdamKorcz) to ***join the project as a maintainer***!

Adam (and ADA Logics) have made outsized contributions to the Scorecard project, including the [Structured Results](https://openssf.org/blog/2024/04/17/beyond-scores-with-openssf-scorecard-granular-structured-results-for-custom-policy-enforcement/) feature, analysis and remediation of project fuzzing results (via contributions and in [OSS-Fuzz](https://google.github.io/oss-fuzz/)), and conducting our soon-to-be released first security audit.

As of 2025-10-02, Adam has:

- contributed [45 pull requests](https://github.com/ossf/scorecard/pulls?q=is%3Apr+is%3Amerged+author%3AAdamKorcz+created%3A%3C%3D2025-10-02)
- participated in [15 issue discussions](https://github.com/ossf/scorecard/issues?q=is%3Aissue%20commenter%3AAdamKorcz%20created%3A%3C%3D2025-10-02)

ref: https://github.com/ossf/scorecard/blob/main/CONTRIBUTOR_LADDER.md#maintainers

(This has been previous discussed amongst the Scorecard Steering Committee and Adam.)

#### What is the current behavior?

Adam is not a maintainer. 😢 

#### What is the new behavior (if this is a feature change)?**

- (N/A) Tests for the changes have been added (for bug fixes/features)

Adam becomes a maintainer! 🚀  

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

I will make the requisite access changes once this merges.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
MAINTAINERS: Add Adam Korczynski (AdamKorcz), ADA Logics
```
