### PR TITLE
🌱 New check: Mean time to update dependencies

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -40,6 +40,7 @@ type RawResults struct {
 	SBOMResults                 SBOMData
 	MaintainedResults           MaintainedData
 	Metadata                    MetadataData
+	MTTUDependenciesResults     MTTUDependenciesData
 	PackagingResults            PackagingData
 	PinningDependenciesResults  PinningDependenciesData
 	SASTResults                 SASTData
@@ -300,6 +301,36 @@ type SASTWorkflow struct {
 // for the Security-Policy check.
 type SecurityPolicyData struct {
 	PolicyFiles []SecurityPolicyFile
+}
+
+type MTTUDependenciesData struct {
+	Dependencies []LockDependency
+}
+
+// Ecosystem represents the ecosystem of a dependency.
+type Ecosystem string
+
+const (
+	EcosystemCargo    Ecosystem = "CARGO"
+	EcosystemGo       Ecosystem = "GO"
+	EcosystemMaven    Ecosystem = "MAVEN"
+	EcosystemNPM      Ecosystem = "NPM"
+	EcosystemNuget    Ecosystem = "NUGET"
+	EcosystemPypi     Ecosystem = "PYPI"
+	EcosystemRubyGems Ecosystem = "RUBYGEMS"
+)
+
+func (e Ecosystem) String() string {
+	return string(e)
+}
+
+type LockDependency struct {
+	TimeSinceOldestReleast time.Time
+	IsLatest               *bool
+	Name                   string
+	Version                string
+	Comparator             string
+	Ecosystem              Ecosystem
 }
 
 // BinaryArtifactData contains the raw results

--- a/checks/MTTUDependencies.go
+++ b/checks/MTTUDependencies.go
@@ -1,0 +1,64 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/checks/evaluation"
+	"github.com/ossf/scorecard/v5/checks/raw"
+	sce "github.com/ossf/scorecard/v5/errors"
+	"github.com/ossf/scorecard/v5/probes"
+	zrunner "github.com/ossf/scorecard/v5/probes/zrunner"
+)
+
+const CheckMTTUDependencies = "MTTUDependencies"
+
+//nolint:gochecknoinits
+func init() {
+	supportedRequestTypes := []checker.RequestType{
+		checker.FileBased,
+	}
+	if err := registerCheck(CheckMTTUDependencies, MTTUDependencies, supportedRequestTypes); err != nil {
+		// this should never happen
+		panic(err)
+	}
+}
+
+// indirections to ease testing.
+var runProbes = zrunner.Run
+
+func MTTUDependencies(c *checker.CheckRequest) checker.CheckResult {
+	// 1) get raw data
+	rawData, err := raw.MTTUDependencies(c)
+	if err != nil {
+		e := sce.WithMessage(sce.ErrScorecardInternal, err.Error())
+		return checker.CreateRuntimeErrorResult(CheckMTTUDependencies, e)
+	}
+
+	// 2) set raw results
+	pRawResults := getRawResults(c)
+	pRawResults.MTTUDependenciesResults = rawData
+
+	// 3) run probes
+	findings, err := runProbes(pRawResults, probes.MTTUDependencies)
+	if err != nil {
+		e := sce.WithMessage(sce.ErrScorecardInternal, err.Error())
+		return checker.CreateRuntimeErrorResult(CheckMTTUDependencies, e)
+	}
+
+	// 4) evaluate
+	ret := evaluation.MTTUDependencies(CheckMTTUDependencies, findings, c.Dlogger)
+	return ret
+}

--- a/checks/MTTUDependencies_test.go
+++ b/checks/MTTUDependencies_test.go
@@ -1,0 +1,759 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package checks
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/ossf/scorecard/v5/checker"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
+	scut "github.com/ossf/scorecard/v5/utests"
+)
+
+// ---- RoundTripper helper to mock deps.dev ----
+
+type rtFunc func(*http.Request) (*http.Response, error)
+
+func (f rtFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+//nolint:gocognit,paralleltest // test function with many test cases
+func TestMTTUDependencies_TableDriven(t *testing.T) {
+	type tc struct {
+		files       map[string]string
+		ddResponses map[string]string
+		name        string
+		wantScore   int
+		wantErr     bool
+	}
+
+	// Helpers for relative timestamps
+	tsDaysAgo := func(d int) string {
+		return time.Now().UTC().AddDate(0, 0, -d).Format(time.RFC3339)
+	}
+	const (
+		longAgo   = 365 // ≥180d → High
+		midAgo    = 30  // [14d,180d) → Low
+		recentAgo = 6   // <14d → VeryLow
+		d60       = 60
+		d90       = 90
+		d300      = 300
+		d455      = 455
+		d445      = 445
+		d435      = 435
+		d500      = 500
+		d200      = 200
+	)
+
+	// ---- Per-testcase deps.dev responses built with relative dates ----
+
+	respNPMA := fmt.Sprintf(`{
+  "packageKey": {"system":"npm","name":"a"},
+  "purl":"pkg:npm/a",
+  "versions":[
+    {"versionKey":{"system":"npm","name":"a","version":"0.9.0"},"purl":"pkg:npm/a@0.9.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"a","version":"0.9.1"},"purl":"pkg:npm/a@0.9.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"a","version":"0.9.2"},"purl":"pkg:npm/a@0.9.2","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"a","version":"1.0.0"},"purl":"pkg:npm/a@1.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	respNPMB := fmt.Sprintf(`{
+  "packageKey": {"system":"npm","name":"b"},
+  "purl":"pkg:npm/b",
+  "versions":[
+    {"versionKey":{"system":"npm","name":"b","version":"1.8.0"},"purl":"pkg:npm/b@1.8.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"1.9.0"},"purl":"pkg:npm/b@1.9.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"1.9.1"},"purl":"pkg:npm/b@1.9.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"2.0.0"},"purl":"pkg:npm/b@2.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	// go.mod testcase constants: system "go", name "github.com/mod/a".
+	// Project uses v1.2.3, but newer versions exist and the oldest newer (v1.2.4) is long ago,
+	// so meantime ≥ 180 days → High probe true → score 0 (deterministic).
+	respGoModA := fmt.Sprintf(`{
+  "packageKey": {"system":"go","name":"github.com/mod/a"},
+  "purl":"pkg:go/github.com/mod/a",
+  "versions":[
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.3"},"purl":"pkg:go/github.com/mod/a@v1.2.3","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.4"},"purl":"pkg:go/github.com/mod/a@v1.2.4","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.3.0"},"purl":"pkg:go/github.com/mod/a@v1.3.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v2.0.0"},"purl":"pkg:go/github.com/mod/a@v2.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d500), tsDaysAgo(longAgo), tsDaysAgo(d300), tsDaysAgo(d200))
+
+	// go.mod: LOW window (mean in [14d, 180d)).
+	// Project uses v1.2.3. Oldest newer is v1.2.4 published ~30 days ago.
+	respGoModALow := fmt.Sprintf(`{
+  "packageKey": {"system":"go","name":"github.com/mod/a"},
+  "purl":"pkg:go/github.com/mod/a",
+  "versions":[
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.2"},"purl":"pkg:go/github.com/mod/a@v1.2.2","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.3"},"purl":"pkg:go/github.com/mod/a@v1.2.3","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.4"},"purl":"pkg:go/github.com/mod/a@v1.2.4","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.3.0"},"purl":"pkg:go/github.com/mod/a@v1.3.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d90), tsDaysAgo(d60), tsDaysAgo(midAgo), tsDaysAgo(recentAgo))
+
+	// go.mod: VERY LOW window (mean < 14d).
+	// Project uses v1.2.3 and that is the default/latest version → contributes 0 → score 10.
+	respGoModAVeryLowLatest := fmt.Sprintf(`{
+  "packageKey": {"system":"go","name":"github.com/mod/a"},
+  "purl":"pkg:go/github.com/mod/a",
+  "versions":[
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.0"},"purl":"pkg:go/github.com/mod/a@v1.2.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.1"},"purl":"pkg:go/github.com/mod/a@v1.2.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.2"},"purl":"pkg:go/github.com/mod/a@v1.2.2","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"go","name":"github.com/mod/a","version":"v1.2.3"},"purl":"pkg:go/github.com/mod/a@v1.2.3","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d90), tsDaysAgo(d60), tsDaysAgo(midAgo), tsDaysAgo(recentAgo))
+
+	respNPMAPackageJSON := fmt.Sprintf(`{
+  "packageKey": {"system":"npm","name":"a"},
+  "purl":"pkg:npm/a",
+  "versions":[
+    {"versionKey":{"system":"npm","name":"a","version":"0.9.0"},"purl":"pkg:npm/a@0.9.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"a","version":"0.9.1"},"purl":"pkg:npm/a@0.9.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"a","version":"0.9.2"},"purl":"pkg:npm/a@0.9.2","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"a","version":"1.0.0"},"purl":"pkg:npm/a@1.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	respNPMBPackageJSON := fmt.Sprintf(`{
+  "packageKey": {"system":"npm","name":"b"},
+  "purl":"pkg:npm/b",
+  "versions":[
+    {"versionKey":{"system":"npm","name":"b","version":"1.8.0"},"purl":"pkg:npm/b@1.8.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"1.9.0"},"purl":"pkg:npm/b@1.9.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"1.9.1"},"purl":"pkg:npm/b@1.9.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"2.0.0"},"purl":"pkg:npm/b@2.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	respNPMBPackageJSONLow := fmt.Sprintf(`{
+  "packageKey": {"system":"npm","name":"b"},
+  "purl":"pkg:npm/b",
+  "versions":[
+    {"versionKey":{"system":"npm","name":"b","version":"1.9.9"},"purl":"pkg:npm/b@1.9.9","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"2.0.0"},"purl":"pkg:npm/b@2.0.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"2.0.1"},"purl":"pkg:npm/b@2.0.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"npm","name":"b","version":"2.1.0"},"purl":"pkg:npm/b@2.1.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d90), tsDaysAgo(d60), tsDaysAgo(midAgo), tsDaysAgo(recentAgo))
+
+	respPyPIALatest := fmt.Sprintf(`{
+  "packageKey": {"system":"pypi","name":"aa"},
+  "purl":"pkg:pypi/a",
+  "versions":[
+    {"versionKey":{"system":"pypi","name":"aa","version":"0.9.0"},"purl":"pkg:pypi/a@0.9.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"aa","version":"0.9.1"},"purl":"pkg:pypi/a@0.9.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"aa","version":"0.9.2"},"purl":"pkg:pypi/a@0.9.2","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"aa","version":"1.0.0"},"purl":"pkg:pypi/a@1.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	respPyPIBLatest := fmt.Sprintf(`{
+  "packageKey": {"system":"pypi","name":"b"},
+  "purl":"pkg:pypi/b",
+  "versions":[
+    {"versionKey":{"system":"pypi","name":"bb","version":"1.9.9"},"purl":"pkg:pypi/b@1.9.9","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"bb","version":"1.9.10"},"purl":"pkg:pypi/b@1.9.10","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"bb","version":"1.9.11"},"purl":"pkg:pypi/b@1.9.11","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d90), tsDaysAgo(d60), tsDaysAgo(d60))
+
+	respPyPICLatest := fmt.Sprintf(`{
+  "packageKey": {"system":"pypi","name":"cc"},
+  "purl":"pkg:pypi/c",
+  "versions":[
+    {"versionKey":{"system":"pypi","name":"cc","version":"2.9.9"},"purl":"pkg:pypi/c@2.9.9","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"cc","version":"2.9.10"},"purl":"pkg:pypi/c@2.9.10","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"cc","version":"2.9.11"},"purl":"pkg:pypi/c@2.9.11","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"pypi","name":"cc","version":"3.0.0"},"purl":"pkg:pypi/c@3.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	respMavenALatest := fmt.Sprintf(`{
+  "packageKey": {"system":"maven","name":"com.example:a"},
+  "purl":"pkg:maven/com.example/a",
+  "versions":[
+    {"versionKey":{"system":"maven","name":"com.example:a","version":"0.9.0"},"purl":"pkg:maven/com.example/a@0.9.0","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:a","version":"0.9.1"},"purl":"pkg:maven/com.example/a@0.9.1","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:a","version":"0.9.2"},"purl":"pkg:maven/com.example/a@0.9.2","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:a","version":"1.0.0"},"purl":"pkg:maven/com.example/a@1.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	// For the "one stale → Low" case, make the oldest-newer ~60d ago.
+	respMavenBLatest := fmt.Sprintf(`{
+  "packageKey": {"system":"maven","name":"com.example:b"},
+  "purl":"pkg:maven/com.example/b",
+  "versions":[
+    {"versionKey":{"system":"maven","name":"com.example:b","version":"1.9.9"},"purl":"pkg:maven/com.example/b@1.9.9","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:b","version":"1.9.10"},"purl":"pkg:maven/com.example/b@1.9.10","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:b","version":"1.9.11"},"purl":"pkg:maven/com.example/b@1.9.11","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d90), tsDaysAgo(d60+10), tsDaysAgo(d60))
+
+	respMavenCLatest := fmt.Sprintf(`{
+  "packageKey": {"system":"maven","name":"com.example:c"},
+  "purl":"pkg:maven/com.example/c",
+  "versions":[
+    {"versionKey":{"system":"maven","name":"com.example:c","version":"2.9.9"},"purl":"pkg:maven/com.example/c@2.9.9","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:c","version":"2.9.10"},"purl":"pkg:maven/com.example/c@2.9.10","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:c","version":"2.9.11"},"purl":"pkg:maven/com.example/c@2.9.11","publishedAt":"%s","isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"maven","name":"com.example:c","version":"3.0.0"},"purl":"pkg:maven/com.example/c@3.0.0","publishedAt":"%s","isDefault":true,"isDeprecated":false}
+  ]
+}`, tsDaysAgo(d455), tsDaysAgo(d445), tsDaysAgo(d435), tsDaysAgo(longAgo))
+
+	tests := []tc{
+		{
+			name: "npm-lock all-latest → VeryLow true → score 10",
+			files: map[string]string{
+				// Aligns with expected packages: a@1.0.0 and b@2.0.0.
+				"package-lock.json": `{
+		  "name": "example",
+		  "version": "1.0.0",
+		  "lockfileVersion": 1,
+		  "dependencies": {
+		    "a": { "version": "1.0.0" },
+		    "b": { "version": "2.0.0" }
+		  }
+		}`,
+			},
+			ddResponses: map[string]string{
+				"NPM/a": respNPMA, // latest is 1.0.0 (default)
+				"NPM/b": respNPMB, // latest is 2.0.0 (default)
+			},
+			wantScore: 10, // mean = 0 → VeryLow probe true → score 10
+		},
+		{
+			name: "javascript package.json all-latest → VeryLow true → score 10",
+			files: map[string]string{
+				"package.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "dependencies": {
+				    "a": "1.0.0",
+				    "b": "2.0.0"
+				  }
+				}`,
+				"package-lock.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "lockfileVersion": 2,
+				  "requires": true,
+				  "packages": {
+				    "": {
+				      "name": "example",
+				      "version": "1.0.0",
+				      "dependencies": {
+				        "a": "1.0.0",
+				        "b": "2.0.0"
+				      }
+				    },
+				    "node_modules/a": {
+				      "version": "1.0.0"
+				    },
+				    "node_modules/b": {
+				      "version": "2.0.0"
+				    }
+				  },
+				  "dependencies": {
+				    "a": {
+				      "version": "1.0.0"
+				    },
+				    "b": {
+				      "version": "2.0.0"
+				    }
+				  }
+				}`,
+			},
+			ddResponses: map[string]string{
+				"NPM/a": respNPMAPackageJSON,
+				"NPM/b": respNPMBPackageJSON,
+			},
+			wantScore: 10, // mean = 0
+		},
+		{
+			name: "javascript package.json very stale → High true → score 0",
+			files: map[string]string{
+				"package.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "dependencies": {
+				    "a": "0.9.2",
+				    "b": "1.9.1"
+				  }
+				}`,
+				"package-lock.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "lockfileVersion": 2,
+				  "requires": true,
+				  "packages": {
+				    "": {
+				      "name": "example",
+				      "version": "1.0.0",
+				      "dependencies": {
+				        "a": "0.9.2",
+				        "b": "1.9.1"
+				      }
+				    },
+				    "node_modules/a": {
+				      "version": "0.9.2"
+				    },
+				    "node_modules/b": {
+				      "version": "1.9.1"
+				    }
+				  },
+				  "dependencies": {
+				    "a": {
+				      "version": "0.9.2"
+				    },
+				    "b": {
+				      "version": "1.9.1"
+				    }
+				  }
+				}`,
+			},
+			ddResponses: map[string]string{
+				"NPM/a": respNPMAPackageJSON, // oldest newer for a is 1.0.0 (long ago)
+				"NPM/b": respNPMBPackageJSON, // oldest newer for b is 2.0.0 (long ago)
+			},
+			wantScore: 0, // mean ≥ 180d
+		},
+		{
+			name: "javascript package.json moderately stale → Low true → score 5",
+			files: map[string]string{
+				"package.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "dependencies": {
+				    "a": "1.0.0",
+				    "b": "2.0.0"
+				  }
+				}`,
+				"package-lock.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "lockfileVersion": 2,
+				  "requires": true,
+				  "packages": {
+				    "": {
+				      "name": "example",
+				      "version": "1.0.0",
+				      "dependencies": {
+				        "a": "1.0.0",
+				        "b": "2.0.0"
+				      }
+				    },
+				    "node_modules/a": {
+				      "version": "1.0.0"
+				    },
+				    "node_modules/b": {
+				      "version": "2.0.0"
+				    }
+				  },
+				  "dependencies": {
+				    "a": {
+				      "version": "1.0.0"
+				    },
+				    "b": {
+				      "version": "2.0.0"
+				    }
+				  }
+				}`,
+			},
+			ddResponses: map[string]string{
+				"NPM/a": respNPMAPackageJSON,    // a is latest → contributes 0
+				"NPM/b": respNPMBPackageJSONLow, // b's oldest newer (2.0.1) published ~30d ago
+			},
+			wantScore: 5, // mean ~ (0 + ~30d)/2 ∈ [14d, 180d)
+		},
+		{
+			name: "go.mod very stale → High true → score 0",
+			files: map[string]string{
+				"go.mod": "module example.com/mod\n\ngo 1.21\nrequire github.com/mod/a v1.2.3\n",
+			},
+			ddResponses: map[string]string{
+				"GO/github.com/mod/a": respGoModA, // oldest newer published long ago → High
+			},
+			wantScore: 0,
+		},
+		{
+			name: "go.mod moderately stale → Low true → score 5",
+			files: map[string]string{
+				"go.mod": "module example.com/mod\n\ngo 1.21\nrequire github.com/mod/a v1.2.3\n",
+			},
+			ddResponses: map[string]string{
+				"GO/github.com/mod/a": respGoModALow, // oldest newer v1.2.4 @ ~30 days ago
+			},
+			wantScore: 5,
+		},
+		{
+			name: "go.mod all-latest → VeryLow true → score 10",
+			files: map[string]string{
+				"go.mod": "module example.com/mod\n\ngo 1.21\nrequire github.com/mod/a v1.2.3\n",
+			},
+			ddResponses: map[string]string{
+				"GO/github.com/mod/a": respGoModAVeryLowLatest, // v1.2.3 is default/latest → mean = 0
+			},
+			wantScore: 10,
+		},
+		{
+			name: "javascript package.json all-latest → VeryLow true → score 10",
+			files: map[string]string{
+				"package.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "dependencies": {
+				    "a": "1.0.0",
+				    "b": "2.0.0"
+				  }
+				}`,
+				"package-lock.json": `{
+				  "name": "example",
+				  "version": "1.0.0",
+				  "lockfileVersion": 2,
+				  "requires": true,
+				  "packages": {
+				    "": {
+				      "name": "example",
+				      "version": "1.0.0",
+				      "dependencies": {
+				        "a": "1.0.0",
+				        "b": "2.0.0"
+				      }
+				    },
+				    "node_modules/a": {
+				      "version": "1.0.0"
+				    },
+				    "node_modules/b": {
+				      "version": "2.0.0"
+				    }
+				  },
+				  "dependencies": {
+				    "a": {
+				      "version": "1.0.0"
+				    },
+				    "b": {
+				      "version": "2.0.0"
+				    }
+				  }
+				}`,
+			},
+			ddResponses: map[string]string{
+				"NPM/a": respNPMAPackageJSON, // latest is 1.0.0 (default)
+				"NPM/b": respNPMBPackageJSON, // latest is 2.0.0 (default)
+			},
+			wantScore: 10, // mean = 0 → VeryLow probe true → score 10
+		},
+		{
+			name: "requirements.txt all-latest → VeryLow true → score 10",
+			files: map[string]string{
+				"requirements.txt": "aa==1.0.0\nbb==1.9.11\ncc==3.0.0\n",
+			},
+			ddResponses: map[string]string{
+				"PYPI/aa": respPyPIALatest,
+				"PYPI/bb": respPyPIBLatest,
+				"PYPI/cc": respPyPICLatest,
+			},
+			wantScore: 10, // mean = 0
+		},
+		{
+			name: "requirements.txt one stale → Low true → score 5",
+			files: map[string]string{
+				"requirements.txt": "aa==1.0.0\nbb==1.9.10\ncc==3.0.0\n",
+			},
+			ddResponses: map[string]string{
+				"PYPI/aa": respPyPIALatest, // aa latest 1.0.0
+				"PYPI/bb": respPyPIBLatest, // bb oldest newer 1.9.11 @ ~30d
+				"PYPI/cc": respPyPICLatest, // cc latest 3.0.0
+			},
+			wantScore: 5,
+		},
+		{
+			name: "requirements.txt very stale → High true → score 0",
+			files: map[string]string{
+				"requirements.txt": "aa==0.9.2\nbb==1.9.11\ncc==2.9.11\n",
+			},
+			ddResponses: map[string]string{
+				"PYPI/aa": respPyPIALatest, // oldest newer 1.0.0 @ ≥365d
+				"PYPI/bb": respPyPIBLatest, // latest, contributes 0
+				"PYPI/cc": respPyPICLatest, // oldest newer 3.0.0 @ ≥365d
+			},
+			wantScore: 0,
+		},
+		// ---- Add these three pom.xml testcases ----
+
+		{
+			name: "pom.xml all-latest → VeryLow true → score 10",
+			files: map[string]string{
+				"pom.xml": `
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>example</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>a</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>b</artifactId>
+      <version>1.9.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>c</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+  </dependencies>
+</project>`,
+			},
+			ddResponses: map[string]string{
+				"MAVEN/com.example:a": respMavenALatest,
+				"MAVEN/com.example:b": respMavenBLatest,
+				"MAVEN/com.example:c": respMavenCLatest,
+			},
+			wantScore: 10, // mean = 0
+		},
+		{
+			name: "pom.xml one stale → Low true → score 5",
+			files: map[string]string{
+				"pom.xml": `
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>example</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>a</artifactId>
+      <version>1.0.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>b</artifactId>
+      <version>1.9.10</version> <!-- one behind; oldest-newer ~60d -->
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>c</artifactId>
+      <version>3.0.0</version>
+    </dependency>
+  </dependencies>
+</project>`,
+			},
+			ddResponses: map[string]string{
+				"MAVEN/com.example:a": respMavenALatest, // latest → 0
+				"MAVEN/com.example:b": respMavenBLatest, // oldest-newer ~60d → Low mean
+				"MAVEN/com.example:c": respMavenCLatest, // latest → 0
+			},
+			wantScore: 5,
+		},
+		{
+			name: "pom.xml very stale → High true → score 0",
+			files: map[string]string{
+				"pom.xml": `
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <groupId>example</groupId>
+  <artifactId>example</artifactId>
+  <version>1.0.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>a</artifactId>
+      <version>0.9.2</version> <!-- oldest-newer 1.0.0 long ago -->
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>b</artifactId>
+      <version>1.9.11</version> <!-- latest, contributes 0 -->
+    </dependency>
+    <dependency>
+      <groupId>com.example</groupId>
+      <artifactId>c</artifactId>
+      <version>2.9.11</version> <!-- oldest-newer 3.0.0 long ago -->
+    </dependency>
+  </dependencies>
+</project>`,
+			},
+			ddResponses: map[string]string{
+				"MAVEN/com.example:a": respMavenALatest, // oldest-newer ≥180d
+				"MAVEN/com.example:b": respMavenBLatest, // latest
+				"MAVEN/com.example:c": respMavenCLatest, // oldest-newer ≥180d
+			},
+			wantScore: 0,
+		},
+	}
+
+	//nolint:paralleltest // test setup uses shared mocks
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Intercept deps.dev calls using a RoundTripper that serves testcase-constant JSON bodies.
+			orig := http.DefaultTransport
+			http.DefaultTransport = rtFunc(func(req *http.Request) (*http.Response, error) {
+				// Expect path like /v3alpha/systems/{system}/packages/{name}
+				parts := strings.Split(strings.Trim(req.URL.Path, "/"), "/")
+				var system, name string
+				for i := 0; i < len(parts)-1; i++ {
+					if parts[i] == "systems" && i+1 < len(parts) {
+						system = parts[i+1]
+					}
+					if parts[i] == "packages" && i+1 < len(parts) {
+						name = strings.Join(parts[i+1:], "/")
+					}
+				}
+				key := system + "/" + name
+				body, ok := tt.ddResponses[key]
+				if !ok {
+					return &http.Response{
+						StatusCode: http.StatusNotFound,
+						Body:       io.NopCloser(strings.NewReader("no mock for " + key)),
+						Header:     make(http.Header),
+						Request:    req,
+					}, nil
+				}
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       io.NopCloser(strings.NewReader(body)),
+					Header:     http.Header{"Content-Type": []string{"application/json"}},
+					Request:    req,
+				}, nil
+			})
+			t.Cleanup(func() { http.DefaultTransport = orig })
+
+			// Create temp directory with test files for scalibr to scan.
+			tmpDir := t.TempDir()
+			for fileName, fileContents := range tt.files {
+				filePath := tmpDir + "/" + fileName
+				if err := os.WriteFile(filePath, []byte(fileContents), 0o600); err != nil {
+					t.Fatalf("failed to write temp file %s: %v", fileName, err)
+				}
+			}
+
+			// If there's a package.json but no package-lock.json, generate a minimal one
+			// since scalibr's NPM extractor requires a lockfile
+			//nolint:nestif // test setup requires nested structure
+			if _, hasPackageJSON := tt.files["package.json"]; hasPackageJSON {
+				if _, hasLock := tt.files["package-lock.json"]; !hasLock {
+					// Parse package.json to extract dependencies
+					lockContent := `{"name":"example","version":"1.0.0","lockfileVersion":2,"requires":true,"packages":{"":{"name":"example","version":"1.0.0","dependencies":{`
+					first := true
+					for _, line := range strings.Split(tt.files["package.json"], "\n") {
+						if strings.Contains(line, `"dependencies"`) {
+							continue
+						}
+						// Simple parser for "name": "version" pairs
+						if strings.Contains(line, `":`) && !strings.Contains(line, `"name"`) && !strings.Contains(line, `"version"`) {
+							parts := strings.Split(line, `":`)
+							if len(parts) == 2 {
+								name := strings.Trim(strings.TrimSpace(parts[0]), `"`)
+								version := strings.Trim(strings.TrimSpace(parts[1]), `,}"`)
+								if name != "" && version != "" {
+									if !first {
+										lockContent += ","
+									}
+									lockContent += `"` + name + `":"` + version + `"`
+									first = false
+								}
+							}
+						}
+					}
+					lockContent += `}}},"dependencies":{`
+					first = true
+					for _, line := range strings.Split(tt.files["package.json"], "\n") {
+						if strings.Contains(line, `"dependencies"`) {
+							continue
+						}
+						if strings.Contains(line, `":`) && !strings.Contains(line, `"name"`) && !strings.Contains(line, `"version"`) {
+							parts := strings.Split(line, `":`)
+							if len(parts) == 2 {
+								name := strings.Trim(strings.TrimSpace(parts[0]), `"`)
+								version := strings.Trim(strings.TrimSpace(parts[1]), `,}"`)
+								if name != "" && version != "" {
+									if !first {
+										lockContent += ","
+									}
+									lockContent += `"` + name + `":{"version":"` + version + `"}`
+									first = false
+								}
+							}
+						}
+					}
+					lockContent += `}}`
+					lockPath := tmpDir + "/package-lock.json"
+					if err := os.WriteFile(lockPath, []byte(lockContent), 0o600); err != nil {
+						t.Fatalf("failed to write generated package-lock.json: %v", err)
+					}
+				}
+			}
+
+			// gomock repo that returns the temp directory path.
+			ctrl := gomock.NewController(t)
+			mockRepo := mockrepo.NewMockRepoClient(ctrl)
+
+			main := "main"
+			mockRepo.EXPECT().URI().Return("github.com/ossf/scorecard").AnyTimes()
+			mockRepo.EXPECT().GetDefaultBranchName().Return(main, nil).AnyTimes()
+			mockRepo.EXPECT().LocalPath().Return(tmpDir, nil).AnyTimes()
+
+			dl := scut.TestDetailLogger{}
+			req := &checker.CheckRequest{
+				RepoClient: mockRepo,
+				Dlogger:    &dl,
+			}
+
+			res := MTTUDependencies(req)
+
+			if tt.wantErr {
+				if res.Error == nil {
+					t.Fatalf("expected error, got nil (score=%d)", res.Score)
+				}
+				return
+			}
+			if res.Error != nil {
+				t.Fatalf("unexpected error: %v", res.Error)
+			}
+			if res.Score != tt.wantScore {
+				t.Fatalf("unexpected score: want %d, got %d", tt.wantScore, res.Score)
+			}
+			if res.Name != "MTTUDependencies" {
+				t.Fatalf("unexpected check name: %s", res.Name)
+			}
+		})
+	}
+}

--- a/checks/evaluation/MTTUDependencies.go
+++ b/checks/evaluation/MTTUDependencies.go
@@ -1,0 +1,65 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evaluation
+
+import (
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	sce "github.com/ossf/scorecard/v5/errors"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsHigh"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsLow"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsVeryLow"
+)
+
+const CheckMTTUDependencies = "MTTUDependencies"
+
+func MTTUDependencies(name string, findings []finding.Finding, dl checker.DetailLogger) checker.CheckResult {
+	expectedProbes := []string{
+		MTTUDependenciesIsHigh.Probe,
+		MTTUDependenciesIsLow.Probe,
+		MTTUDependenciesIsVeryLow.Probe,
+	}
+	if !finding.UniqueProbesEqual(findings, expectedProbes) {
+		e := sce.WithMessage(sce.ErrScorecardInternal, "invalid probe results")
+		return checker.CreateRuntimeErrorResult(name, e)
+	}
+
+	score := 0
+	reason := ""
+	for i := range findings {
+		f := &findings[i]
+		switch f.Probe {
+		case MTTUDependenciesIsHigh.Probe:
+			if f.Outcome == finding.OutcomeTrue {
+				score = 0
+				reason = fmt.Sprintf("Mean time to update dependencies is high (>= 6 months): %s", f.Message)
+			}
+		case MTTUDependenciesIsLow.Probe:
+			if f.Outcome == finding.OutcomeTrue {
+				score = 5
+				reason = fmt.Sprintf("Mean time to update dependencies is moderate (< 6 months, >= 3 months): %s", f.Message)
+			}
+		case MTTUDependenciesIsVeryLow.Probe:
+			if f.Outcome == finding.OutcomeTrue {
+				score = 10
+				reason = fmt.Sprintf("Mean time to update dependencies is low (< 3 months): %s", f.Message)
+			}
+		}
+	}
+
+	return checker.CreateResultWithScore(CheckMTTUDependencies, reason, score)
+}

--- a/checks/evaluation/MTTUDependencies_test.go
+++ b/checks/evaluation/MTTUDependencies_test.go
@@ -1,0 +1,92 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package evaluation
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsHigh"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsLow"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsVeryLow"
+)
+
+func f(probe string, outcome finding.Outcome) finding.Finding {
+	return finding.Finding{Probe: probe, Outcome: outcome}
+}
+
+//nolint:paralleltest // test uses shared state
+func TestEvaluation_Scoring(t *testing.T) {
+	tests := []struct {
+		name     string
+		findings []finding.Finding
+		want     int
+	}{
+		{
+			name: "high-true → score 0",
+			findings: []finding.Finding{
+				f(MTTUDependenciesIsHigh.Probe, finding.OutcomeTrue),
+				f(MTTUDependenciesIsLow.Probe, finding.OutcomeFalse),
+				f(MTTUDependenciesIsVeryLow.Probe, finding.OutcomeFalse),
+			},
+			want: 0,
+		},
+		{
+			name: "low-true → score 5",
+			findings: []finding.Finding{
+				f(MTTUDependenciesIsHigh.Probe, finding.OutcomeFalse),
+				f(MTTUDependenciesIsLow.Probe, finding.OutcomeTrue),
+				f(MTTUDependenciesIsVeryLow.Probe, finding.OutcomeFalse),
+			},
+			want: 5,
+		},
+		{
+			name: "verylow-true → score 10",
+			findings: []finding.Finding{
+				f(MTTUDependenciesIsHigh.Probe, finding.OutcomeFalse),
+				f(MTTUDependenciesIsLow.Probe, finding.OutcomeFalse),
+				f(MTTUDependenciesIsVeryLow.Probe, finding.OutcomeTrue),
+			},
+			want: 10,
+		},
+	}
+
+	//nolint:paralleltest // test cases use shared state
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var dl checker.DetailLogger = nil
+			res := MTTUDependencies(CheckMTTUDependencies, tc.findings, dl)
+			if res.Score != tc.want {
+				t.Fatalf("want score %d, got %d", tc.want, res.Score)
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // test expected to panic
+func TestEvaluation_InvalidProbeSet(t *testing.T) {
+	// Missing one probe → runtime error expected.
+	ff := []finding.Finding{
+		f(MTTUDependenciesIsHigh.Probe, finding.OutcomeFalse),
+		f(MTTUDependenciesIsLow.Probe, finding.OutcomeTrue),
+		// verylow missing
+	}
+	var dl checker.DetailLogger = nil
+	res := MTTUDependencies(CheckMTTUDependencies, ff, dl)
+	if res.Error == nil {
+		t.Fatalf("expected runtime error for invalid probe set, got nil")
+	}
+}

--- a/checks/raw/mttu_dependencies.go
+++ b/checks/raw/mttu_dependencies.go
@@ -1,0 +1,382 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package raw implements raw data collectors for Scorecard checks.
+package raw
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"golang.org/x/mod/semver"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
+	depsdev "github.com/ossf/scorecard/v5/internal/packageclient"
+)
+
+const (
+	ecosystemGo       = "GO"
+	ecosystemNPM      = "NPM"
+	ecosystemPyPI     = "PYPI"
+	ecosystemMaven    = "MAVEN"
+	ecosystemCargo    = "CARGO"
+	ecosystemNuGet    = "NUGET"
+	ecosystemRubyGems = "RUBYGEMS"
+)
+
+// MTTUDependencies uses osv-scalibr to discover direct dependencies in the repository,
+// queries deps.dev to check for newer versions, and annotates dependencies with
+// IsLatest and TimeSinceOldestReleast (mean time to update).
+//
+//nolint:gocognit // Complex business logic with multiple dependency handling paths
+func MTTUDependencies(c *checker.CheckRequest) (checker.MTTUDependenciesData, error) {
+	var data checker.MTTUDependenciesData
+
+	// Get the local path to the repository.
+	localPath, err := c.RepoClient.LocalPath()
+	if err != nil {
+		return data, fmt.Errorf("getting local path: %w", err)
+	}
+
+	// Create context if not provided.
+	ctx := c.Ctx
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	// Use osv-scalibr to scan for direct dependencies.
+	// Note: The scalibr client is configured with DirectFS capability and
+	// filters out transitive/indirect dependencies based on metadata.
+	depsClient := clients.NewDirectDepsClient()
+	depsResp, err := depsClient.GetDeps(ctx, localPath)
+	if err != nil {
+		return data, fmt.Errorf("scanning dependencies with scalibr: %w", err)
+	}
+
+	// Nothing to do if no dependencies found.
+	if len(depsResp.Deps) == 0 {
+		if c.Dlogger != nil {
+			c.Dlogger.Info(&checker.LogMessage{
+				Text: "No dependencies found by scalibr",
+			})
+		}
+		return data, nil
+	}
+
+	// Log summary of what was found
+	ecosystemCounts := make(map[string]int)
+	for _, dep := range depsResp.Deps {
+		ecosystemCounts[dep.Ecosystem]++
+	}
+
+	if c.Dlogger != nil {
+		c.Dlogger.Info(&checker.LogMessage{
+			Text: fmt.Sprintf("Detected %d total packages from repository", len(depsResp.Deps)),
+		})
+
+		for eco, count := range ecosystemCounts {
+			c.Dlogger.Debug(&checker.LogMessage{
+				Text: fmt.Sprintf("  - %s: %d packages", eco, count),
+			})
+		}
+	}
+
+	// Build deps.dev client.
+	httpClient := &http.Client{Timeout: 15 * time.Second}
+	dd := depsdev.NewClient(httpClient)
+
+	// Annotate each dependency with IsLatest and TimeSinceOldestReleast.
+	now := time.Now().UTC()
+
+	// Cache to avoid duplicate queries to deps.dev for the same package.
+	// Key format: "SYSTEM||NAME" (e.g., "NPM||express")
+	packageCache := make(map[string]*depsdev.Package)
+
+	for _, dep := range depsResp.Deps {
+		if dep.Name == "" || dep.Version == "" {
+			continue
+		}
+
+		// Convert scalibr ecosystem to deps.dev system name.
+		systemName := scalibrEcosystemToDepsDevSystem(dep.Ecosystem)
+		if systemName == "" {
+			// Unknown ecosystem, skip.
+			continue
+		}
+
+		// Build cache key.
+		cacheKey := systemName + "||" + dep.Name
+
+		// Check cache first to avoid duplicate queries.
+		pkg, cached := packageCache[cacheKey]
+		if !cached {
+			// Query deps.dev for all versions of this package.
+			var err error
+			pkg, err = dd.GetPackage(ctx, systemName, dep.Name)
+			if err != nil || pkg == nil || len(pkg.Versions) == 0 {
+				// Cache nil result to avoid retrying failed queries.
+				packageCache[cacheKey] = nil
+				continue
+			}
+			// Cache successful result.
+			packageCache[cacheKey] = pkg
+		}
+
+		// Skip if package data is unavailable (cached failure).
+		if pkg == nil || len(pkg.Versions) == 0 {
+			continue
+		}
+
+		isLatest, oldestNewerPublishedAt := newestInfoFor(dep.Version, pkg.Versions)
+
+		// Create LockDependency from scalibr Dep.
+		lockDep := checker.LockDependency{
+			Name:      dep.Name,
+			Version:   dep.Version,
+			Ecosystem: scalibrEcosystemToCheckerEcosystem(dep.Ecosystem),
+			IsLatest:  ptrBool(isLatest),
+		}
+
+		// If not latest, encode the "time since oldest newer release".
+		if oldestNewerPublishedAt != nil {
+			delta := now.Sub(*oldestNewerPublishedAt)
+			if delta < 0 {
+				delta = 0
+			}
+			lockDep.TimeSinceOldestReleast = time.Unix(0, 0).UTC().Add(delta)
+		}
+
+		data.Dependencies = append(data.Dependencies, lockDep)
+	}
+
+	// Count how many are up-to-date vs outdated
+	upToDate := 0
+	outdated := 0
+	for _, dep := range data.Dependencies {
+		if dep.IsLatest != nil && *dep.IsLatest {
+			upToDate++
+		} else {
+			outdated++
+		}
+	}
+
+	if len(data.Dependencies) > 0 && c.Dlogger != nil {
+		c.Dlogger.Info(&checker.LogMessage{
+			Text: fmt.Sprintf("Summary: %d dependencies up-to-date, %d outdated", upToDate, outdated),
+		})
+	}
+
+	return data, nil
+}
+
+// scalibrEcosystemToDepsDevSystem maps scalibr ecosystem names to deps.dev system names.
+func scalibrEcosystemToDepsDevSystem(eco string) string {
+	switch strings.ToLower(strings.TrimSpace(eco)) {
+	case "golang", "go":
+		return ecosystemGo
+	case "npm":
+		return ecosystemNPM
+	case "pypi":
+		return ecosystemPyPI
+	case "maven":
+		return ecosystemMaven
+	case "cargo":
+		return ecosystemCargo
+	case "nuget":
+		return ecosystemNuGet
+	case "gem":
+		return ecosystemRubyGems
+	default:
+		return ""
+	}
+}
+
+// scalibrEcosystemToCheckerEcosystem maps scalibr ecosystem names to checker.Ecosystem.
+func scalibrEcosystemToCheckerEcosystem(eco string) checker.Ecosystem {
+	switch strings.ToLower(strings.TrimSpace(eco)) {
+	case "golang", "go":
+		return checker.EcosystemGo
+	case "npm":
+		return checker.EcosystemNPM
+	case "pypi":
+		return checker.EcosystemPypi
+	case "maven":
+		return checker.EcosystemMaven
+	case "cargo":
+		return checker.EcosystemCargo
+	case "nuget":
+		return checker.EcosystemNuget
+	case "gem":
+		return checker.EcosystemRubyGems
+	default:
+		return checker.Ecosystem("")
+	}
+}
+
+func ptrBool(b bool) *bool { return &b }
+
+// isPseudoVersion checks if a version is a Go pseudo-version.
+// Pseudo-versions represent unreleased commits and follow the pattern:
+// vX.Y.Z-yyyymmddhhmmss-abcdefabcdef or vX.Y.Z-0.yyyymmddhhmmss-abcdefabcdef
+// or vX.Y.Z-pre.0.yyyymmddhhmmss-abcdefabcdef
+// Examples: v1.2.1-0.20250916002408-014fb9c9e8f7
+// We want to exclude these and only consider actual tagged releases.
+func isPseudoVersion(version string) bool {
+	// Pseudo-versions contain a timestamp in the format: -yyyymmddhhmmss-
+	// The canonical format includes: -0.yyyymmddhhmmss- or -pre.0.yyyymmddhhmmss-
+	// Look for a sequence of exactly 14 digits preceded and followed by non-digit characters
+	if len(version) < 25 { // Minimum length for a pseudo-version
+		return false
+	}
+
+	// Look for the timestamp pattern: 14 consecutive digits
+	// In practice, these appear as .(14 digits)- in the version string
+	//nolint:nestif // Timestamp validation requires multiple nested checks
+	for i := 0; i < len(version)-15; i++ {
+		// Check if we have 14 consecutive digits
+		if version[i] >= '0' && version[i] <= '9' {
+			allDigits := true
+			digitCount := 0
+			for j := 0; j < 14 && i+j < len(version); j++ {
+				if version[i+j] >= '0' && version[i+j] <= '9' {
+					digitCount++
+				} else {
+					allDigits = false
+					break
+				}
+			}
+			// If we found exactly 14 consecutive digits, and there's a dash after them,
+			// and there was a dot or dash before them, it's likely a pseudo-version timestamp
+			if allDigits && digitCount == 14 && i+14 < len(version) && version[i+14] == '-' {
+				// Check if there's a dot before the digits (common pattern: .20250916002408-)
+				if i > 0 && (version[i-1] == '.' || version[i-1] == '-') {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// newestInfoFor determines:
+//  1. Whether currentVersion is the latest release among versions.
+//  2. If not, returns the PublishedAt time of the OLDEST version that is strictly newer.
+//
+// Primary ordering is semantic versioning using golang.org/x/mod/semver (after normalizing to
+// a "v" prefix). Only considers actual tagged releases, excluding Go pseudo-versions which
+// represent unreleased commits.
+//
+//nolint:gocognit // Complex version comparison logic with multiple edge cases and fallbacks
+func newestInfoFor(currentVersion string, versions []depsdev.Version) (bool, *time.Time) {
+	normalize := func(v string) string {
+		if v == "" {
+			return v
+		}
+		if v[0] != 'v' {
+			return "v" + v
+		}
+		return v
+	}
+
+	curSem := normalize(currentVersion)
+	curIsSem := semver.IsValid(curSem)
+
+	var (
+		latestSemver      string
+		oldestNewerSemver string
+		oldestNewerPub    time.Time
+		latestPub         time.Time
+	)
+
+	// First pass: try to use semver ordering wherever possible.
+	// IMPORTANT: Skip pseudo-versions - only consider actual tagged releases.
+	for i := range versions {
+		v := &versions[i]
+		pub, err := time.Parse(time.RFC3339, v.PublishedAt)
+		if err != nil {
+			continue
+		}
+		vs := normalize(v.VersionKey.Version)
+
+		// Skip pseudo-versions - they represent unreleased commits, not official releases
+		if isPseudoVersion(vs) {
+			continue
+		}
+
+		//nolint:nestif // Version comparison logic requires nested checks for accuracy
+		if semver.IsValid(vs) {
+			// Track the overall latest by semver
+			if latestSemver == "" || semver.Compare(vs, latestSemver) > 0 {
+				latestSemver = vs
+				latestPub = pub
+			}
+
+			// Track the OLDEST version that is newer than current
+			if curIsSem && semver.Compare(vs, curSem) > 0 {
+				// This version is newer than current
+				if oldestNewerSemver == "" || semver.Compare(vs, oldestNewerSemver) < 0 {
+					oldestNewerSemver = vs
+					oldestNewerPub = pub
+				}
+			}
+		} else if latestPub.IsZero() || pub.After(latestPub) {
+			// Track latest by published time as a fallback signal.
+			latestPub = pub
+			latestSemver = "" // signal: relying on time-based latest
+		}
+	}
+
+	// If we have valid semver for both current and at least one release, use semver result.
+	if latestSemver != "" && curIsSem {
+		isLatest := semver.Compare(curSem, latestSemver) == 0
+		if isLatest {
+			return true, nil
+		}
+		// Return the oldest newer version's timestamp if we found one
+		if !oldestNewerPub.IsZero() {
+			return false, &oldestNewerPub
+		}
+		// Fallback to latest if no specific older-newer found
+		if !latestPub.IsZero() {
+			return false, &latestPub
+		}
+		// No latest found (odd), but not equal to latest -> not latest, no timestamp.
+		return false, nil
+	}
+	// Pure timestamp fallback: determine if current is latest by publish time.
+	var curPub time.Time
+	for i := range versions {
+		if versions[i].VersionKey.Version == currentVersion {
+			var err error
+			curPub, err = time.Parse(time.RFC3339, versions[i].PublishedAt)
+			if err != nil {
+				continue
+			}
+			break
+		}
+	}
+	isLatest := !curPub.IsZero() && (curPub.Equal(latestPub) || curPub.After(latestPub))
+	if isLatest {
+		return true, nil
+	}
+
+	if !latestPub.IsZero() {
+		return false, &latestPub
+	}
+	return false, nil
+}

--- a/checks/raw/mttu_dependencies_test.go
+++ b/checks/raw/mttu_dependencies_test.go
@@ -1,0 +1,1718 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/ossf/scorecard/v5/checker"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
+	depsdev "github.com/ossf/scorecard/v5/internal/packageclient"
+)
+
+// transportStubMux returns different canned deps.dev GetPackage payloads.
+type transportStubMux struct {
+	bodies map[string]string
+}
+
+func (m *transportStubMux) RoundTrip(req *http.Request) (*http.Response, error) {
+	path := req.URL.RawPath
+	if path == "" {
+		path = req.URL.Path
+	}
+	system, name := parseDepsDevPath(path)
+	system = canonSystem(system)
+	key := system + "||" + name
+	body, ok := m.bodies[key]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("not found")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+func parseDepsDevPath(p string) (system, name string) {
+	const systemsAnchor = "/systems/"
+	const packagesAnchor = "/packages/"
+
+	i := strings.Index(p, systemsAnchor)
+	if i >= 0 {
+		start := i + len(systemsAnchor)
+		rest := p[start:]
+		if j := strings.IndexByte(rest, '/'); j >= 0 {
+			system = rest[:j]
+		}
+	}
+
+	k := strings.Index(p, packagesAnchor)
+	if k >= 0 {
+		name = strings.TrimPrefix(p[k+len(packagesAnchor):], "/")
+	}
+
+	if dec, err := url.PathUnescape(name); err == nil {
+		name = dec
+	}
+
+	return system, name
+}
+
+func canonSystem(s string) string {
+	u := strings.ToUpper(s)
+	switch u {
+	case "GO", "GOLANG":
+		return "GO"
+	case "NPM", "JAVASCRIPT":
+		return "NPM"
+	case "MAVEN":
+		return "MAVEN"
+	case "PYPI", "PYTHON", "PIP":
+		return "PYPI"
+	case "CARGO":
+		return "CARGO"
+	case "NUGET":
+		return "NUGET"
+	case "RUBYGEMS", "GEM":
+		return "RUBYGEMS"
+	default:
+		return u
+	}
+}
+
+// TestMTTUDependencies_WithGoModule tests the basic functionality
+// of MTTUDependencies with a go.mod file.
+//
+//nolint:paralleltest // test uses temp dir and file I/O
+func TestMTTUDependencies_WithGoModule(t *testing.T) {
+	// Cannot run in parallel because it modifies http.DefaultTransport
+	// t.Parallel()
+	tmpDir := t.TempDir()
+
+	goModContent := "module example.com/test\n\ngo 1.21\n\nrequire (\n\tgithub.com/google/uuid v1.3.0\n)\n"
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tCurrent := now.AddDate(0, -6, 0)
+	tOldestNewer := now.AddDate(0, -3, 0)
+	tLatest := now.AddDate(0, -1, 0)
+
+	depsDevBody := fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/google/uuid"},
+  "purl":"pkg:golang/github.com/google/uuid",
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.3.0"},"purl":"pkg:golang/github.com/google/uuid@v1.3.0","publishedAt":%q,"isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.4.0"},"purl":"pkg:golang/github.com/google/uuid@v1.4.0","publishedAt":%q,"isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.5.0"},"purl":"pkg:golang/github.com/google/uuid@v1.5.0","publishedAt":%q,"isDefault":true,"isDeprecated":false}
+  ]
+}`,
+		tCurrent.Format(time.RFC3339),
+		tOldestNewer.Format(time.RFC3339),
+		tLatest.Format(time.RFC3339),
+	)
+
+	mux := &transportStubMux{bodies: map[string]string{
+		"GO||github.com/google/uuid": depsDevBody,
+	}}
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = mux
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	if len(result.Dependencies) == 0 {
+		t.Fatal("Expected at least one dependency, got none")
+	}
+
+	var found bool
+	for _, dep := range result.Dependencies {
+		if dep.Name != "github.com/google/uuid" {
+			continue
+		}
+		found = true
+
+		// Note: scalibr's Go module extractor returns versions without "v" prefix
+		if dep.Version != "1.3.0" {
+			t.Errorf("Expected version 1.3.0, got %s", dep.Version)
+		}
+
+		if dep.Ecosystem != checker.EcosystemGo {
+			t.Errorf("Expected ecosystem %s, got %s", checker.EcosystemGo, dep.Ecosystem)
+		}
+
+		if dep.IsLatest == nil {
+			t.Error("IsLatest should not be nil")
+		} else if *dep.IsLatest {
+			t.Error("IsLatest should be false")
+		}
+
+		encoded := dep.TimeSinceOldestReleast.Sub(time.Unix(0, 0))
+		if encoded <= 0 {
+			t.Error("TimeSinceOldestReleast duration should be > 0")
+		}
+
+		inferredPublishedAt := now.Add(-encoded)
+		tolerance := 5 * time.Second
+		diff := inferredPublishedAt.Sub(tOldestNewer)
+		if diff < -tolerance || diff > tolerance {
+			t.Errorf("Expected oldest newer release time around %s, got %s (diff: %v)",
+				tOldestNewer.Format(time.RFC3339),
+				inferredPublishedAt.Format(time.RFC3339),
+				diff)
+		}
+	}
+
+	if !found {
+		t.Error("Expected to find github.com/google/uuid in dependencies")
+	}
+}
+
+func TestMTTUDependencies_NoDependencies(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	if len(result.Dependencies) != 0 {
+		t.Errorf("Expected 0 dependencies, got %d", len(result.Dependencies))
+	}
+}
+
+func TestMTTUDependencies_LocalPathError(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return("", fmt.Errorf("local path error")).
+		Times(1)
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	_, err := MTTUDependencies(req)
+	if err == nil {
+		t.Fatal("Expected error when LocalPath fails, got nil")
+	}
+
+	if !strings.Contains(err.Error(), "getting local path") {
+		t.Errorf("Expected error message to contain 'getting local path', got: %v", err)
+	}
+}
+
+func TestScalibrEcosystemToDepsDevSystem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"golang", "GO"},
+		{"go", "GO"},
+		{"npm", "NPM"},
+		{"pypi", "PYPI"},
+		{"maven", "MAVEN"},
+		{"cargo", "CARGO"},
+		{"nuget", "NUGET"},
+		{"gem", "RUBYGEMS"},
+		{"unknown", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result := scalibrEcosystemToDepsDevSystem(tt.input)
+			if result != tt.expected {
+				t.Errorf("scalibrEcosystemToDepsDevSystem(%q) = %q, want %q",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestScalibrEcosystemToCheckerEcosystem(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected checker.Ecosystem
+	}{
+		{"golang", checker.EcosystemGo},
+		{"go", checker.EcosystemGo},
+		{"npm", checker.EcosystemNPM},
+		{"pypi", checker.EcosystemPypi},
+		{"maven", checker.EcosystemMaven},
+		{"cargo", checker.EcosystemCargo},
+		{"nuget", checker.EcosystemNuget},
+		{"gem", checker.EcosystemRubyGems},
+		{"unknown", checker.Ecosystem("")},
+		{"", checker.Ecosystem("")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result := scalibrEcosystemToCheckerEcosystem(tt.input)
+			if result != tt.expected {
+				t.Errorf("scalibrEcosystemToCheckerEcosystem(%q) = %q, want %q",
+					tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+//nolint:paralleltest // test uses temp dir and file I/O
+func TestMTTUDependencies_Deduplication(t *testing.T) {
+	// Cannot run in parallel because it modifies http.DefaultTransport
+	// t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a go.mod file that references the same package multiple times
+	// (this would be unusual but let's verify we handle it correctly)
+	goModContent := `module example.com/test
+
+go 1.21
+
+require (
+github.com/google/uuid v1.3.0
+)
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tCurrent := now.AddDate(0, -6, 0)
+	tOldestNewer := now.AddDate(0, -3, 0)
+	tLatest := now.AddDate(0, -1, 0)
+
+	depsDevBody := fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/google/uuid"},
+  "purl":"pkg:golang/github.com/google/uuid",
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.3.0"},"purl":"pkg:golang/github.com/google/uuid@v1.3.0","publishedAt":%q,"isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.4.0"},"purl":"pkg:golang/github.com/google/uuid@v1.4.0","publishedAt":%q,"isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.5.0"},"purl":"pkg:golang/github.com/google/uuid@v1.5.0","publishedAt":%q,"isDefault":true,"isDeprecated":false}
+  ]
+}`,
+		tCurrent.Format(time.RFC3339),
+		tOldestNewer.Format(time.RFC3339),
+		tLatest.Format(time.RFC3339),
+	)
+
+	// Create a transport that tracks how many times each package is queried
+	queryCount := make(map[string]int)
+	trackingTransport := &trackingRoundTripper{
+		bodies:     map[string]string{"GO||github.com/google/uuid": depsDevBody},
+		queryCount: queryCount,
+	}
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = trackingTransport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	if len(result.Dependencies) == 0 {
+		t.Fatal("Expected at least one dependency, got none")
+	}
+
+	// Verify that each unique package was queried exactly once
+	for key, count := range queryCount {
+		if count != 1 {
+			t.Errorf("Package %q was queried %d times, expected 1 (deduplication not working)", key, count)
+		}
+	}
+}
+
+// trackingRoundTripper tracks how many times each package is queried.
+type trackingRoundTripper struct {
+	bodies     map[string]string
+	queryCount map[string]int
+}
+
+func (t *trackingRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	path := req.URL.RawPath
+	if path == "" {
+		path = req.URL.Path
+	}
+	system, name := parseDepsDevPath(path)
+	system = canonSystem(system)
+	key := system + "||" + name
+
+	// Track the query
+	t.queryCount[key]++
+
+	body, ok := t.bodies[key]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("not found")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+//nolint:paralleltest // test uses temp dir and file I/O
+func TestMTTUDependencies_NoIndirectDependencies(t *testing.T) {
+	// Cannot run in parallel because it modifies http.DefaultTransport
+	// t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a go.mod with both direct and indirect dependencies
+	// The indirect dependency should NOT be queried
+	goModContent := `module example.com/test
+
+go 1.21
+
+require (
+	github.com/google/uuid v1.3.0
+	github.com/stretchr/testify v1.8.0 // indirect
+)
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tCurrent := now.AddDate(0, -6, 0)
+	tLatest := now.AddDate(0, -1, 0)
+
+	// Only provide response for direct dependency
+	uuidBody := fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/google/uuid"},
+  "purl":"pkg:golang/github.com/google/uuid",
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.3.0"},"purl":"pkg:golang/github.com/google/uuid@v1.3.0","publishedAt":%q,"isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.5.0"},"purl":"pkg:golang/github.com/google/uuid@v1.5.0","publishedAt":%q,"isDefault":true,"isDeprecated":false}
+  ]
+}`,
+		tCurrent.Format(time.RFC3339),
+		tLatest.Format(time.RFC3339),
+	)
+
+	// Track all queries to ensure indirect dependencies are NOT queried
+	queryCount := make(map[string]int)
+	trackingTransport := &trackingRoundTripper{
+		bodies: map[string]string{
+			"GO||github.com/google/uuid": uuidBody,
+			// Deliberately NOT providing testify - it should not be queried
+		},
+		queryCount: queryCount,
+	}
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = trackingTransport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	// Should have found the direct dependency
+	if len(result.Dependencies) == 0 {
+		t.Fatal("Expected at least one dependency (direct only), got none")
+	}
+
+	// Verify that github.com/stretchr/testify was NOT queried (it's indirect)
+	if count, found := queryCount["GO||github.com/stretchr/testify"]; found {
+		t.Errorf("Indirect dependency github.com/stretchr/testify was queried %d times, should NOT be queried at all", count)
+	}
+
+	// Verify only direct dependencies were queried
+	for key := range queryCount {
+		if strings.Contains(key, "testify") {
+			t.Errorf("Indirect dependency %q was queried, but should have been filtered out", key)
+		}
+	}
+
+	// Ensure at least the direct dependency was found
+	foundDirect := false
+	for _, dep := range result.Dependencies {
+		if dep.Name == "github.com/google/uuid" {
+			foundDirect = true
+			break
+		}
+	}
+	if !foundDirect {
+		t.Error("Direct dependency github.com/google/uuid was not found in results")
+	}
+
+	t.Logf("Queried packages: %v", queryCount)
+	t.Logf("Found dependencies: %d", len(result.Dependencies))
+}
+
+// TestMTTUDependencies_E2E_DirectDepsOnly is a comprehensive end-to-end test that:
+// 1. Creates a realistic project with direct and indirect dependencies
+// 2. Asserts that scalibr only returns direct dependencies
+// 3. Monitors all HTTP requests to verify only direct dependencies are queried.
+//
+//nolint:paralleltest // test uses temp dir and file I/O
+func TestMTTUDependencies_E2E_DirectDepsOnly(t *testing.T) {
+	// Cannot run in parallel because it modifies http.DefaultTransport
+	// t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a realistic go.mod with:
+	// - Multiple direct dependencies
+	// - Multiple indirect dependencies (should be ignored)
+	goModContent := `module example.com/testproject
+
+go 1.21
+
+require (
+	github.com/google/uuid v1.3.0
+	github.com/stretchr/testify v1.8.0 // indirect
+)
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	// Create a minimal main.go to make this a valid Go project
+	mainGoContent := `package main
+
+import (
+	"fmt"
+	_ "github.com/google/uuid"
+)
+
+func main() {
+	fmt.Println("test")
+}
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(mainGoContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create main.go: %v", err)
+	}
+
+	// Expected direct dependencies (what scalibr should find)
+	expectedDirectDeps := map[string]bool{
+		"github.com/google/uuid": true,
+		// Note: stdlib is queried but not included in Dependencies list
+	}
+
+	// Indirect dependencies that should NOT be found or queried
+	forbiddenIndirectDeps := map[string]bool{
+		"github.com/stretchr/testify": true,
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tCurrent := now.AddDate(0, -6, 0)
+	tLatest := now.AddDate(0, -1, 0)
+
+	// Prepare API response for direct dependency
+	uuidBody := fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/google/uuid"},
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.3.0"},"publishedAt":%q,"isDefault":false},
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.5.0"},"publishedAt":%q,"isDefault":true}
+  ]
+}`, tCurrent.Format(time.RFC3339), tLatest.Format(time.RFC3339))
+
+	// Track all HTTP requests
+	type requestLog struct {
+		system string
+		name   string
+	}
+	var requestedPackages []requestLog
+	var requestMutex sync.Mutex
+
+	trackingTransport := &trackingRoundTripperE2E{
+		bodies: map[string]string{
+			"GO||github.com/google/uuid": uuidBody,
+			// Deliberately NOT providing indirect deps - they should never be requested
+		},
+		onRequest: func(system, name string) {
+			requestMutex.Lock()
+			requestedPackages = append(requestedPackages, requestLog{system: system, name: name})
+			requestMutex.Unlock()
+		},
+	}
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = trackingTransport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	// Execute the check
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	// ===== ASSERTION STAGE 1: Verify scalibr only returned direct dependencies =====
+	t.Log("=== STAGE 1: Verifying scalibr returned only direct dependencies ===")
+
+	foundDeps := make(map[string]bool)
+	for _, dep := range result.Dependencies {
+		foundDeps[dep.Name] = true
+		t.Logf("Found dependency: %s@%s", dep.Name, dep.Version)
+	}
+
+	// Check that all direct dependencies were found
+	for directDep := range expectedDirectDeps {
+		if !foundDeps[directDep] {
+			t.Errorf("Expected direct dependency %q was not found by scalibr", directDep)
+		}
+	}
+
+	// Check that NO indirect dependencies were found
+	for indirectDep := range forbiddenIndirectDeps {
+		if foundDeps[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q was found by scalibr, but should have been filtered out", indirectDep)
+		}
+	}
+
+	// ===== ASSERTION STAGE 2: Verify only direct dependencies were queried via HTTP =====
+	t.Log("=== STAGE 2: Verifying only direct dependencies were queried via HTTP ===")
+
+	requestMutex.Lock()
+	queriedPackages := make(map[string]bool)
+	for _, req := range requestedPackages {
+		key := req.name
+		queriedPackages[key] = true
+		t.Logf("HTTP request made to: %s (system: %s)", req.name, req.system)
+	}
+	requestMutex.Unlock()
+
+	// Verify NO indirect dependencies were queried
+	for indirectDep := range forbiddenIndirectDeps {
+		if queriedPackages[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q was queried via HTTP, should NOT have been queried", indirectDep)
+		}
+	}
+
+	// Verify all found direct dependencies were queried (except stdlib which doesn't need querying)
+	for _, dep := range result.Dependencies {
+		if dep.Name == "stdlib" {
+			continue // stdlib doesn't need HTTP queries
+		}
+		if !queriedPackages[dep.Name] {
+			t.Logf("Warning: Direct dependency %q was found but not queried (might be intentional)", dep.Name)
+		}
+	}
+
+	// ===== FINAL SUMMARY =====
+	t.Logf("=== TEST SUMMARY ===")
+	t.Logf("Direct dependencies found: %d (expected: %d)", len(foundDeps), len(expectedDirectDeps))
+	t.Logf("HTTP requests made: %d", len(requestedPackages))
+
+	if len(foundDeps) != len(expectedDirectDeps) {
+		t.Logf("Note: Found %d deps but expected %d - this may be due to scalibr not detecting all dependencies from go.mod alone", len(foundDeps), len(expectedDirectDeps))
+	}
+
+	t.Logf("✓ Stage 1: Scalibr filtering validated - NO indirect dependencies found")
+	t.Logf("✓ Stage 2: HTTP request filtering validated - NO indirect dependencies queried")
+}
+
+// trackingRoundTripperE2E is a custom transport for E2E testing with callback.
+type trackingRoundTripperE2E struct {
+	bodies    map[string]string
+	onRequest func(system, name string)
+}
+
+func (t *trackingRoundTripperE2E) RoundTrip(req *http.Request) (*http.Response, error) {
+	path := req.URL.RawPath
+	if path == "" {
+		path = req.URL.Path
+	}
+	system, name := parseDepsDevPath(path)
+	system = canonSystem(system)
+	key := system + "||" + name
+
+	// Callback to track the request
+	if t.onRequest != nil {
+		t.onRequest(system, name)
+	}
+
+	body, ok := t.bodies[key]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Body:       io.NopCloser(strings.NewReader("not found")),
+			Header:     make(http.Header),
+			Request:    req,
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Header:     make(http.Header),
+		Request:    req,
+	}, nil
+}
+
+// TestMTTUDependencies_RealGoMod tests with the actual go.mod from this repository
+// to ensure we correctly filter indirect dependencies from a real-world project.
+//
+//nolint:gocognit,paralleltest // test function with complex setup
+func TestMTTUDependencies_RealGoMod(t *testing.T) {
+	// Cannot run in parallel because it modifies http.DefaultTransport
+	// t.Parallel()
+
+	// Read the actual go.mod from the repository root
+	repoRoot := filepath.Join("..", "..")
+	goModPath := filepath.Join(repoRoot, "go.mod")
+
+	goModContent, err := os.ReadFile(goModPath)
+	if err != nil {
+		t.Skipf("Could not read repository go.mod: %v", err)
+	}
+
+	// Parse direct and indirect dependencies from the actual go.mod
+	directDeps := make(map[string]bool)
+	indirectDeps := make(map[string]bool)
+
+	lines := strings.Split(string(goModContent), "\n")
+	inRequireBlock := false
+
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+
+		if strings.HasPrefix(line, "require (") {
+			inRequireBlock = true
+			continue
+		}
+
+		if inRequireBlock && line == ")" {
+			inRequireBlock = false
+			continue
+		}
+
+		if !inRequireBlock || len(line) == 0 {
+			continue
+		}
+
+		// Parse dependency line
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+
+		pkgName := parts[0]
+		isIndirect := strings.Contains(line, "// indirect")
+
+		if isIndirect {
+			indirectDeps[pkgName] = true
+		} else {
+			directDeps[pkgName] = true
+		}
+	}
+
+	t.Logf("Parsed from real go.mod: %d direct deps, %d indirect deps", len(directDeps), len(indirectDeps))
+
+	// Create a test directory with a subset of the real dependencies
+	tmpDir := t.TempDir()
+
+	// Use a small subset for testing (to avoid needing too many mock responses)
+	testDirectDeps := []string{
+		"github.com/google/go-cmp",
+		"github.com/spf13/cobra",
+	}
+
+	testIndirectDeps := []string{
+		"github.com/BurntSushi/toml",
+		"github.com/cespare/xxhash/v2",
+		"golang.org/x/tools",
+	}
+
+	// Verify our test deps are actually in the real go.mod
+	for _, dep := range testDirectDeps {
+		if !directDeps[dep] {
+			t.Errorf("Test direct dependency %q not found in real go.mod direct deps", dep)
+		}
+	}
+
+	for _, dep := range testIndirectDeps {
+		if !indirectDeps[dep] {
+			t.Errorf("Test indirect dependency %q not found in real go.mod indirect deps", dep)
+		}
+	}
+
+	// Create a go.mod with both direct and indirect dependencies from real project
+	testGoModContent := `module github.com/ossf/scorecard/v5
+
+go 1.24.6
+
+require (
+github.com/google/go-cmp v0.7.0
+github.com/spf13/cobra v1.10.1
+)
+
+require (
+github.com/BurntSushi/toml v1.5.0 // indirect
+github.com/cespare/xxhash/v2 v2.3.0 // indirect
+golang.org/x/tools v0.37.0 // indirect
+)
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(testGoModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	// Track all HTTP requests
+	type requestLog struct {
+		system string
+		name   string
+	}
+	var requestedPackages []requestLog
+	var requestMutex sync.Mutex
+
+	// Mock responses for direct dependencies only
+	now := time.Now().UTC().Truncate(time.Second)
+	tCurrent := now.AddDate(0, -6, 0)
+	tLatest := now.AddDate(0, -1, 0)
+
+	mockBodies := map[string]string{
+		"GO||github.com/google/go-cmp": fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/google/go-cmp"},
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/google/go-cmp","version":"v0.7.0"},"publishedAt":%q,"isDefault":true}
+  ]
+}`, tCurrent.Format(time.RFC3339)),
+		"GO||github.com/spf13/cobra": fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/spf13/cobra"},
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.10.1"},"publishedAt":%q,"isDefault":true}
+  ]
+}`, tLatest.Format(time.RFC3339)),
+		// Deliberately NOT providing responses for indirect deps
+	}
+
+	trackingTransport := &trackingRoundTripperE2E{
+		bodies: mockBodies,
+		onRequest: func(system, name string) {
+			requestMutex.Lock()
+			requestedPackages = append(requestedPackages, requestLog{system: system, name: name})
+			requestMutex.Unlock()
+		},
+	}
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = trackingTransport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	// Execute the check
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	// Verify results
+	foundDeps := make(map[string]bool)
+	for _, dep := range result.Dependencies {
+		foundDeps[dep.Name] = true
+		t.Logf("Found dependency: %s@%s", dep.Name, dep.Version)
+	}
+
+	// Verify direct dependencies were found
+	for _, directDep := range testDirectDeps {
+		if !foundDeps[directDep] {
+			t.Errorf("Expected direct dependency %q (from real go.mod) was not found", directDep)
+		}
+	}
+
+	// Verify NO indirect dependencies were found
+	for _, indirectDep := range testIndirectDeps {
+		if foundDeps[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q (from real go.mod) was found, should be filtered out", indirectDep)
+		}
+	}
+
+	// Verify HTTP requests - NO indirect deps should be queried
+	requestMutex.Lock()
+	queriedPackages := make(map[string]bool)
+	for _, req := range requestedPackages {
+		queriedPackages[req.name] = true
+		t.Logf("HTTP request: %s (system: %s)", req.name, req.system)
+	}
+	requestMutex.Unlock()
+
+	// Verify NO indirect dependencies were queried
+	for _, indirectDep := range testIndirectDeps {
+		if queriedPackages[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q was queried via HTTP, should NOT be queried", indirectDep)
+		}
+	}
+
+	// Verify direct dependencies were queried
+	for _, directDep := range testDirectDeps {
+		if !queriedPackages[directDep] {
+			t.Logf("Note: Direct dependency %q was not queried (might not have been detected by scalibr)", directDep)
+		}
+	}
+
+	t.Logf("✓ Successfully validated filtering using real go.mod dependencies")
+	t.Logf("✓ %d direct dependencies expected, %d found", len(testDirectDeps), len(foundDeps))
+	t.Logf("✓ 0 indirect dependencies expected, verified none were found or queried")
+}
+
+// TestMTTUDependencies_TarballStructure tests with a tarball-like directory structure
+// where files are under a subdirectory (as extracted from GitHub tarballs).
+//
+//nolint:paralleltest // test uses temp dir and file I/O
+func TestMTTUDependencies_TarballStructure(t *testing.T) {
+	// Cannot run in parallel because it modifies http.DefaultTransport
+	// t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Simulate GitHub tarball structure: files are under "repo-commitsha/" subdirectory
+	repoSubdir := filepath.Join(tmpDir, "scorecard-abc123")
+	err := os.MkdirAll(repoSubdir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create subdirectory: %v", err)
+	}
+
+	// Create a go.mod with both direct and indirect dependencies
+	goModContent := `module example.com/test
+
+go 1.21
+
+require (
+github.com/google/uuid v1.3.0
+)
+
+require (
+github.com/stretchr/testify v1.8.0 // indirect
+golang.org/x/sys v0.1.0 // indirect
+)
+`
+	err = os.WriteFile(filepath.Join(repoSubdir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tCurrent := now.AddDate(0, -6, 0)
+
+	mockBodies := map[string]string{
+		"GO||github.com/google/uuid": fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/google/uuid"},
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.3.0"},"publishedAt":%q,"isDefault":true}
+  ]
+}`, tCurrent.Format(time.RFC3339)),
+	}
+
+	// Track all HTTP requests
+	type requestLog struct {
+		system string
+		name   string
+	}
+	var requestedPackages []requestLog
+	var requestMutex sync.Mutex
+
+	trackingTransport := &trackingRoundTripperE2E{
+		bodies: mockBodies,
+		onRequest: func(system, name string) {
+			requestMutex.Lock()
+			requestedPackages = append(requestedPackages, requestLog{system: system, name: name})
+			requestMutex.Unlock()
+		},
+	}
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = trackingTransport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	// Return the tmpDir (parent of the repo subdirectory), simulating tarball extraction
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	// Execute the check
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	// Verify only direct dependencies were found
+	foundDeps := make(map[string]bool)
+	for _, dep := range result.Dependencies {
+		foundDeps[dep.Name] = true
+		t.Logf("Found dependency: %s@%s", dep.Name, dep.Version)
+	}
+
+	// Should find the direct dependency
+	if !foundDeps["github.com/google/uuid"] {
+		t.Errorf("Expected direct dependency 'github.com/google/uuid' was not found")
+	}
+
+	// Should NOT find indirect dependencies
+	indirectDeps := []string{"github.com/stretchr/testify", "golang.org/x/sys"}
+	for _, indirectDep := range indirectDeps {
+		if foundDeps[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q was found, should be filtered out", indirectDep)
+		}
+	}
+
+	// Verify NO indirect dependencies were queried via HTTP
+	requestMutex.Lock()
+	queriedPackages := make(map[string]bool)
+	for _, req := range requestedPackages {
+		queriedPackages[req.name] = true
+		t.Logf("HTTP request: %s (system: %s)", req.name, req.system)
+	}
+	requestMutex.Unlock()
+
+	for _, indirectDep := range indirectDeps {
+		if queriedPackages[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q was queried via HTTP, should NOT be queried", indirectDep)
+		}
+	}
+
+	t.Logf("✓ Successfully validated tarball-structure filtering")
+	t.Logf("✓ Found %d dependencies, verified no indirect dependencies", len(foundDeps))
+}
+
+// TestMTTUDependencies_MultipleGoMods tests with multiple go.mod files
+// (root and tools/ subdirectory) to ensure indirect deps from ALL files are filtered.
+//
+//nolint:paralleltest // test uses temp dir and file I/O
+func TestMTTUDependencies_MultipleGoMods(t *testing.T) {
+	// Cannot run in parallel because it modifies http.DefaultTransport
+	// t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create main go.mod
+	goModContent := `module example.com/test
+
+go 1.21
+
+require (
+github.com/google/uuid v1.3.0
+)
+
+require (
+github.com/stretchr/testify v1.8.0 // indirect
+)
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	// Create tools/ subdirectory with its own go.mod
+	toolsDir := filepath.Join(tmpDir, "tools")
+	err = os.MkdirAll(toolsDir, 0o755)
+	if err != nil {
+		t.Fatalf("Failed to create tools directory: %v", err)
+	}
+
+	toolsGoModContent := `module example.com/test/tools
+
+go 1.21
+
+require (
+github.com/golangci/golangci-lint v1.50.0
+)
+
+require (
+github.com/dimchansky/utfbom v1.1.1 // indirect
+golang.org/x/tools v0.1.0 // indirect
+)
+`
+	err = os.WriteFile(filepath.Join(toolsDir, "go.mod"), []byte(toolsGoModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create tools/go.mod: %v", err)
+	}
+
+	now := time.Now().UTC().Truncate(time.Second)
+	tCurrent := now.AddDate(0, -6, 0)
+
+	mockBodies := map[string]string{
+		"GO||github.com/google/uuid": fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/google/uuid"},
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.3.0"},"publishedAt":%q,"isDefault":true}
+  ]
+}`, tCurrent.Format(time.RFC3339)),
+		"GO||github.com/golangci/golangci-lint": fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/golangci/golangci-lint"},
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/golangci/golangci-lint","version":"v1.50.0"},"publishedAt":%q,"isDefault":true}
+  ]
+}`, tCurrent.Format(time.RFC3339)),
+	}
+
+	// Track all HTTP requests
+	type requestLog struct {
+		system string
+		name   string
+	}
+	var requestedPackages []requestLog
+	var requestMutex sync.Mutex
+
+	trackingTransport := &trackingRoundTripperE2E{
+		bodies: mockBodies,
+		onRequest: func(system, name string) {
+			requestMutex.Lock()
+			requestedPackages = append(requestedPackages, requestLog{system: system, name: name})
+			requestMutex.Unlock()
+		},
+	}
+
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = trackingTransport
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	// Execute the check
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	// Verify only direct dependencies were found
+	foundDeps := make(map[string]bool)
+	for _, dep := range result.Dependencies {
+		foundDeps[dep.Name] = true
+		t.Logf("Found dependency: %s@%s", dep.Name, dep.Version)
+	}
+
+	// Should find the direct dependencies
+	expectedDirect := []string{"github.com/google/uuid", "github.com/golangci/golangci-lint"}
+	for _, directDep := range expectedDirect {
+		if !foundDeps[directDep] {
+			t.Errorf("Expected direct dependency %q was not found", directDep)
+		}
+	}
+
+	// Should NOT find indirect dependencies from ANY go.mod file
+	indirectDeps := []string{
+		"github.com/stretchr/testify",  // indirect in root go.mod
+		"github.com/dimchansky/utfbom", // indirect in tools/go.mod
+		"golang.org/x/tools",           // indirect in tools/go.mod
+	}
+	for _, indirectDep := range indirectDeps {
+		if foundDeps[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q was found, should be filtered out", indirectDep)
+		}
+	}
+
+	// Verify NO indirect dependencies were queried via HTTP
+	requestMutex.Lock()
+	queriedPackages := make(map[string]bool)
+	for _, req := range requestedPackages {
+		queriedPackages[req.name] = true
+		t.Logf("HTTP request: %s (system: %s)", req.name, req.system)
+	}
+	requestMutex.Unlock()
+
+	for _, indirectDep := range indirectDeps {
+		if queriedPackages[indirectDep] {
+			t.Errorf("FAIL: Indirect dependency %q was queried via HTTP, should NOT be queried", indirectDep)
+		}
+	}
+
+	t.Logf("✓ Successfully validated multi-go.mod filtering")
+	t.Logf("✓ Found %d dependencies, verified no indirect dependencies from any go.mod", len(foundDeps))
+}
+
+// TestIsPseudoVersion tests the isPseudoVersion function with comprehensive cases.
+//
+//nolint:paralleltest,tparallel // test cases are independent
+func TestIsPseudoVersion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		version string
+		want    bool
+	}{
+		// True cases - actual pseudo-versions
+		{
+			name:    "standard pseudo-version with v prefix",
+			version: "v1.2.0-0.20250916002408-abc123def456",
+			want:    true,
+		},
+		{
+			name:    "v0.0.0 pseudo-version",
+			version: "v0.0.0-20241213102144-19d51d7fe467",
+			want:    true,
+		},
+		{
+			name:    "pseudo-version without v prefix",
+			version: "1.2.0-0.20250916002408-abc123def",
+			want:    true,
+		},
+		{
+			name:    "pseudo-version with dots before timestamp",
+			version: "v1.2.3.0.20240101120000-abcdef123456",
+			want:    true,
+		},
+		{
+			name:    "pseudo-version with dash before timestamp",
+			version: "v2.0.0-20231217203849-220c5c2851b7",
+			want:    true,
+		},
+
+		// False cases - real versions
+		{
+			name:    "normal semver",
+			version: "v1.2.3",
+			want:    false,
+		},
+		{
+			name:    "semver with +incompatible",
+			version: "v2.0.0+incompatible",
+			want:    false,
+		},
+		{
+			name:    "pre-release version",
+			version: "v1.2.3-rc.1",
+			want:    false,
+		},
+		{
+			name:    "beta version",
+			version: "v1.2.3-beta",
+			want:    false,
+		},
+		{
+			name:    "alpha version",
+			version: "v0.1.0-alpha.2",
+			want:    false,
+		},
+		{
+			name:    "version with date but not 14 digits",
+			version: "v1.2.3-20250916",
+			want:    false,
+		},
+		{
+			name:    "version with 12 digit timestamp (not 14)",
+			version: "v1.2.3-202509160024-abc",
+			want:    false,
+		},
+		{
+			name:    "version with 14 digits but no dash after",
+			version: "v1.2.3-20250916002408abc",
+			want:    false,
+		},
+		{
+			name:    "version with letters in timestamp position",
+			version: "v1.2.3-0.abcdefghijklmn-hash",
+			want:    false,
+		},
+
+		// Edge cases
+		{
+			name:    "empty string",
+			version: "",
+			want:    false,
+		},
+		{
+			name:    "just v",
+			version: "v",
+			want:    false,
+		},
+		{
+			name:    "invalid format",
+			version: "invalid",
+			want:    false,
+		},
+		{
+			name:    "timestamp at start (no version before)",
+			version: "20250916002408-abc123",
+			want:    false,
+		},
+		{
+			name:    "multiple timestamps",
+			version: "v1.2.0-20240101120000-20240202130000-abc",
+			want:    true, // first timestamp matches pattern
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := isPseudoVersion(tc.version)
+			if got != tc.want {
+				t.Errorf("isPseudoVersion(%q) = %v, want %v", tc.version, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNewestInfoFor tests the newestInfoFor function.
+//
+//nolint:paralleltest,tparallel // test cases are independent
+func TestNewestInfoFor(t *testing.T) {
+	t.Parallel()
+
+	// Helper to create a version with timestamp
+	makeVersion := func(ver, published string) depsdev.Version {
+		return depsdev.Version{
+			VersionKey: depsdev.VersionKey{
+				System:  "GO",
+				Name:    "test/package",
+				Version: ver,
+			},
+			PublishedAt: published,
+		}
+	}
+
+	tests := []struct {
+		name           string
+		currentVersion string
+		wantTimestamp  string
+		versions       []depsdev.Version
+		wantLatest     bool
+	}{
+		{
+			name:           "current is latest",
+			currentVersion: "v1.3.0",
+			versions: []depsdev.Version{
+				makeVersion("v1.0.0", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.1.0", "2024-02-01T00:00:00Z"),
+				makeVersion("v1.2.0", "2024-03-01T00:00:00Z"),
+				makeVersion("v1.3.0", "2024-04-01T00:00:00Z"),
+			},
+			wantLatest:    true,
+			wantTimestamp: "",
+		},
+		{
+			name:           "current is outdated - should return oldest newer",
+			currentVersion: "v1.0.0",
+			versions: []depsdev.Version{
+				makeVersion("v1.0.0", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.1.0", "2024-03-01T00:00:00Z"), // oldest newer
+				makeVersion("v1.2.0", "2024-06-01T00:00:00Z"),
+				makeVersion("v1.3.0", "2024-09-01T00:00:00Z"), // latest
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-03-01T00:00:00Z", // v1.1.0, not v1.3.0!
+		},
+		{
+			name:           "pseudo-versions ignored - current is latest release",
+			currentVersion: "v1.2.0",
+			versions: []depsdev.Version{
+				makeVersion("v1.2.0", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.2.1-0.20250916002408-abc123", "2024-06-01T00:00:00Z"), // pseudo - ignored
+				makeVersion("v1.3.0-0.20251201120000-def456", "2024-07-01T00:00:00Z"), // pseudo - ignored
+			},
+			wantLatest:    true, // because pseudo-versions are filtered
+			wantTimestamp: "",
+		},
+		{
+			name:           "pseudo-versions ignored - has real newer version",
+			currentVersion: "v1.0.0",
+			versions: []depsdev.Version{
+				makeVersion("v1.0.0", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.0.1-0.20240215000000-abc", "2024-02-15T00:00:00Z"), // pseudo - ignored
+				makeVersion("v1.1.0", "2024-03-01T00:00:00Z"),                      // real - should use this
+				makeVersion("v1.2.0-0.20240401000000-def", "2024-04-01T00:00:00Z"), // pseudo - ignored
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-03-01T00:00:00Z", // v1.1.0
+		},
+		{
+			name:           "version without v prefix",
+			currentVersion: "1.2.0",
+			versions: []depsdev.Version{
+				makeVersion("1.2.0", "2024-01-01T00:00:00Z"),
+				makeVersion("1.3.0", "2024-02-01T00:00:00Z"),
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-02-01T00:00:00Z",
+		},
+		{
+			name:           "mixed v prefix handling",
+			currentVersion: "v1.2.0",
+			versions: []depsdev.Version{
+				makeVersion("1.2.0", "2024-01-01T00:00:00Z"),  // no v
+				makeVersion("v1.3.0", "2024-02-01T00:00:00Z"), // with v
+				makeVersion("1.4.0", "2024-03-01T00:00:00Z"),  // no v
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-02-01T00:00:00Z", // oldest newer (v1.3.0)
+		},
+		{
+			name:           "empty version list",
+			currentVersion: "v1.0.0",
+			versions:       []depsdev.Version{},
+			wantLatest:     false,
+			wantTimestamp:  "",
+		},
+		{
+			name:           "invalid timestamps ignored",
+			currentVersion: "v1.0.0",
+			versions: []depsdev.Version{
+				makeVersion("v1.0.0", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.1.0", "invalid-timestamp"),
+				makeVersion("v1.2.0", "2024-03-01T00:00:00Z"),
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-03-01T00:00:00Z", // v1.2.0 (v1.1.0 skipped due to bad timestamp)
+		},
+		{
+			name:           "current version not in list",
+			currentVersion: "v1.5.0",
+			versions: []depsdev.Version{
+				makeVersion("v1.0.0", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.1.0", "2024-02-01T00:00:00Z"),
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-02-01T00:00:00Z", // falls back to latest timestamp
+		},
+		{
+			name:           "v0.0.0 pseudo-version filtered",
+			currentVersion: "v1.0.0",
+			versions: []depsdev.Version{
+				makeVersion("v0.0.0-20241213102144-19d51d7fe467", "2024-01-01T00:00:00Z"), // pseudo
+				makeVersion("v1.0.0", "2024-02-01T00:00:00Z"),
+				makeVersion("v1.1.0", "2024-03-01T00:00:00Z"),
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-03-01T00:00:00Z",
+		},
+		{
+			name:           "all versions are pseudo-versions",
+			currentVersion: "v1.0.0-0.20240101000000-abc",
+			versions: []depsdev.Version{
+				makeVersion("v1.0.0-0.20240101000000-abc", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.1.0-0.20240201000000-def", "2024-02-01T00:00:00Z"),
+			},
+			wantLatest:    true, // no real releases, so considered latest by timestamp fallback
+			wantTimestamp: "",
+		},
+		{
+			name:           "oldest of multiple newer versions",
+			currentVersion: "v1.0.0",
+			versions: []depsdev.Version{
+				makeVersion("v1.0.0", "2024-01-01T00:00:00Z"),
+				makeVersion("v1.0.1", "2024-01-15T00:00:00Z"), // oldest newer
+				makeVersion("v1.0.2", "2024-02-01T00:00:00Z"),
+				makeVersion("v1.1.0", "2024-03-01T00:00:00Z"),
+				makeVersion("v1.2.0", "2024-04-01T00:00:00Z"),
+				makeVersion("v2.0.0", "2024-05-01T00:00:00Z"), // latest
+			},
+			wantLatest:    false,
+			wantTimestamp: "2024-01-15T00:00:00Z", // v1.0.1
+		},
+	}
+
+	//nolint:paralleltest // subtests are independent
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotLatest, gotTime := newestInfoFor(tc.currentVersion, tc.versions)
+
+			if gotLatest != tc.wantLatest {
+				t.Errorf("isLatest = %v, want %v", gotLatest, tc.wantLatest)
+			}
+
+			//nolint:nestif // test validation requires nested structure
+			if tc.wantTimestamp == "" {
+				if gotTime != nil {
+					t.Errorf("expected nil timestamp, got %v", gotTime)
+				}
+			} else {
+				if gotTime == nil {
+					t.Errorf("expected timestamp %s, got nil", tc.wantTimestamp)
+				} else {
+					want, err := time.Parse(time.RFC3339, tc.wantTimestamp)
+					if err != nil {
+						t.Fatalf("failed to parse want timestamp: %v", err)
+					}
+					if !gotTime.Equal(want) {
+						t.Errorf("timestamp = %v, want %v", gotTime.Format(time.RFC3339), tc.wantTimestamp)
+					}
+				}
+			}
+		})
+	}
+}
+
+// TestMTTUDependencies_WithPseudoVersionsE2E is an end-to-end test verifying
+// that pseudo-versions are correctly filtered in a realistic scenario.
+func TestMTTUDependencies_WithPseudoVersionsE2E(t *testing.T) {
+	t.Parallel()
+
+	tmpDir := t.TempDir()
+
+	// Create a go.mod with a dependency that we'll test
+	goModContent := `module example.com/test
+
+go 1.21
+
+require (
+	github.com/example/pkg v1.2.0
+)
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	// Mock deps.dev response with both real versions and pseudo-versions
+	now := time.Now().UTC()
+	currentRelease := now.AddDate(0, -6, 0) // 6 months ago
+	pseudoVersion := now.AddDate(0, -1, 0)  // 1 month ago (but pseudo)
+	newerRelease := now.AddDate(0, -3, 0)   // 3 months ago (real release)
+
+	depsDevBody := fmt.Sprintf(`{
+  "packageKey": {"system":"GO","name":"github.com/example/pkg"},
+  "purl":"pkg:golang/github.com/example/pkg",
+  "versions":[
+    {"versionKey":{"system":"GO","name":"github.com/example/pkg","version":"v1.2.0"},"purl":"pkg:golang/github.com/example/pkg@v1.2.0","publishedAt":%q,"isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"GO","name":"github.com/example/pkg","version":"v1.2.1-0.20250916002408-abc123"},"purl":"pkg:golang/github.com/example/pkg@v1.2.1-0.20250916002408-abc123","publishedAt":%q,"isDefault":false,"isDeprecated":false},
+    {"versionKey":{"system":"GO","name":"github.com/example/pkg","version":"v1.3.0"},"purl":"pkg:golang/github.com/example/pkg@v1.3.0","publishedAt":%q,"isDefault":true,"isDeprecated":false}
+  ]
+}`,
+		currentRelease.Format(time.RFC3339),
+		pseudoVersion.Format(time.RFC3339),
+		newerRelease.Format(time.RFC3339),
+	)
+
+	mux := &transportStubMux{bodies: map[string]string{
+		"GO||github.com/example/pkg": depsDevBody,
+	}}
+	origTransport := http.DefaultTransport
+	http.DefaultTransport = mux
+	defer func() { http.DefaultTransport = origTransport }()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mockRepoClient.EXPECT().
+		LocalPath().
+		Return(tmpDir, nil).
+		AnyTimes()
+
+	req := &checker.CheckRequest{
+		Ctx:        context.Background(),
+		RepoClient: mockRepoClient,
+		Dlogger:    nil,
+	}
+
+	result, err := MTTUDependencies(req)
+	if err != nil {
+		t.Fatalf("MTTUDependencies returned error: %v", err)
+	}
+
+	// Find our dependency
+	var found bool
+	for _, dep := range result.Dependencies {
+		if dep.Name != "github.com/example/pkg" {
+			continue
+		}
+		found = true
+
+		// Verify it's marked as not latest (because v1.3.0 exists)
+		if dep.IsLatest == nil {
+			t.Error("IsLatest should not be nil")
+		} else if *dep.IsLatest {
+			t.Error("IsLatest should be false (v1.3.0 exists)")
+		}
+
+		// Verify the timestamp is from v1.3.0 (real release), not pseudo-version
+		if dep.TimeSinceOldestReleast.IsZero() {
+			t.Error("TimeSinceOldestReleast should not be zero")
+		}
+
+		// Calculate what the published time should be based on encoded duration
+		encoded := dep.TimeSinceOldestReleast.Sub(time.Unix(0, 0))
+		inferredPublishedAt := now.Add(-encoded)
+
+		// Should be close to newerRelease (3 months ago), NOT pseudoVersion (1 month ago)
+		tolerance := 5 * time.Second
+		diffFromReal := inferredPublishedAt.Sub(newerRelease)
+		if diffFromReal < -tolerance || diffFromReal > tolerance {
+			t.Errorf("Expected timestamp close to v1.3.0 release (%s), got %s (diff: %v)",
+				newerRelease.Format(time.RFC3339),
+				inferredPublishedAt.Format(time.RFC3339),
+				diffFromReal)
+		}
+
+		// Explicitly verify it's NOT using the pseudo-version timestamp
+		diffFromPseudo := inferredPublishedAt.Sub(pseudoVersion)
+		if diffFromPseudo > -tolerance && diffFromPseudo < tolerance {
+			t.Errorf("FAIL: Appears to be using pseudo-version timestamp (%s), should use real release (%s)",
+				pseudoVersion.Format(time.RFC3339),
+				newerRelease.Format(time.RFC3339))
+		}
+	}
+
+	if !found {
+		t.Error("Expected to find github.com/example/pkg in dependencies")
+	}
+}

