### PR TITLE
:bug: add check for empty github workflow `uses`

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -789,7 +789,7 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 					fmt.Sprintf("unable to parse step '%v' for job '%v'", jobName, stepName))
 			}
 
-			if execAction == nil || execAction.Uses == nil {
+			if execAction == nil || execAction.Uses == nil || execAction.Uses.Value == "" {
 				// Cannot check further, continue.
 				continue
 			}

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -77,6 +77,11 @@ func TestGithubWorkflowPinning(t *testing.T) {
 			filename: "./testdata/.github/workflows/github-workflow-unknown-os.yaml",
 			warns:    2, // 1 in job with unknown OS, 1 in job with known OS
 		},
+		{
+			name:     "YAML anchor usage doesn't panic",
+			filename: "./testdata/.github/workflows/workflow-anchor.yaml",
+			warns:    1, // anchor definition is unpinned, but alias isn't supported by actionlint
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/raw/testdata/.github/workflows/workflow-anchor.yaml
+++ b/checks/raw/testdata/.github/workflows/workflow-anchor.yaml
@@ -1,0 +1,30 @@
+# Copyright 2025 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+name: CI
+
+on:
+  push:
+
+jobs:
+  yaml-anchor:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload coverage artifact
+        uses: &actions-upload-artifact actions/upload-artifact@v4.6.2
+
+  yaml-alias:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Upload coverage artifact
+        uses: *actions-upload-artifact


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The Pinned-Dependency check is dereferencing nil pointers on repos which use GitHub's new YAML anchor syntax in their workflows.
https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/

#### What is the new behavior (if this is a feature change)?**
Ignore cases where the `uses` field isn't set. The value isn't actually empty in the testcase which triggered the panic, but our GitHub workflow library doesn't currently support parsing GitHub's new  YAML anchors/aliases.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
