### PR TITLE
:seedling: cron: remove error wrapping workaround

### DIFF
--- a/cron/data/blob.go
+++ b/cron/data/blob.go
@@ -22,7 +22,6 @@ import (
 	"io"
 	"time"
 
-	"cloud.google.com/go/storage"
 	"gocloud.dev/blob"
 	_ "gocloud.dev/blob/fileblob" // Needed to read file:/// buckets. Intended primarily for testing, though needed here for tests outside the package.
 	_ "gocloud.dev/blob/gcsblob"  // Needed to link in GCP drivers.
@@ -99,8 +98,7 @@ func BlobExists(ctx context.Context, bucketURL, key string) (bool, error) {
 	defer bucket.Close()
 
 	ret, err := bucket.Exists(ctx, key)
-	// TODO(https://github.com/ossf/scorecard/issues/4636)
-	if err != nil && !errors.Is(err, storage.ErrObjectNotExist) {
+	if err != nil {
 		return ret, fmt.Errorf("error during bucket.Exists: %w", err)
 	}
 	return ret, nil

--- a/cron/data/blob_test.go
+++ b/cron/data/blob_test.go
@@ -16,6 +16,7 @@ package data
 
 import (
 	"errors"
+	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -165,6 +166,66 @@ func TestBlobKeysPrefix(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, testcase.want) {
 				t.Errorf("got = %v, want %v", got, testcase.want)
+			}
+		})
+	}
+}
+
+func TestBlobExists(t *testing.T) {
+	t.Parallel()
+	testcases := []struct {
+		name      string
+		bucketURL string
+		key       string
+		want      bool
+		wantErr   bool
+	}{
+		{
+			name: "exists",
+			bucketURL: func() string {
+				// convert local to absolute path, which is needed for the fileblob bucket
+				testdataPath, err := filepath.Abs("testdata/blob_test")
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return "file:///" + testdataPath
+			}(),
+			key:     "key1.txt",
+			want:    true,
+			wantErr: false,
+		},
+		{
+			name: "not exists",
+			bucketURL: func() string {
+				// convert local to absolute path, which is needed for the fileblob bucket
+				testdataPath, err := filepath.Abs("testdata/blob_test")
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return "file:///" + testdataPath
+			}(),
+			key:     "notfound.txt",
+			want:    false,
+			wantErr: false,
+		},
+		{
+			name:      "open bucket error",
+			bucketURL: "invalid",
+			want:      false,
+			wantErr:   true,
+		},
+	}
+
+	for i := range testcases {
+		tt := &testcases[i]
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			exists, err := BlobExists(t.Context(), tt.bucketURL, tt.key)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("BlobExists() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if exists != tt.want {
+				t.Errorf("expected blob to exist: got %v, want %v", exists, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This removes the workaround for the error wrapping in the `cron/data` package.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Behaviour is not changed.

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4636

#### Special notes for your reviewer

`gocloud.dev` has been upgraded by #4773

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