--- a/checks/raw/signed_releases.go
+++ b/checks/raw/signed_releases.go
@@ -39,6 +39,7 @@ func SignedReleases(c *checker.CheckRequest) (checker.SignedReleasesData, error)
 		}, nil
 	}
 
+	//nolint:gocritic // rangeValCopy: Existing code pattern, outside MTTUDependencies scope
 	for _, v := range versions.Versions {
 		prov := checker.PackageProvenance{}
 

--- a/checks/raw/version_comparison_offline_test.go
+++ b/checks/raw/version_comparison_offline_test.go
@@ -1,0 +1,557 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	depsdev "github.com/ossf/scorecard/v5/internal/packageclient"
+)
+
+// TestVersionComparison_OfflineValidation tests version comparison logic
+// using pre-captured API responses (no live API calls).
+// This test validates the newestInfoFor function with real-world test cases,
+// covering various scenarios from latest versions to very outdated dependencies.
+//
+// IMPORTANT: newestInfoFor returns the timestamp of the OLDEST NEWER version,
+// not the latest version. This provides a fair "time to update" measurement.
+// It also filters out Go pseudo-versions (unreleased commits).
+//
+//nolint:gocognit // test function with many validation cases
+func TestVersionComparison_OfflineValidation(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name           string
+		packageName    string
+		currentVersion string
+		versionsJSON   string // Raw JSON from deps.dev API
+		expectIsLatest bool
+		expectDaysOld  int // Expected days between current and OLDEST NEWER version (not latest!)
+		daysTolerance  int // Acceptable tolerance due to test time precision
+	}{
+		// Test cases 1-2: Latest versions
+		{
+			name:           "go-cmp v0.7.0 is latest",
+			packageName:    "github.com/google/go-cmp",
+			currentVersion: "0.7.0",
+			versionsJSON:   goCmpVersionsJSON,
+			expectIsLatest: true,
+		},
+		{
+			name:           "go-git/v5 v5.16.3 is latest",
+			packageName:    "github.com/go-git/go-git/v5",
+			currentVersion: "5.16.3",
+			versionsJSON:   goGitV5VersionsJSON,
+			expectIsLatest: true,
+		},
+
+		// Test cases 3-10: Recent dependencies (< 200 days old)
+		{
+			name:           "buildkit v0.25.1 - 1 day behind latest",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.25.1",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  1,
+			daysTolerance:  1,
+		},
+		{
+			name:           "cobra v1.10.1 - is latest (pseudo-version v1.10.2-0.xxx filtered)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.10.1",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: true, // v1.10.2-0.xxx is a pseudo-version, filtered out
+		},
+		{
+			name:           "go-containerregistry v0.20.6 - latest (next is pseudo-version)",
+			packageName:    "github.com/google/go-containerregistry",
+			currentVersion: "0.20.6",
+			versionsJSON:   goContainerRegistryVersionsJSON,
+			expectIsLatest: true,
+			expectDaysOld:  0,
+			daysTolerance:  1,
+		},
+		{
+			name:           "semver/v3 v3.4.0 - latest (next is pseudo-version)",
+			packageName:    "github.com/Masterminds/semver/v3",
+			currentVersion: "3.4.0",
+			versionsJSON:   semverV3VersionsJSON,
+			expectIsLatest: true,
+			expectDaysOld:  0,
+			daysTolerance:  1,
+		},
+		{
+			name:           "logr v1.4.3 - latest (next is pseudo-version)",
+			packageName:    "github.com/go-logr/logr",
+			currentVersion: "1.4.3",
+			versionsJSON:   logrVersionsJSON,
+			expectIsLatest: true,
+			expectDaysOld:  0,
+			daysTolerance:  2,
+		},
+		{
+			name:           "go-git/v5 v5.16.2 - 102 days behind latest",
+			packageName:    "github.com/go-git/go-git/v5",
+			currentVersion: "5.16.2",
+			versionsJSON:   goGitV5VersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  102,
+			daysTolerance:  1,
+		},
+		{
+			name:           "go-git/v5 v5.16.1 - 2 days to v5.16.2 (oldest newer)",
+			packageName:    "github.com/go-git/go-git/v5",
+			currentVersion: "5.16.1",
+			versionsJSON:   goGitV5VersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  2,
+			daysTolerance:  2,
+		},
+		{
+			name:           "go-git/v5 v5.16.0 - 11 days to v5.16.1 (oldest newer)",
+			packageName:    "github.com/go-git/go-git/v5",
+			currentVersion: "5.16.0",
+			versionsJSON:   goGitV5VersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  11,
+			daysTolerance:  2,
+		},
+
+		// Test cases 11-20: Moderately outdated (200-600 days)
+		{
+			name:           "backoff/v4 v4.3.0 - latest (next is pseudo-version)",
+			packageName:    "github.com/cenkalti/backoff/v4",
+			currentVersion: "4.3.0",
+			versionsJSON:   backoffV4VersionsJSON,
+			expectIsLatest: true,
+			expectDaysOld:  0,
+			daysTolerance:  2,
+		},
+		{
+			name:           "xxhash/v2 v2.3.0 - latest (next is pseudo-version)",
+			packageName:    "github.com/cespare/xxhash/v2",
+			currentVersion: "2.3.0",
+			versionsJSON:   xxhashV2VersionsJSON,
+			expectIsLatest: true,
+			expectDaysOld:  0,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.25.0 - 26 days to v0.25.1 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.25.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  26,
+			daysTolerance:  1,
+		},
+		{
+			name:           "buildkit v0.24.0 - 29 days to v0.25.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.24.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  29,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.23.0 - 56 days to v0.24.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.23.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  56,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.22.0 - 92 days to v0.23.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.22.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  92,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.21.0 - 90 days to v0.22.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.21.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  90,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.20.0 - 140 days to v0.21.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.20.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  140,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.19.0 - 103 days to v0.20.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.19.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  103,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.18.0 - 62 days to v0.19.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.18.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  62,
+			daysTolerance:  2,
+		},
+
+		// Test cases 21-33: Very outdated (> 600 days)
+		{
+			name:           "uuid v1.6.0 - latest (next is pseudo-version)",
+			packageName:    "github.com/google/uuid",
+			currentVersion: "1.6.0",
+			versionsJSON:   uuidVersionsJSON,
+			expectIsLatest: true,
+			expectDaysOld:  0,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.17.0 - 69 days to v0.18.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.17.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  69,
+			daysTolerance:  2,
+		},
+		{
+			name:           "buildkit v0.16.0 - 63 days to v0.17.0 (oldest newer)",
+			packageName:    "github.com/moby/buildkit",
+			currentVersion: "0.16.0",
+			versionsJSON:   buildkitVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  63,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.10.0 - 0 days to v1.10.1 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.10.0",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  0,
+			daysTolerance:  1,
+		},
+		{
+			name:           "cobra v1.9.1 - 194 days to v1.10.0 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.9.1",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  194,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.9.0 - 13 days to v1.9.1 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.9.0",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  13,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.8.1 - 87 days to v1.9.0 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.8.1",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  87,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.8.0 - 284 days to v1.8.1 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.8.0",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  284,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.7.0 - 258 days to v1.8.0 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.7.0",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  258,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.6.1 - 180 days to v1.7.0 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.6.1",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  180,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.6.0 - 15 days to v1.6.1 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.6.0",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  15,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.5.0 - 121 days to v1.6.0 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.5.0",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  121,
+			daysTolerance:  2,
+		},
+		{
+			name:           "cobra v1.4.0 - 150 days to v1.5.0 (oldest newer)",
+			packageName:    "github.com/spf13/cobra",
+			currentVersion: "1.4.0",
+			versionsJSON:   cobraVersionsJSON,
+			expectIsLatest: false,
+			expectDaysOld:  150,
+			daysTolerance:  2,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			// Parse the captured API response
+			var versions []depsdev.Version
+			if err := json.Unmarshal([]byte(tc.versionsJSON), &versions); err != nil {
+				t.Fatalf("Failed to parse versions JSON: %v", err)
+			}
+
+			t.Logf("Testing %s version %s", tc.packageName, tc.currentVersion)
+			t.Logf("Total versions from captured API response: %d", len(versions))
+
+			// Test our newestInfoFor function
+			isLatest, oldestNewerPublishedAt := newestInfoFor(tc.currentVersion, versions)
+
+			// Verify isLatest
+			if isLatest != tc.expectIsLatest {
+				t.Errorf("IsLatest mismatch: got %v, want %v", isLatest, tc.expectIsLatest)
+			}
+
+			// Verify days old calculation (to oldest newer version)
+			//nolint:nestif // test validation requires nested structure
+			if !tc.expectIsLatest {
+				if oldestNewerPublishedAt == nil {
+					t.Error("Expected oldestNewerPublishedAt to be set for outdated version")
+					return
+				}
+
+				// Find current version's publish date
+				var currentPub time.Time
+				for _, v := range versions {
+					// Normalize version strings for comparison (handle with/without 'v' prefix)
+					versionToMatch := tc.currentVersion
+					versionInList := v.VersionKey.Version
+					if versionToMatch[0] != 'v' {
+						versionToMatch = "v" + versionToMatch
+					}
+					if versionInList[0] != 'v' && len(versionInList) > 0 {
+						versionInList = "v" + versionInList
+					}
+
+					if versionInList == versionToMatch {
+						var err error
+						currentPub, err = time.Parse(time.RFC3339, v.PublishedAt)
+						if err != nil {
+							t.Errorf("Failed to parse current version publish date: %v", err)
+							return
+						}
+						break
+					}
+				}
+
+				if currentPub.IsZero() {
+					t.Error("Could not find current version in versions list")
+					return
+				}
+
+				delta := oldestNewerPublishedAt.Sub(currentPub)
+				days := int(delta.Hours() / 24)
+
+				t.Logf("Result: %d days between current and oldest newer (expected ~%d)", days, tc.expectDaysOld)
+				t.Logf("Current version published: %s", currentPub.Format(time.RFC3339))
+				t.Logf("Oldest newer version published: %s", oldestNewerPublishedAt.Format(time.RFC3339))
+
+				diff := days - tc.expectDaysOld
+				if diff < 0 {
+					diff = -diff
+				}
+
+				if diff > tc.daysTolerance {
+					t.Errorf("Days old mismatch: got %d days, expected %d days (tolerance: %d)",
+						days, tc.expectDaysOld, tc.daysTolerance)
+				}
+			} else {
+				t.Logf("Result: IS LATEST VERSION")
+			}
+		})
+	}
+}
+
+// Captured API responses from deps.dev (via depsclient.GetPackage)
+// These are real responses captured on 2025-11-10
+// Format matches depsdev.Version struct: {VersionKey:{Version:"x.y.z"}, PublishedAt:"RFC3339"}
+
+const goCmpVersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/google/go-cmp","version":"v0.5.8-0.20250114181544-9b12f366a942"},"publishedAt":"2025-01-14T18:15:44Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-cmp","version":"v0.7.0"},"publishedAt":"2024-08-23T18:33:36Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-cmp","version":"v0.6.0"},"publishedAt":"2023-05-03T19:29:09Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-cmp","version":"v0.5.9"},"publishedAt":"2022-11-05T00:04:31Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-cmp","version":"v0.5.8"},"publishedAt":"2022-05-12T02:16:49Z"}
+]`
+
+const uuidVersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20241114170450-2d3c2a9cc518"},"publishedAt":"2024-11-14T17:04:50Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v0.0.0-20241114170450-2d3c2a9cc518"},"publishedAt":"2024-11-14T17:04:50Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20240806143732-cf44fad6f0fe"},"publishedAt":"2024-08-06T14:37:32Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20240806143717-0e97ed3b5379"},"publishedAt":"2024-08-06T14:37:17Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20240701162350-d55c313874fe"},"publishedAt":"2024-07-01T16:23:50Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v0.0.0-20240701162350-d55c313874fe"},"publishedAt":"2024-07-01T16:23:50Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20240701161543-e8d82d30a3eb"},"publishedAt":"2024-07-01T16:15:43Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20240603173921-53dda83ebe99"},"publishedAt":"2024-06-03T17:39:21Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v0.0.0-20240222164149-6e10cd1027e2"},"publishedAt":"2024-02-22T16:41:49Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20240222164149-6e10cd1027e2"},"publishedAt":"2024-02-22T16:41:49Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.1-0.20240212160722-b5b9aeb1d146"},"publishedAt":"2024-02-12T16:07:22Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.6.0"},"publishedAt":"2024-01-16T19:19:00Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/uuid","version":"v1.5.0"},"publishedAt":"2023-12-12T16:22:53Z"}
+]`
+
+const backoffV4VersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/cenkalti/backoff/v4","version":"v4.3.1-0.20241216033218-258846da02f4"},"publishedAt":"2024-12-16T03:32:18Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cenkalti/backoff/v4","version":"v4.3.0"},"publishedAt":"2024-01-15T22:28:23Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cenkalti/backoff/v4","version":"v4.2.1"},"publishedAt":"2023-03-14T09:25:16Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cenkalti/backoff/v4","version":"v4.2.0"},"publishedAt":"2022-12-17T13:51:06Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cenkalti/backoff/v4","version":"v4.1.3"},"publishedAt":"2022-04-28T07:30:39Z"}
+]`
+
+const cobraVersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.10.2-0.20251010135735-4c363afb59d5"},"publishedAt":"2025-10-10T13:57:35Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.10.1"},"publishedAt":"2025-09-01T16:19:51Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.10.0"},"publishedAt":"2025-08-31T23:15:08Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.9.1"},"publishedAt":"2025-02-18T19:32:38Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.9.0"},"publishedAt":"2025-02-05T16:51:13Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.8.1"},"publishedAt":"2024-11-10T15:18:04Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.8.0"},"publishedAt":"2024-01-30T18:57:44Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.7.0"},"publishedAt":"2023-05-17T17:16:26Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.6.1"},"publishedAt":"2022-11-17T22:02:53Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.6.0"},"publishedAt":"2022-11-02T17:34:10Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.5.0"},"publishedAt":"2022-07-04T11:01:52Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.4.0"},"publishedAt":"2022-02-03T14:47:36Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.3.0"},"publishedAt":"2021-12-27T13:15:00Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.2.1"},"publishedAt":"2021-08-03T18:01:34Z"},
+  {"versionKey":{"system":"GO","name":"github.com/spf13/cobra","version":"v1.2.0"},"publishedAt":"2021-07-28T18:26:26Z"}
+]`
+
+const logrVersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20251103063727-c29d895a2b3f"},"publishedAt":"2025-11-03T06:37:27Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20251027064622-e28ca26c967c"},"publishedAt":"2025-10-27T06:46:22Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20251020155725-604d54d8fcaa"},"publishedAt":"2025-10-20T15:57:25Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20251015075504-f9181c41b310"},"publishedAt":"2025-10-15T07:55:04Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20251006060816-034c819a9ec3"},"publishedAt":"2025-10-06T06:08:16Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250929160248-622a7cb1577d"},"publishedAt":"2025-09-29T16:02:48Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250915042438-41ac1c6cf14c"},"publishedAt":"2025-09-15T04:24:38Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250818172122-502aeda2b1ee"},"publishedAt":"2025-08-18T17:21:22Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250806110651-2ec7e2a95fcd"},"publishedAt":"2025-08-06T11:06:51Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250715095740-f9c496a62c06"},"publishedAt":"2025-07-15T09:57:40Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250701115622-4a7b5fce10e0"},"publishedAt":"2025-07-01T11:56:22Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250617103518-edf7bdf1fa5a"},"publishedAt":"2025-06-17T10:35:18Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250610092451-c067ccaa42e0"},"publishedAt":"2025-06-10T09:24:51Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250603034946-e6c09eb8abbc"},"publishedAt":"2025-06-03T03:49:46Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.4-0.20250602042353-7e799854f8dd"},"publishedAt":"2025-06-02T04:23:53Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.3"},"publishedAt":"2025-05-29T15:04:52Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-logr/logr","version":"v1.4.2"},"publishedAt":"2024-04-29T11:40:52Z"}
+]`
+
+const goContainerRegistryVersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.20.7-0.20251028202801-aab7c77e9d78"},"publishedAt":"2025-10-28T20:28:01Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.0.0-20251028202801-aab7c77e9d78"},"publishedAt":"2025-10-28T20:28:01Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.0.0-20251010214028-cb4a037720c0"},"publishedAt":"2025-10-10T21:40:28Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.20.7-0.20251010214028-cb4a037720c0"},"publishedAt":"2025-10-10T21:40:28Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.20.7-0.20251003171851-d0099a1a8b77"},"publishedAt":"2025-10-03T17:18:51Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.0.0-20251003171851-d0099a1a8b77"},"publishedAt":"2025-10-03T17:18:51Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.0.0-20251002232900-5924946662b9"},"publishedAt":"2025-10-02T23:29:00Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.20.7-0.20251002232900-5924946662b9"},"publishedAt":"2025-10-02T23:29:00Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.20.7-0.20251002230642-8d9c9efa049a"},"publishedAt":"2025-10-02T23:06:42Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.20.6"},"publishedAt":"2025-10-02T15:58:44Z"},
+  {"versionKey":{"system":"GO","name":"github.com/google/go-containerregistry","version":"v0.20.5"},"publishedAt":"2025-09-24T14:57:13Z"}
+]`
+
+const buildkitVersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.26.0-rc1.0.20251107065059-474cae70a594"},"publishedAt":"2025-11-07T06:50:59Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.26.0-rc1"},"publishedAt":"2025-11-05T23:49:43Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.25.2"},"publishedAt":"2025-11-05T10:29:03Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.25.1"},"publishedAt":"2025-11-05T09:48:00Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.25.0"},"publishedAt":"2025-10-10T02:22:03Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.24.0"},"publishedAt":"2025-09-10T19:55:56Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.23.0"},"publishedAt":"2025-07-16T09:51:57Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.22.0"},"publishedAt":"2025-04-15T07:26:29Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.21.0"},"publishedAt":"2025-01-15T02:45:20Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.20.0"},"publishedAt":"2024-08-27T19:08:23Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.19.0"},"publishedAt":"2024-05-16T02:56:39Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.18.0"},"publishedAt":"2024-03-14T03:02:18Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.17.0"},"publishedAt":"2024-01-04T22:25:05Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.16.0"},"publishedAt":"2023-11-02T03:03:05Z"},
+  {"versionKey":{"system":"GO","name":"github.com/moby/buildkit","version":"v0.15.0"},"publishedAt":"2023-10-06T02:17:12Z"}
+]`
+
+const xxhashV2VersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/cespare/xxhash/v2","version":"v2.3.1-0.20240703180136-ab37246c889f"},"publishedAt":"2024-07-03T18:01:36Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cespare/xxhash/v2","version":"v2.3.0"},"publishedAt":"2024-04-04T20:00:10Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cespare/xxhash/v2","version":"v2.2.1-0.20230726053707-21fc82b0b9b5"},"publishedAt":"2023-07-26T05:37:07Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cespare/xxhash/v2","version":"v2.2.1-0.20230403140943-66b140914239"},"publishedAt":"2023-04-03T14:09:43Z"},
+  {"versionKey":{"system":"GO","name":"github.com/cespare/xxhash/v2","version":"v2.2.0"},"publishedAt":"2022-12-04T02:06:23Z"}
+]`
+
+const semverV3VersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/Masterminds/semver/v3","version":"v3.4.1-0.20250707152403-bf01c6184597"},"publishedAt":"2025-07-07T15:24:03Z"},
+  {"versionKey":{"system":"GO","name":"github.com/Masterminds/semver/v3","version":"v3.4.0"},"publishedAt":"2025-06-27T14:48:33Z"},
+  {"versionKey":{"system":"GO","name":"github.com/Masterminds/semver/v3","version":"v3.3.1"},"publishedAt":"2024-11-19T20:00:22Z"},
+  {"versionKey":{"system":"GO","name":"github.com/Masterminds/semver/v3","version":"v3.3.0"},"publishedAt":"2024-08-02T19:12:08Z"},
+  {"versionKey":{"system":"GO","name":"github.com/Masterminds/semver/v3","version":"v3.2.1"},"publishedAt":"2023-05-19T15:30:05Z"}
+]`
+
+const goGitV5VersionsJSON = `[
+  {"versionKey":{"system":"GO","name":"github.com/go-git/go-git/v5","version":"v5.16.3"},"publishedAt":"2025-09-17T10:22:49Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-git/go-git/v5","version":"v5.16.2"},"publishedAt":"2025-06-06T16:15:07Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-git/go-git/v5","version":"v5.16.1"},"publishedAt":"2025-06-04T09:28:06Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-git/go-git/v5","version":"v5.16.0"},"publishedAt":"2025-05-23T10:57:28Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-git/go-git/v5","version":"v5.15.0"},"publishedAt":"2025-03-04T19:19:04Z"},
+  {"versionKey":{"system":"GO","name":"github.com/go-git/go-git/v5","version":"v5.14.0"},"publishedAt":"2024-11-08T12:11:36Z"}
+]`

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -484,6 +484,12 @@ func TestSignedRelease(t *testing.T) {
 					return &v, nil
 				},
 			).AnyTimes()
+			mockPkgC.EXPECT().GetPackage(gomock.Any(), gomock.Any(), gomock.Any()).DoAndReturn(
+				func(ctx context.Context, host, project string) (*packageclient.Package, error) {
+					v := packageclient.Package{}
+					return &v, nil
+				},
+			).AnyTimes()
 
 			req := checker.CheckRequest{
 				RepoClient:    mockRepoC,

--- a/clients/mockclients/projectpackageclient.go
+++ b/clients/mockclients/projectpackageclient.go
@@ -61,5 +61,21 @@ func (m *MockProjectPackageClient) GetProjectPackageVersions(ctx context.Context
 // GetProjectPackageVersions indicates an expected call of GetProjectPackageVersions.
 func (mr *MockProjectPackageClientMockRecorder) GetProjectPackageVersions(ctx, host, project interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectPackageVersions", reflect.TypeOf((*MockProjectPackageClient)(nil).GetProjectPackageVersions), ctx, host, project)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectPackageVersions", reflect.TypeOf((*MockProjectPackageClient)(nil).GetPackage), ctx, host, project)
+}
+
+
+// GetPackage mocks base method.
+func (m *MockProjectPackageClient) GetPackage(ctx context.Context, host, project string) (*packageclient.Package, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetPackage", ctx, host, project)
+	ret0, _ := ret[0].(*packageclient.Package)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetPackage indicates an expected call of GetPackage.
+func (mr *MockProjectPackageClientMockRecorder) GetPackage(ctx, host, project interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPackage", reflect.TypeOf((*MockProjectPackageClient)(nil).GetPackage), ctx, host, project)
 }

--- a/clients/scalibr_client.go
+++ b/clients/scalibr_client.go
@@ -1,0 +1,303 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	scalibr "github.com/google/osv-scalibr"
+	scalibrfs "github.com/google/osv-scalibr/fs"
+	"github.com/google/osv-scalibr/plugin"
+	pl "github.com/google/osv-scalibr/plugin/list"
+	"github.com/package-url/packageurl-go"
+)
+
+// ===== Debug support (opt-in) ================================================
+
+var scalibrDebug = func() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("SCALIBR_DEBUG")))
+	return v == "1" || v == "true" || v == "yes" || v == "on"
+}()
+
+func SetScalibrDebug(enable bool) { scalibrDebug = enable }
+
+func dbgf(format string, args ...any) {
+	if scalibrDebug {
+		log.Printf("[scalibr] "+format, args...)
+	}
+}
+
+// =============================================================================
+
+var (
+	ErrLocalDirRequired = errors.New("localDir is required")
+	ErrScalibrNoResult  = errors.New("scalibr returned no result")
+)
+
+type DepsClient interface {
+	GetDeps(ctx context.Context, localDir string) (DepsResponse, error)
+}
+
+type DepsResponse struct {
+	Started  time.Time
+	Finished time.Time
+	Deps     []Dep
+}
+
+type Dep struct {
+	Ecosystem string // derived from PURL type when available
+	Name      string
+	Version   string
+	PURL      string
+	Location  string // left empty; current extractor API doesn't expose file reliably
+}
+
+func NewDirectDepsClient() DepsClient {
+	return &scalibrDepsClient{
+		capab: &plugin.Capabilities{
+			DirectFS: true,
+			Network:  plugin.NetworkOffline,
+		},
+	}
+}
+
+type scalibrDepsClient struct {
+	capab *plugin.Capabilities
+}
+
+func (c *scalibrDepsClient) GetDeps(ctx context.Context, localDir string) (DepsResponse, error) {
+	if strings.TrimSpace(localDir) == "" {
+		return DepsResponse{}, ErrLocalDirRequired
+	}
+
+	// Parse go.mod to identify indirect dependencies
+	goIndirectDeps := parseGoModIndirect(localDir)
+	log.Printf("[scalibr] GetDeps: parsed %d indirect dependencies from go.mod", len(goIndirectDeps))
+
+	// Load all registered plugins, then filter by capabilities.
+	allPlugins := pl.All()
+	selected := plugin.FilterByCapabilities(allPlugins, c.capab)
+	dbgf("GetDeps: scan root=%q, plugins available=%d, selected=%d (DirectFS, offline)",
+		localDir, len(allPlugins), len(selected))
+
+	cfg := &scalibr.ScanConfig{
+		Plugins:      selected,
+		ScanRoots:    scalibrfs.RealFSScanRoots(localDir),
+		UseGitignore: true,
+	}
+	res := scalibr.New().Scan(ctx, cfg)
+	if res == nil || res.Inventory.Packages == nil {
+		dbgf("GetDeps: scalibr returned no result or empty inventory")
+		return DepsResponse{}, ErrScalibrNoResult
+	}
+
+	out := DepsResponse{Started: res.StartTime, Finished: res.EndTime}
+	dbgf("GetDeps: inventory packages reported: %d (pre-filter)", len(res.Inventory.Packages))
+
+	skippedIndirect := 0
+	for _, p := range res.Inventory.Packages {
+		if p == nil {
+			continue
+		}
+
+		// Derive ecosystem from PURL type when present.
+		var purlStr, eco string
+		if u := p.PURL(); u != nil {
+			purlStr = u.String()
+			eco = normalizePURLType(u.Type)
+		}
+
+		// Keep only direct dependencies, when metadata indicates scope.
+		if md, ok := p.Metadata.(map[string]string); ok {
+			if strings.EqualFold(md["dependency_scope"], "indirect") {
+				skippedIndirect++
+				dbgf("GetDeps: skip indirect: name=%q version=%q", p.Name, p.Version)
+				continue
+			}
+		}
+
+		// For Go dependencies, also check if marked indirect in go.mod
+		if goIndirectDeps[p.Name] {
+			skippedIndirect++
+			dbgf("GetDeps: skip Go indirect (from go.mod): name=%q version=%q", p.Name, p.Version)
+			continue
+		}
+
+		name := strings.TrimSpace(p.Name)
+		version := strings.TrimSpace(p.Version)
+
+		// Synthesize PURL if missing but we have enough info.
+		if purlStr == "" && eco != "" && name != "" && version != "" {
+			purlStr = packageurl.NewPackageURL(eco, "", name, version, nil, "").ToString()
+		}
+
+		out.Deps = append(out.Deps, Dep{
+			Ecosystem: eco,
+			Name:      name,
+			Version:   version,
+			PURL:      purlStr,
+			Location:  "",
+		})
+	}
+
+	// Deterministic order.
+	sort.Slice(out.Deps, func(i, j int) bool {
+		a, b := out.Deps[i], out.Deps[j]
+		if a.Ecosystem != b.Ecosystem {
+			return a.Ecosystem < b.Ecosystem
+		}
+		if a.Name != b.Name {
+			return a.Name < b.Name
+		}
+		if a.Version != b.Version {
+			return a.Version < b.Version
+		}
+		return a.PURL < b.PURL
+	})
+
+	dbgf("GetDeps: skipped %d indirect deps; returning %d direct deps", skippedIndirect, len(out.Deps))
+	for _, d := range out.Deps {
+		dbgf("GetDeps: direct dep: eco=%q name=%q ver=%q purl=%q", d.Ecosystem, d.Name, d.Version, d.PURL)
+	}
+
+	return out, nil
+}
+
+// normalizePURLType maps PURL types to canonical forms we use elsewhere.
+//
+//nolint:goconst // String literals are clearer than constants for this mapping function
+func normalizePURLType(t string) string {
+	switch strings.ToLower(strings.TrimSpace(t)) {
+	case "golang", "go", "gomod":
+		return "golang"
+	case "npm", "node", "packagejson":
+		return "npm"
+	case "pypi", "python", "pyproject", "requirements":
+		return "pypi"
+	case "maven", "pom", "pomxml", "gradle":
+		return "maven"
+	case "cargo", "cargotoml", "rust", "crates.io":
+		return "cargo"
+	case "nuget", ".net", "nugetproj":
+		return "nuget"
+	case "gem", "ruby", "rubygems", "gemfile":
+		return "gem"
+	default:
+		return t
+	}
+}
+
+// parseGoModIndirect recursively parses ALL go.mod files in the given directory
+// and returns a set of package names that are marked as indirect dependencies.
+// This is necessary because osv-scalibr scans ALL go.mod files in the tree
+// (including subdirectories like "tools/"), not just the root one.
+func parseGoModIndirect(rootDir string) map[string]bool {
+	indirectDeps := make(map[string]bool)
+
+	log.Printf("[scalibr] parseGoModIndirect: searching for go.mod files recursively in: %s", rootDir)
+
+	// First, check if we need to navigate into a tarball-extracted subdirectory
+	// (GitHub tarballs extract to "repo-{sha}/" subdirectory)
+	entries, err := os.ReadDir(rootDir)
+	if err != nil {
+		log.Printf("[scalibr] parseGoModIndirect: failed to read directory: %v", err)
+		return indirectDeps
+	}
+
+	// If there's exactly one subdirectory and no go.mod at root, it's likely a tarball extraction
+	_, errRootGoMod := os.Stat(filepath.Join(rootDir, "go.mod"))
+	if errRootGoMod != nil && len(entries) == 1 && entries[0].IsDir() {
+		// Navigate into the single subdirectory (tarball structure)
+		rootDir = filepath.Join(rootDir, entries[0].Name())
+		log.Printf("[scalibr] parseGoModIndirect: detected tarball structure, using: %s", rootDir)
+	}
+
+	// Now walk the tree and parse ALL go.mod files
+	goModCount := 0
+	//nolint:nilerr // Intentionally skip unreadable directories and continue walking
+	err = filepath.WalkDir(rootDir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // Skip directories we can't read
+		}
+
+		// Skip hidden directories like .git
+		if d.IsDir() && strings.HasPrefix(d.Name(), ".") {
+			return filepath.SkipDir
+		}
+
+		// Parse go.mod files
+		if !d.IsDir() && d.Name() == "go.mod" {
+			goModCount++
+			beforeCount := len(indirectDeps)
+			if err := parseGoModFileForIndirect(path, indirectDeps); err == nil {
+				newIndirect := len(indirectDeps) - beforeCount
+				if newIndirect > 0 {
+					log.Printf("[scalibr] parseGoModIndirect: found %d indirect deps in %s", newIndirect, path)
+				}
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		log.Printf("[scalibr] parseGoModIndirect: error during walk: %v", err)
+	}
+
+	log.Printf("[scalibr] parseGoModIndirect: scanned %d go.mod files, found %d total indirect dependencies",
+		goModCount, len(indirectDeps))
+	return indirectDeps
+}
+
+// parseGoModFileForIndirect parses a single go.mod file and populates the indirectDeps map.
+func parseGoModFileForIndirect(goModPath string, indirectDeps map[string]bool) error {
+	file, err := os.Open(goModPath)
+	if err != nil {
+		return fmt.Errorf("opening go.mod file %s: %w", goModPath, err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+
+		// Look for lines with "// indirect" comment
+		if !strings.Contains(line, "// indirect") {
+			continue
+		}
+
+		// Parse the dependency name from the line
+		// Format: "github.com/pkg/name v1.2.3 // indirect"
+		parts := strings.Fields(line)
+		if len(parts) >= 2 {
+			pkgName := parts[0]
+			indirectDeps[pkgName] = true
+			dbgf("parseGoModIndirect: found indirect dep: %q", pkgName)
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning go.mod file %s: %w", goModPath, err)
+	}
+	return nil
+}

--- a/clients/scalibr_client_test.go
+++ b/clients/scalibr_client_test.go
@@ -1,0 +1,269 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewDirectDepsClient(t *testing.T) {
+	t.Parallel()
+	client := NewDirectDepsClient()
+	if client == nil {
+		t.Fatal("NewDirectDepsClient() returned nil")
+	}
+}
+
+func TestScalibrDepsClient_GetDeps_EmptyDir(t *testing.T) {
+	t.Parallel()
+	client := NewDirectDepsClient()
+
+	// Test with empty string
+	_, err := client.GetDeps(context.Background(), "")
+	if err == nil {
+		t.Error("GetDeps with empty dir should return error")
+	}
+}
+
+func TestScalibrDepsClient_GetDeps_NonexistentDir(t *testing.T) {
+	t.Parallel()
+	client := NewDirectDepsClient()
+
+	// Test with nonexistent directory - scalibr succeeds but finds no dependencies
+	resp, err := client.GetDeps(context.Background(), "/nonexistent/path/to/nowhere")
+	if err != nil {
+		t.Errorf("GetDeps with nonexistent dir should not error, got: %v", err)
+	}
+	if len(resp.Deps) != 0 {
+		t.Errorf("Expected 0 dependencies from nonexistent dir, got %d", len(resp.Deps))
+	}
+}
+
+func TestScalibrDepsClient_GetDeps_ValidGoProject(t *testing.T) {
+	t.Parallel()
+	// Create a temporary directory with a simple Go project
+	tmpDir := t.TempDir()
+
+	// Create a go.mod file
+	goModContent := `module example.com/test
+
+go 1.21
+
+require (
+	github.com/google/uuid v1.3.0
+)
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	// Create a main.go file
+	mainGoContent := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, World!")
+}
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "main.go"), []byte(mainGoContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create main.go: %v", err)
+	}
+
+	client := NewDirectDepsClient()
+	resp, err := client.GetDeps(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("GetDeps failed: %v", err)
+	}
+
+	// Check that we got the uuid dependency
+	found := false
+	for _, dep := range resp.Deps {
+		if dep.Name == "github.com/google/uuid" {
+			found = true
+			// Note: scalibr's Go module extractor returns versions without "v" prefix
+			if dep.Version != "1.3.0" {
+				t.Errorf("Expected version 1.3.0, got %s", dep.Version)
+			}
+			if dep.Ecosystem != "golang" {
+				t.Errorf("Expected ecosystem golang, got %s", dep.Ecosystem)
+			}
+		}
+	}
+
+	if !found {
+		t.Error("Expected to find github.com/google/uuid dependency")
+	}
+}
+
+func TestScalibrDepsClient_GetDeps_ValidNPMProject(t *testing.T) {
+	t.Parallel()
+	// Create a temporary directory with a simple NPM project
+	tmpDir := t.TempDir()
+
+	// Create a package.json file
+	packageJSONContent := `{
+  "name": "test-project",
+  "version": "1.0.0",
+  "dependencies": {
+    "express": "4.18.2"
+  }
+}
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "package.json"), []byte(packageJSONContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create package.json: %v", err)
+	}
+
+	// Create a package-lock.json as scalibr needs it to find dependencies
+	packageLockJSONContent := `{
+  "name": "test-project",
+  "version": "1.0.0",
+  "lockfileVersion": 2,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "test-project",
+      "version": "1.0.0",
+      "dependencies": {
+        "express": "4.18.2"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz"
+    }
+  },
+  "dependencies": {
+    "express": {
+      "version": "4.18.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.18.2.tgz"
+    }
+  }
+}
+`
+	err = os.WriteFile(filepath.Join(tmpDir, "package-lock.json"), []byte(packageLockJSONContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create package-lock.json: %v", err)
+	}
+
+	client := NewDirectDepsClient()
+	resp, err := client.GetDeps(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("GetDeps failed: %v", err)
+	}
+
+	// Check that we got the express dependency
+	found := false
+	for _, dep := range resp.Deps {
+		if dep.Name == "express" {
+			found = true
+			if dep.Version != "4.18.2" {
+				t.Errorf("Expected version 4.18.2, got %s", dep.Version)
+			}
+			if dep.Ecosystem != "npm" {
+				t.Errorf("Expected ecosystem npm, got %s", dep.Ecosystem)
+			}
+		}
+	}
+
+	if !found {
+		t.Error("Expected to find express dependency")
+	}
+}
+
+func TestNormalizePURLType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"golang", "golang"},
+		{"go", "golang"},
+		{"gomod", "golang"},
+		{"npm", "npm"},
+		{"node", "npm"},
+		{"pypi", "pypi"},
+		{"python", "pypi"},
+		{"maven", "maven"},
+		{"cargo", "cargo"},
+		{"rust", "cargo"},
+		{"nuget", "nuget"},
+		{"gem", "gem"},
+		{"ruby", "gem"},
+		{"unknown", "unknown"},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			result := normalizePURLType(tt.input)
+			if result != tt.expected {
+				t.Errorf("normalizePURLType(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestScalibrDepsClient_GetDeps_DeterministicOrder(t *testing.T) {
+	t.Parallel()
+	// Create a temporary directory with multiple dependencies
+	tmpDir := t.TempDir()
+
+	goModContent := `module example.com/test
+
+go 1.21
+
+require (
+	github.com/google/uuid v1.3.0
+	github.com/stretchr/testify v1.8.0
+	golang.org/x/sync v0.1.0
+)
+`
+	err := os.WriteFile(filepath.Join(tmpDir, "go.mod"), []byte(goModContent), 0o600)
+	if err != nil {
+		t.Fatalf("Failed to create go.mod: %v", err)
+	}
+
+	client := NewDirectDepsClient()
+
+	// Run GetDeps multiple times and ensure order is consistent
+	resp1, err := client.GetDeps(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("GetDeps failed: %v", err)
+	}
+
+	resp2, err := client.GetDeps(context.Background(), tmpDir)
+	if err != nil {
+		t.Fatalf("GetDeps failed: %v", err)
+	}
+
+	if len(resp1.Deps) != len(resp2.Deps) {
+		t.Fatalf("Inconsistent number of deps: %d vs %d", len(resp1.Deps), len(resp2.Deps))
+	}
+
+	for i := range resp1.Deps {
+		if resp1.Deps[i].Name != resp2.Deps[i].Name {
+			t.Errorf("Deps order mismatch at index %d: %s vs %s",
+				i, resp1.Deps[i].Name, resp2.Deps[i].Name)
+		}
+	}
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -397,6 +397,33 @@ License Requirements:
 - For other hosting environments, create the license in a `.adoc`, `.asc`, `.docx`, `.doc`, `.ext`, `.html`, `.markdown`, `.md`, `.rst`, `.txt`, or `.xml`, named `LICENSE`, `COPYRIGHT`, or `COPYING`, and place it in the top-level directory. To identify a specific license, use an [SPDX license identifier](https://spdx.org/licenses/) in the filename. Examples include `LICENSE.md`, `Apache-2.0-LICENSE.md` or `LICENSE-Apache-2.0`.
 - Alternately, create a `LICENSES` directory and add a license file(s) with a name that matches your [SPDX license identifier](https://spdx.org/licenses/). such as `LICENSES/Apache-2.0.txt`.
 
+## MTTUDependencies 
+
+Risk: `Medium` (dependencies with known vulnerabilities or lacking recent updates)
+
+This check calculates the Mean Time To Update (MTTU) for the project's direct
+dependencies. For each dependency, it measures the time elapsed since the oldest
+newer version was released (not the latest version). This provides a fair assessment
+of how quickly the project updates dependencies after new versions become available.
+
+The check uses osv-scalibr to discover direct dependencies (excluding transitive
+dependencies) and queries the deps.dev API to determine version history. Dependencies
+already on the latest stable version contribute zero to the mean. Pseudo-versions
+(unreleased development versions like v1.2.3-0.20240101120000-abc123def) are
+filtered out to ensure fair comparison against released versions only.
+
+Scoring:
+  - Mean MTTU < 3 months: Score 10 (dependencies are updated promptly)
+  - Mean MTTU 3-6 months: Score 5 (moderate update lag)
+  - Mean MTTU >= 6 months: Score 0 (significant update delays)
+ 
+
+**Remediation steps**
+- Update dependencies regularly to reduce the mean time to update.
+- Use a dependency update tool like Dependabot or Renovate to automatically receive notifications when new versions are available.
+- Review the changelog of newer versions to understand what improvements and security fixes are available.
+- Establish a regular dependency update cadence (e.g., weekly or monthly reviews).
+
 ## Maintained 
 
 Risk: `High` (possibly unpatched vulnerabilities)

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -48,6 +48,40 @@ checks:
         check simply provides insight into the project activity and maintenance
         commitment. External users should determine whether the software is the type
         that would not normally need active maintenance.
+  MTTUDependencies:
+    risk: Medium
+    tags: supply-chain, security, dependencies
+    repos: GitHub, GitLab, local
+    short: Determines the mean time to update dependencies (MTTU).
+    description: |
+      Risk: `Medium` (dependencies with known vulnerabilities or lacking recent updates)
+
+      This check calculates the Mean Time To Update (MTTU) for the project's direct
+      dependencies. For each dependency, it measures the time elapsed since the oldest
+      newer version was released (not the latest version). This provides a fair assessment
+      of how quickly the project updates dependencies after new versions become available.
+
+      The check uses osv-scalibr to discover direct dependencies (excluding transitive
+      dependencies) and queries the deps.dev API to determine version history. Dependencies
+      already on the latest stable version contribute zero to the mean. Pseudo-versions
+      (unreleased development versions like v1.2.3-0.20240101120000-abc123def) are
+      filtered out to ensure fair comparison against released versions only.
+
+      Scoring:
+        - Mean MTTU < 3 months: Score 10 (dependencies are updated promptly)
+        - Mean MTTU 3-6 months: Score 5 (moderate update lag)
+        - Mean MTTU >= 6 months: Score 0 (significant update delays)
+    remediation:
+      - >-
+        Update dependencies regularly to reduce the mean time to update.
+      - >-
+        Use a dependency update tool like Dependabot or Renovate to automatically
+        receive notifications when new versions are available.
+      - >-
+        Review the changelog of newer versions to understand what improvements and
+        security fixes are available.
+      - >-
+        Establish a regular dependency update cadence (e.g., weekly or monthly reviews).
   Dependency-Update-Tool:
     risk: High
     tags: supply-chain, security, dependencies

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -5,6 +5,48 @@ This page describes each Scorecard probe in detail, including description, motiv
 and outcomes. If you have ideas for additions or new detection techniques,
 please [contribute](../CONTRIBUTING.md)!
 
+## MTTUDependenciesIsHigh
+
+**Lifecycle**: experimental
+
+**Description**: Mean time since the oldest newer dependency release is high (≥ 6 months).
+
+**Motivation**: Highly stale dependencies significantly increase security and operational risks. Long delays in updating dependencies make it more likely to miss critical security fixes and complicate incident response.
+
+**Implementation**: The probe computes, for each declared dependency, the time elapsed since the oldest release newer than the version used by the project. Dependencies already on the latest version contribute zero. Pseudo-versions (unreleased development versions) are filtered out to ensure fair comparison. It then takes the mean across all dependencies. If the mean is ≥ 180 days (6 months), the probe returns OutcomeTrue; otherwise OutcomeFalse.
+
+**Outcomes**: OutcomeTrue when the mean time is ≥ 180 days (6 months).
+OutcomeFalse when the mean time is < 180 days.
+
+
+## MTTUDependenciesIsLow
+
+**Lifecycle**: experimental
+
+**Description**: Mean time since the oldest newer dependency release is moderate (3-6 months).
+
+**Motivation**: Moderately stale dependencies increase operational and security risk over time. Keeping the mean time within a few months is better than large backlogs, but further improvement reduces exposure to vulnerabilities and incompatibilities.
+
+**Implementation**: The probe computes, for each declared dependency, the time elapsed since the oldest release newer than the version used by the project. Dependencies already on the latest version contribute zero. Pseudo-versions (unreleased development versions) are filtered out to ensure fair comparison. It then takes the mean across all dependencies. If the mean is ≥ 90 days (3 months) and < 180 days (6 months), the probe returns OutcomeTrue; otherwise OutcomeFalse.
+
+**Outcomes**: OutcomeTrue when 90 days ≤ mean time < 180 days (3-6 months).
+OutcomeFalse when mean time < 90 days or ≥ 180 days.
+
+
+## MTTUDependenciesIsVeryLow
+
+**Lifecycle**: experimental
+
+**Description**: Mean time since the oldest newer dependency release is very low (< 3 months).
+
+**Motivation**: Keeping dependencies fresh reduces exposure to known vulnerabilities and supply-chain risk, and makes it easier to adopt security fixes quickly. A very low mean time indicates that the project updates promptly when newer releases are available.
+
+**Implementation**: The probe computes, for each declared dependency, the time elapsed since the oldest release newer than the version used by the project. Dependencies already on the latest version contribute zero. Pseudo-versions (unreleased development versions) are filtered out to ensure fair comparison. It then takes the mean across all dependencies. If the mean is less than 90 days (3 months), the probe returns OutcomeTrue; otherwise OutcomeFalse.
+
+**Outcomes**: OutcomeTrue when the mean time is < 90 days (3 months).
+OutcomeFalse when the mean time is >= 90 days.
+
+
 ## archived
 
 **Lifecycle**: stable

--- a/go.mod
+++ b/go.mod
@@ -41,13 +41,16 @@ require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/gobwas/glob v0.2.3
 	github.com/google/go-github/v53 v53.2.0
+	github.com/google/osv-scalibr v0.3.7-0.20251023161426-90e9ac9cc1b3
 	github.com/google/osv-scanner/v2 v2.2.4
 	github.com/hmarr/codeowners v1.2.1
 	github.com/in-toto/attestation v1.1.2
 	github.com/mcuadros/go-jsonschema-generator v0.0.0-20200330054847-ba7a369d4303
 	github.com/onsi/ginkgo/v2 v2.27.2
 	github.com/otiai10/copy v1.14.1
+	github.com/package-url/packageurl-go v0.1.3
 	gitlab.com/gitlab-org/api/client-go v0.159.0
+	golang.org/x/mod v0.28.0
 	sigs.k8s.io/release-utils v0.11.1
 )
 
@@ -135,7 +138,6 @@ require (
 	github.com/google/gnostic-models v0.6.8 // indirect
 	github.com/google/go-github/v75 v75.0.0 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
-	github.com/google/osv-scalibr v0.3.7-0.20251023161426-90e9ac9cc1b3 // indirect
 	github.com/google/pprof v0.0.0-20250403155104-27863c87afa6 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
@@ -168,7 +170,6 @@ require (
 	github.com/ossf/osv-schema/bindings/go v0.0.0-20251012234424-434020c6442f // indirect
 	github.com/otiai10/mint v1.6.3 // indirect
 	github.com/owenrumney/go-sarif/v3 v3.2.3 // indirect
-	github.com/package-url/packageurl-go v0.1.3 // indirect
 	github.com/pandatix/go-cvss v0.6.2 // indirect
 	github.com/pierrec/lz4/v4 v4.1.21 // indirect
 	github.com/pjbgf/sha1cd v0.4.0 // indirect
@@ -215,7 +216,6 @@ require (
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	go.yaml.in/yaml/v4 v4.0.0-rc.2 // indirect
-	golang.org/x/mod v0.28.0 // indirect
 	golang.org/x/telemetry v0.0.0-20250908211612-aef8a434d053 // indirect
 	golang.org/x/term v0.36.0 // indirect
 	golang.org/x/time v0.13.0 // indirect

--- a/internal/checknames/checknames.go
+++ b/internal/checknames/checknames.go
@@ -29,6 +29,7 @@ const (
 	Fuzzing              CheckName = "Fuzzing"
 	License              CheckName = "License"
 	Maintained           CheckName = "Maintained"
+	MTTUDependencies     CheckName = "MTTUDependencies"
 	Packaging            CheckName = "Packaging"
 	PinnedDependencies   CheckName = "Pinned-Dependencies"
 	SAST                 CheckName = "SAST"
@@ -52,6 +53,7 @@ var AllValidChecks []string = []string{
 	Fuzzing,
 	License,
 	Maintained,
+	MTTUDependencies,
 	Packaging,
 	PinnedDependencies,
 	SAST,

--- a/internal/packageclient/depsdev_test.go
+++ b/internal/packageclient/depsdev_test.go
@@ -1,0 +1,148 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package packageclient
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+type RoundTripFunc func(req *http.Request) *http.Response
+
+func (f RoundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req), nil
+}
+
+func NewTestClient(fn RoundTripFunc) *http.Client {
+	return &http.Client{
+		Transport: fn,
+	}
+}
+
+func TestGetPackage(t *testing.T) {
+	t.Parallel()
+	resp := `{
+  "packageKey": {
+    "system": "NPM",
+    "name": "@colors/colors"
+  },
+  "purl": "pkg:npm/%40colors/colors",
+  "versions": [
+    {
+      "versionKey": {
+        "system": "NPM",
+        "name": "@colors/colors",
+        "version": "1.4.0"
+      },
+      "purl": "pkg:npm/%40colors/colors@1.4.0",
+      "publishedAt": "2022-02-12T06:40:43Z",
+      "isDefault": false,
+      "isDeprecated": false
+    },
+    {
+      "versionKey": {
+        "system": "NPM",
+        "name": "@colors/colors",
+        "version": "1.5.0"
+      },
+      "purl": "pkg:npm/%40colors/colors@1.5.0",
+      "publishedAt": "2022-02-12T07:39:04Z",
+      "isDefault": false,
+      "isDeprecated": false
+    },
+    {
+      "versionKey": {
+        "system": "NPM",
+        "name": "@colors/colors",
+        "version": "1.6.0"
+      },
+      "purl": "pkg:npm/%40colors/colors@1.6.0",
+      "publishedAt": "2023-07-10T05:16:15Z",
+      "isDefault": true,
+      "isDeprecated": false
+    }
+  ]
+}`
+	expected := &Package{
+		PackageKey: PackageKey{
+			PackageSystem: "NPM",
+			PackageName:   "@colors/colors",
+		},
+		Purl: "pkg:npm/%40colors/colors",
+		Versions: []Version{
+			{
+				VersionKey: VersionKey{
+					System:  "NPM",
+					Name:    "@colors/colors",
+					Version: "1.4.0",
+				},
+				Purl:         "pkg:npm/%40colors/colors@1.4.0",
+				PublishedAt:  "2022-02-12T06:40:43Z",
+				IsDefault:    false,
+				IsDeprecated: false,
+			},
+			{
+				VersionKey: VersionKey{
+					System:  "NPM",
+					Name:    "@colors/colors",
+					Version: "1.5.0",
+				},
+				Purl:         "pkg:npm/%40colors/colors@1.5.0",
+				PublishedAt:  "2022-02-12T07:39:04Z",
+				IsDefault:    false,
+				IsDeprecated: false,
+			},
+			{
+				VersionKey: VersionKey{
+					System:  "NPM",
+					Name:    "@colors/colors",
+					Version: "1.6.0",
+				},
+				Purl:         "pkg:npm/%40colors/colors@1.6.0",
+				PublishedAt:  "2023-07-10T05:16:15Z",
+				IsDefault:    true,
+				IsDeprecated: false,
+			},
+		},
+	}
+
+	// Create test client that does not call the deps.dev api
+	testClient := NewTestClient(func(req *http.Request) *http.Response {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			// Send response to be tested
+			Body: io.NopCloser(bytes.NewBufferString(resp)),
+			// Must be set to non-nil value or it panics
+			Header: make(http.Header),
+		}
+	})
+	depsClient := depsDevClient{
+		client: testClient,
+	}
+	depsClient.client = testClient
+
+	r, err := depsClient.GetPackage(context.Background(), "npm", "@colors/colors")
+	if err != nil {
+		t.Errorf("GetPackage returned an error: %v", err)
+	}
+	if diff := cmp.Diff(r, expected); diff != "" {
+		t.Errorf("setDefaultCommitData() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/probes/MTTUDependenciesIsHigh/def.yml
+++ b/probes/MTTUDependenciesIsHigh/def.yml
@@ -1,0 +1,36 @@
+# Copyright 2025 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: MTTUDependenciesIsHigh
+lifecycle: experimental
+short: Mean time since the oldest newer dependency release is high (≥ 6 months).
+motivation: >
+  Highly stale dependencies significantly increase security and operational risks. Long delays in updating
+  dependencies make it more likely to miss critical security fixes and complicate incident response.
+implementation: >
+  The probe computes, for each declared dependency, the time elapsed since the oldest release newer than
+  the version used by the project. Dependencies already on the latest version contribute zero. Pseudo-versions
+  (unreleased development versions) are filtered out to ensure fair comparison. It then takes the mean
+  across all dependencies. If the mean is ≥ 180 days (6 months), the probe returns OutcomeTrue;
+  otherwise OutcomeFalse.
+outcome:
+  - OutcomeTrue when the mean time is ≥ 180 days (6 months).
+  - OutcomeFalse when the mean time is < 180 days.
+remediation:
+  onOutcome: False
+  effort: Medium
+  text:
+    - Reduce staleness by enabling automated updates and planning dependency upgrade sprints to bring the mean under 6 months.
+    - Prioritize dependencies with known security vulnerabilities.
+    - Break down large update efforts into smaller, manageable chunks.

--- a/probes/MTTUDependenciesIsHigh/impl.go
+++ b/probes/MTTUDependenciesIsHigh/impl.go
@@ -1,0 +1,64 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package MTTUDependenciesIsHigh
+
+import (
+	"embed"
+	"fmt"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/mttu"
+)
+
+//go:embed *.yml
+var fs embed.FS
+
+// Probe identifies this probe in emitted findings.
+const Probe = "MTTUDependenciesIsHigh"
+
+// Run computes the mean time since the oldest newer release and emits a single Finding.
+// OutcomeTrue iff mean >= 6 months (defined as 180 days).
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	meantime, evaluated, problems, err := mttu.MeanTimeSinceFirstNewer(raw)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("computing mean MTTU: %w", err)
+	}
+
+	const daysPerMonth = 30
+	threshold := time.Duration(6*daysPerMonth) * 24 * time.Hour
+
+	days := int(meantime.Hours() / 24)
+	months := days / 30
+	text := fmt.Sprintf("meantime is %dd (~%d months) based on %d dependencies", days, months, evaluated)
+
+	if len(problems) > 0 && len(problems) <= 3 {
+		text += fmt.Sprintf(" (issues: %d dependencies skipped)", len(problems))
+	} else if len(problems) > 3 {
+		text += fmt.Sprintf(" (issues: %d dependencies skipped)", len(problems))
+	}
+
+	outcome := finding.OutcomeFalse
+	if meantime >= threshold {
+		outcome = finding.OutcomeTrue
+	}
+
+	f, err := finding.NewWith(fs, Probe, text, nil, outcome)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("create finding: %w", err)
+	}
+	return []finding.Finding{*f}, Probe, nil
+}

--- a/probes/MTTUDependenciesIsHigh/impl_test.go
+++ b/probes/MTTUDependenciesIsHigh/impl_test.go
@@ -1,0 +1,87 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package MTTUDependenciesIsHigh
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+var epoch = time.Unix(0, 0).UTC()
+
+func enc(d time.Duration) time.Time { return epoch.Add(d) }
+func boolp(b bool) *bool            { return &b }
+
+//nolint:paralleltest // probe test is independent
+func TestRun_HighTrue_WhenMeanGE6Months(t *testing.T) {
+	// With two deps, to make mean >= 180d, set stale to >= 360d.
+	stale := 360 * 24 * time.Hour
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(true)}, // 0
+				{Name: "b", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(stale)},
+			},
+		},
+	}
+	ff, probe, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if probe != Probe {
+		t.Fatalf("unexpected probe name: %q", probe)
+	}
+	if len(ff) != 1 {
+		t.Fatalf("expected single finding, got %d", len(ff))
+	}
+	if ff[0].Outcome != finding.OutcomeTrue {
+		t.Fatalf("expected OutcomeTrue, got %v", ff[0].Outcome)
+	}
+}
+
+//nolint:paralleltest // probe test is independent
+func TestRun_HighFalse_WhenMeanBelow6Months(t *testing.T) {
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(30 * 24 * time.Hour)},
+				{Name: "b", Version: "1.0.0", IsLatest: boolp(true)},
+			},
+		},
+	}
+	ff, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if ff[0].Outcome != finding.OutcomeFalse {
+		t.Fatalf("expected OutcomeFalse, got %v", ff[0].Outcome)
+	}
+}
+
+//nolint:paralleltest // probe test is independent
+func TestRun_Error_WhenNoUsableData(t *testing.T) {
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: nil,
+		},
+	}
+	_, _, err := Run(raw)
+	if err == nil {
+		t.Fatalf("expected error, got nil")
+	}
+}

--- a/probes/MTTUDependenciesIsLow/def.yml
+++ b/probes/MTTUDependenciesIsLow/def.yml
@@ -1,0 +1,36 @@
+# Copyright 2025 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: MTTUDependenciesIsLow
+lifecycle: experimental
+short: Mean time since the oldest newer dependency release is moderate (3-6 months).
+motivation: >
+  Moderately stale dependencies increase operational and security risk over time. Keeping the mean time
+  within a few months is better than large backlogs, but further improvement reduces exposure
+  to vulnerabilities and incompatibilities.
+implementation: >
+  The probe computes, for each declared dependency, the time elapsed since the oldest release newer than
+  the version used by the project. Dependencies already on the latest version contribute zero. Pseudo-versions
+  (unreleased development versions) are filtered out to ensure fair comparison. It then takes the mean
+  across all dependencies. If the mean is ≥ 90 days (3 months) and < 180 days (6 months), the probe returns
+  OutcomeTrue; otherwise OutcomeFalse.
+outcome:
+  - OutcomeTrue when 90 days ≤ mean time < 180 days (3-6 months).
+  - OutcomeFalse when mean time < 90 days or ≥ 180 days.
+remediation:
+  onOutcome: False
+  effort: Medium
+  text:
+    - Schedule regular dependency updates (e.g., weekly or monthly) and use tools like Dependabot or Renovate to reduce backlog.
+    - Prioritize security-related updates and plan upgrade sprints for major version updates.

--- a/probes/MTTUDependenciesIsLow/impl.go
+++ b/probes/MTTUDependenciesIsLow/impl.go
@@ -1,0 +1,61 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package MTTUDependenciesIsLow
+
+import (
+	"embed"
+	"fmt"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/mttu"
+)
+
+//go:embed *.yml
+var fs embed.FS
+
+// Probe identifies this probe in emitted findings.
+const Probe = "MTTUDependenciesIsLow"
+
+// Run emits OutcomeTrue iff 2 weeks <= mean < 6 months.
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	meantime, evaluated, problems, err := mttu.MeanTimeSinceFirstNewer(raw)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("computing mean MTTU: %w", err)
+	}
+
+	thresholdLow := 14 * 24 * time.Hour
+	thresholdHigh := 180 * 24 * time.Hour
+
+	days := int(meantime.Hours() / 24)
+	months := days / 30
+	text := fmt.Sprintf("meantime is %dd (~%d months) based on %d dependencies", days, months, evaluated)
+
+	if len(problems) > 0 {
+		text += fmt.Sprintf(" (issues: %d dependencies skipped)", len(problems))
+	}
+
+	outcome := finding.OutcomeFalse
+	if meantime >= thresholdLow && meantime < thresholdHigh {
+		outcome = finding.OutcomeTrue
+	}
+
+	f, err := finding.NewWith(fs, Probe, text, nil, outcome)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("create finding: %w", err)
+	}
+	return []finding.Finding{*f}, Probe, nil
+}

--- a/probes/MTTUDependenciesIsLow/impl_test.go
+++ b/probes/MTTUDependenciesIsLow/impl_test.go
@@ -1,0 +1,84 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package MTTUDependenciesIsLow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+var epoch = time.Unix(0, 0).UTC()
+
+func enc(d time.Duration) time.Time { return epoch.Add(d) }
+func boolp(b bool) *bool            { return &b }
+
+//nolint:paralleltest // probe test is independent
+func TestRun_LowTrue_WhenMeanInWindow(t *testing.T) {
+	// mean ~ 30d → in [14d, 180d)
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(30 * 24 * time.Hour)},
+				{Name: "b", Version: "1.0.0", IsLatest: boolp(true)},
+			},
+		},
+	}
+	ff, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if ff[0].Outcome != finding.OutcomeTrue {
+		t.Fatalf("expected OutcomeTrue, got %v", ff[0].Outcome)
+	}
+}
+
+//nolint:paralleltest // probe test is independent
+func TestRun_LowFalse_WhenMeanBelow2Weeks(t *testing.T) {
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(10 * 24 * time.Hour)},
+			},
+		},
+	}
+	ff, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if ff[0].Outcome != finding.OutcomeFalse {
+		t.Fatalf("expected OutcomeFalse, got %v", ff[0].Outcome)
+	}
+}
+
+//nolint:paralleltest // probe test is independent
+func TestRun_LowFalse_WhenMeanGE6Months(t *testing.T) {
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(200 * 24 * time.Hour)},
+			},
+		},
+	}
+	ff, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if ff[0].Outcome != finding.OutcomeFalse {
+		t.Fatalf("expected OutcomeFalse, got %v", ff[0].Outcome)
+	}
+}

--- a/probes/MTTUDependenciesIsVeryLow/def.yml
+++ b/probes/MTTUDependenciesIsVeryLow/def.yml
@@ -1,0 +1,36 @@
+# Copyright 2025 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: MTTUDependenciesIsVeryLow
+lifecycle: experimental
+short: Mean time since the oldest newer dependency release is very low (< 3 months).
+motivation: >
+  Keeping dependencies fresh reduces exposure to known vulnerabilities and supply-chain risk, and
+  makes it easier to adopt security fixes quickly. A very low mean time indicates that the project
+  updates promptly when newer releases are available.
+implementation: >
+  The probe computes, for each declared dependency, the time elapsed since the oldest release newer than
+  the version used by the project. Dependencies already on the latest version contribute zero. Pseudo-versions
+  (unreleased development versions) are filtered out to ensure fair comparison. It then takes the mean
+  across all dependencies. If the mean is less than 90 days (3 months), the probe returns OutcomeTrue;
+  otherwise OutcomeFalse.
+outcome:
+  - OutcomeTrue when the mean time is < 90 days (3 months).
+  - OutcomeFalse when the mean time is >= 90 days.
+remediation:
+  onOutcome: False
+  effort: Medium
+  text:
+    - Enable automated dependency update tools (e.g., Dependabot, Renovate) and triage PRs promptly.
+    - Establish a regular dependency review cadence (e.g., weekly or bi-weekly).

--- a/probes/MTTUDependenciesIsVeryLow/impl.go
+++ b/probes/MTTUDependenciesIsVeryLow/impl.go
@@ -1,0 +1,59 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package MTTUDependenciesIsVeryLow
+
+import (
+	"embed"
+	"fmt"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/mttu"
+)
+
+//go:embed *.yml
+var fs embed.FS
+
+// Probe identifies this probe in emitted findings.
+const Probe = "MTTUDependenciesIsVeryLow"
+
+// Run emits OutcomeTrue iff mean < 2 weeks.
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	meantime, evaluated, problems, err := mttu.MeanTimeSinceFirstNewer(raw)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("computing mean MTTU: %w", err)
+	}
+
+	threshold := 14 * 24 * time.Hour
+
+	days := int(meantime.Hours() / 24)
+	text := fmt.Sprintf("meantime is %dd based on %d dependencies", days, evaluated)
+
+	if len(problems) > 0 {
+		text += fmt.Sprintf(" (issues: %d dependencies skipped)", len(problems))
+	}
+
+	outcome := finding.OutcomeFalse
+	if meantime < threshold {
+		outcome = finding.OutcomeTrue
+	}
+
+	f, err := finding.NewWith(fs, Probe, text, nil, outcome)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("create finding: %w", err)
+	}
+	return []finding.Finding{*f}, Probe, nil
+}

--- a/probes/MTTUDependenciesIsVeryLow/impl_test.go
+++ b/probes/MTTUDependenciesIsVeryLow/impl_test.go
@@ -1,0 +1,65 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package MTTUDependenciesIsVeryLow
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+var epoch = time.Unix(0, 0).UTC()
+
+func enc(d time.Duration) time.Time { return epoch.Add(d) }
+func boolp(b bool) *bool            { return &b }
+
+//nolint:paralleltest // probe test is independent
+func TestRun_VeryLowTrue_WhenMeanBelow2Weeks(t *testing.T) {
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(7 * 24 * time.Hour)},
+				{Name: "b", Version: "1.0.0", IsLatest: boolp(true)}, // 0
+			},
+		},
+	}
+	ff, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if ff[0].Outcome != finding.OutcomeTrue {
+		t.Fatalf("expected OutcomeTrue, got %v", ff[0].Outcome)
+	}
+}
+
+//nolint:paralleltest // probe test is independent
+func TestRun_VeryLowFalse_WhenMeanAtOrAbove2Weeks(t *testing.T) {
+	raw := &checker.RawResults{
+		MTTUDependenciesResults: checker.MTTUDependenciesData{
+			Dependencies: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(14 * 24 * time.Hour)},
+			},
+		},
+	}
+	ff, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run returned error: %v", err)
+	}
+	if ff[0].Outcome != finding.OutcomeFalse {
+		t.Fatalf("expected OutcomeFalse, got %v", ff[0].Outcome)
+	}
+}

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -17,6 +17,9 @@ package probes
 import (
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsHigh"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsLow"
+	"github.com/ossf/scorecard/v5/probes/MTTUDependenciesIsVeryLow"
 	"github.com/ossf/scorecard/v5/probes/archived"
 	"github.com/ossf/scorecard/v5/probes/blocksDeleteOnBranches"
 	"github.com/ossf/scorecard/v5/probes/blocksForcePushOnBranches"
@@ -88,6 +91,11 @@ var (
 	// DependencyUpdateTool check.
 	DependencyToolUpdates = []ProbeImpl{
 		dependencyUpdateToolConfigured.Run,
+	}
+	MTTUDependencies = []ProbeImpl{
+		MTTUDependenciesIsHigh.Run,
+		MTTUDependenciesIsLow.Run,
+		MTTUDependenciesIsVeryLow.Run,
 	}
 	Fuzzing = []ProbeImpl{
 		fuzzed.Run,

--- a/probes/internal/utils/mttu/mean.go
+++ b/probes/internal/utils/mttu/mean.go
@@ -1,0 +1,93 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mttu
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+)
+
+var (
+	epoch                      = time.Unix(0, 0).UTC()
+	ErrNoDependencies          = errors.New("no dependencies provided")
+	ErrNoDependenciesEvaluated = errors.New("no dependencies could be evaluated (all missing usable data)")
+)
+
+// decodeDuration returns the duration represented by t where t == epoch + duration.
+// Negative and zero values are clamped to 0.
+func decodeDuration(t time.Time) time.Duration {
+	if t.IsZero() {
+		return 0
+	}
+	d := t.Sub(epoch)
+	if d < 0 {
+		return 0
+	}
+	return d
+}
+
+// MeanTimeSinceFirstNewer computes the mean of "time since the oldest newer release"
+// across the dependencies contained in raw.MTTUDependenciesResults.Dependencies,
+// treating dependencies already on the latest release as contributing 0.
+//
+// Returns:
+//   - mean:      the average duration
+//   - evaluated: number of dependencies that contributed to the mean
+//   - problems:  any human-readable issues (e.g., missing data)
+//   - err:       if no dependencies could be evaluated
+func MeanTimeSinceFirstNewer(
+	raw *checker.RawResults,
+) (mean time.Duration, evaluated int, problems []string, err error) {
+	deps := raw.MTTUDependenciesResults.Dependencies
+	if len(deps) == 0 {
+		return 0, 0, nil, ErrNoDependencies
+	}
+
+	var total time.Duration
+	var count int
+
+	for _, dep := range deps {
+		switch {
+		case dep.IsLatest != nil && *dep.IsLatest:
+			// Latest → contributes 0 duration.
+			count++
+		default:
+			// Not latest (or unknown). Use encoded duration if present.
+			d := decodeDuration(dep.TimeSinceOldestReleast)
+			if d == 0 && (dep.IsLatest == nil || (dep.IsLatest != nil && !*dep.IsLatest)) {
+				state := "unknown"
+				if dep.IsLatest != nil && !*dep.IsLatest {
+					state = "not latest"
+				}
+				problems = append(problems,
+					fmt.Sprintf("%s@%s (%s): missing or zero time_since_oldest_releast",
+						dep.Name, dep.Version, state))
+				continue
+			}
+			total += d
+			count++
+		}
+	}
+
+	if count == 0 {
+		return 0, 0, problems, ErrNoDependenciesEvaluated
+	}
+
+	mean = time.Duration(int64(total) / int64(count))
+	return mean, count, problems, nil
+}

--- a/probes/internal/utils/mttu/mean_test.go
+++ b/probes/internal/utils/mttu/mean_test.go
@@ -1,0 +1,113 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mttu
+
+import (
+	"testing"
+	"time"
+
+	"github.com/ossf/scorecard/v5/checker"
+)
+
+// Convenience: encode a duration using epoch+duration.
+func enc(d time.Duration) time.Time { return epoch.Add(d) }
+
+//nolint:paralleltest // utility test is independent
+func Test_decodeDuration(t *testing.T) {
+	t.Run("zero", func(t *testing.T) {
+		if got := decodeDuration(time.Time{}); got != 0 {
+			t.Fatalf("want 0, got %v", got)
+		}
+	})
+	t.Run("negative-clamped", func(t *testing.T) {
+		neg := epoch.Add(-time.Hour)
+		if got := decodeDuration(neg); got != 0 {
+			t.Fatalf("want 0, got %v", got)
+		}
+	})
+	t.Run("positive", func(t *testing.T) {
+		one := enc(time.Hour)
+		if got := decodeDuration(one); got != time.Hour {
+			t.Fatalf("want 1h, got %v", got)
+		}
+	})
+}
+
+//nolint:paralleltest // utility test is independent
+func TestMeanTimeSinceFirstNewer(t *testing.T) {
+	boolp := func(b bool) *bool { return &b }
+
+	tests := []struct {
+		name string
+		deps []checker.LockDependency
+		want time.Duration
+		err  bool
+	}{
+		{
+			name: "all-latest-contribute-zero",
+			deps: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(true)},
+				{Name: "b", Version: "2.0.0", IsLatest: boolp(true)},
+			},
+			want: 0,
+		},
+		{
+			name: "mix-latest-and-stale",
+			deps: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(true)}, // 0
+				{Name: "b", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(7 * 24 * time.Hour)},
+			},
+			want: (0 + 7*24*time.Hour) / 2,
+		},
+		{
+			name: "missing-duration-for-stale-dep-is-ignored",
+			deps: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: boolp(false)}, // no encoded time → skipped
+				{Name: "b", Version: "1.0.0", IsLatest: boolp(false), TimeSinceOldestReleast: enc(48 * time.Hour)},
+			},
+			want: 48 * time.Hour,
+		},
+		{
+			name: "no-usable-data",
+			deps: []checker.LockDependency{
+				{Name: "a", Version: "1.0.0", IsLatest: nil, TimeSinceOldestReleast: time.Time{}},
+			},
+			err: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			raw := &checker.RawResults{
+				MTTUDependenciesResults: checker.MTTUDependenciesData{
+					Dependencies: tc.deps,
+				},
+			}
+			got, _, _, err := MeanTimeSinceFirstNewer(raw)
+			if tc.err {
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("mean mismatch: want %v, got %v", tc.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

New check

This PR adds a new check with 3 underlying probes to scorecard. The check is an implementation of https://github.com/ossf/scorecard/issues/2458. In essence, the check works like this:

1. First, it collects a list of all the project's direct dependencies at the time of checking.
2. Then, it calls deps.dev for a list of releases of each dependency.
3. Then, the check assesses whether each dependency is the latest available version according to deps.dev.
4. With the dependencies that are not the latest available version, the check assesses how much time has passed between the release date of the version that the project uses and the release date of the version right after the project uses. For example, if a project uses 1.2.3, and 1.2.4 was available 100 days ago, the check will record 100 days, even though 1.2.5 is the newest available. This is a design part on my end.
5. Finally, the check creates an average of the dependencies that are not the latest available version and scores accordingly. 

As such, the check considers the negative findings in a project - the dependencies that have not been updated to its latest version - and the check can be considered one that reports how old a project's dependencies are rather than providing a full picture of how quickly a project updates its dependencies. 

A few notes on implementation details:

1. The check relies heavily on osv-scalibr and the deps.dev API which means that any shortcomings in these two libraries will have direct impact on the check. The most significant shortcoming I have found is that the check doesn't always process all dependencies that it finds in a dependency manifest. I haven't debugged this extensively. At the same time, osv-scalibr and deps.dev seem like great sources for this check, and a few edge cases shouldn't in my opinion prevent us from using them. Even if the check doesn't process all dependencies, it is still useful by assessing the majority of a projects dependencies. Initially, I was working with distinct parsers for different lock file types, but this is in my opinion not the way to go. osv-scalibr provides a lot of value out of the box, and given that it is a fairly new library, I think it is fair to expect that it will continue its development.
2. The check only considers direct dependencies. This is a design decision as I don't see a point in evaluating transitive dependencies; The goal of the check is to determine a project's maintenance practices - not to find old dependencies. As such, I have made the decision to give maintainers as much control I could over their score; by only considering direct dependencies, maintainers can simply update their dependencies. If we were to consider transitive dependencies too, maintainers are at the mercy of their direct dependencies to keep _their_ dependencies up to date.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes https://github.com/ossf/scorecard/issues/2458

#### Special notes for your reviewer

I would recommend reading the documentation in the `.yml and .yaml` files in this PR and testing the check with `go run main.go --repo=github.com/owner/repo --checks=MTTUDependencies` before reviewing the code.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
