### PR TITLE
:seedling: osv: re-enable transitive scanning without pypi

### DIFF
--- a/clients/osv.go
+++ b/clients/osv.go
@@ -61,10 +61,10 @@ func (v osvClient) ListUnfixedVulnerabilities(
 		GitCommits:        gitCommits,
 		CompareOffline:    v.local,
 		DownloadDatabases: v.local,
+		// swap out the transitive requirements scanning for offline extractor
 		ExperimentalScannerActions: osvscanner.ExperimentalScannerActions{
-			TransitiveScanningActions: osvscanner.TransitiveScanningActions{
-				Disabled: true,
-			},
+			PluginsEnabled:  []string{"python/requirements"},
+			PluginsDisabled: []string{"python/requirementsenhanceable"},
 		},
 	}) // TODO: Do logging?
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

config tweak

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
All transitive dependency scanning was disabled

#### What is the new behavior (if this is a feature change)?**
Only the Python transitive scanning is disabled.

Plugins are a new osv-scanner/osv-scalibr way of disabling specific features, which give us finer control over what features to toggle.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Re-enabled transitive scanning in osv-scanner v2 except for PyPI
```
