### PR TITLE
:bug: disable transitive osv-scanner scanning

### DIFF
--- a/clients/osv.go
+++ b/clients/osv.go
@@ -61,6 +61,11 @@ func (v osvClient) ListUnfixedVulnerabilities(
 		GitCommits:        gitCommits,
 		CompareOffline:    v.local,
 		DownloadDatabases: v.local,
+		ExperimentalScannerActions: osvscanner.ExperimentalScannerActions{
+			TransitiveScanningActions: osvscanner.TransitiveScanningActions{
+				Disabled: true,
+			},
+		},
 	}) // TODO: Do logging?
 
 	response := VulnerabilitiesResponse{}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The weekly scan infrastructure has a huge increase in vCPU usage, at least 5-10x. This caused the entire weekly scan infrastructure to grind to a halt through evictions, crashes, and backoff loops.

#### What is the new behavior (if this is a feature change)?**
Disable the transitive scanning introduced in #4833 

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Disabled transitive scanning in osv-scanner v2 due to excessive resource consumption
```
