### PR TITLE
:seedling: workflows: Add OSPS baseline assessment GitHub Action

### DIFF
--- a/.github/workflows/osps-baseline.yml
+++ b/.github/workflows/osps-baseline.yml
@@ -22,7 +22,7 @@ jobs:
         with:
             owner: ${{ github.repository_owner }}
             repo: ${{ github.event.repository.name }}
-            token: ${{ secrets.GITHUB_TOKEN }}
+            token: ${{ secrets.GH_AUTH_TOKEN }}
             catalog: "osps-baseline"
             upload-sarif: "true"
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

[Follow-up from today's Steering meeting.]

As part of year-end, OpenSSF would like projects to evaluate themselves against the [OSPS Baseline](https://openssf.org/projects/osps-baseline/).

Adding this [GitHub Action](https://github.com/marketplace/actions/open-source-project-security-baseline-scanner) allows us to do an initial automated assessment.

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
