### PR TITLE
chore: remove redundant code

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Run secret-dependent integration tests only after approval
 name: Integration tests
 
 on:
@@ -27,21 +26,9 @@ env:
   GO_VERSION: stable
 
 jobs:
-  approve:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
-        with:
-          egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
-
-      - name: approve
-        run: echo For security reasons, all pull requests need to be approved before running integration tests.
-
   integration-trusted:
     runs-on: ubuntu-latest
     environment: integration-test
-    needs: [approve]
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Remove redundant code from when `pull_request_target` was used that was removed by #2672.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

A redundant always-passing job runs (`Integration tests / approve (pull_request)`).

#### What is the new behavior (if this is a feature change)?**

The redundant job has been removed.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

None.

#### Does this PR introduce a user-facing change?

No.

```release-note
NONE
```
