### PR TITLE
:seedling: Set OSV User-Agent for scorecard cli and cron workers.

### DIFF
--- a/clients/vulnerabilities.go
+++ b/clients/vulnerabilities.go
@@ -29,7 +29,7 @@ type VulnerabilitiesClient interface {
 
 // DefaultVulnerabilitiesClient returns a new OSV Vulnerabilities client.
 func DefaultVulnerabilitiesClient() VulnerabilitiesClient {
-	return osvClient{local: false}
+	return NewOSVClient(nil)
 }
 
 // ExperimentalLocalOSVClient returns an OSV Vulnerabilities client which

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/google/osv-scanner/v2/pkg/osvscanner"
 	"github.com/spf13/cobra"
 	"sigs.k8s.io/release-utils/version"
 
@@ -170,12 +171,19 @@ func rootCmd(o *options.Options) error {
 
 	enabledProbes := o.Probes()
 
+	info := version.GetVersionInfo()
+	actions := osvscanner.ExperimentalScannerActions{}
+	config := clients.OSVConfig{}
+	actions.RequestUserAgent = fmt.Sprintf("scorecard-cli/%s", info.GitVersion)
+	config.UserAgent = actions.RequestUserAgent
+
 	opts := []scorecard.Option{
 		scorecard.WithLogLevel(sclog.ParseLevel(o.LogLevel)),
 		scorecard.WithCommitSHA(o.Commit),
 		scorecard.WithCommitDepth(o.CommitDepth),
 		scorecard.WithProbes(enabledProbes),
 		scorecard.WithChecks(checks),
+		scorecard.WithVulnerabilitiesClient(clients.NewOSVClient(&config)),
 	}
 	if strings.EqualFold(o.FileMode, options.FileModeGit) {
 		opts = append(opts, scorecard.WithFileModeGit())

--- a/go.mod
+++ b/go.mod
@@ -40,7 +40,7 @@ require (
 require (
 	github.com/caarlos0/env/v6 v6.10.1
 	github.com/gobwas/glob v0.2.3
-	github.com/google/go-github/v53 v53.2.0
+	github.com/google/go-github/v82 v82.0.0
 	github.com/google/osv-scanner/v2 v2.3.2
 	github.com/hmarr/codeowners v1.2.1
 	github.com/in-toto/attestation v1.1.2

--- a/main.go
+++ b/main.go
@@ -16,20 +16,13 @@
 package main
 
 import (
-	"fmt"
 	"log"
-
-	"github.com/google/osv-scanner/v2/pkg/osvscanner"
-	"sigs.k8s.io/release-utils/version"
 
 	"github.com/ossf/scorecard/v5/cmd"
 	"github.com/ossf/scorecard/v5/options"
 )
 
 func main() {
-	info := version.GetVersionInfo()
-	actions := osvscanner.ExperimentalScannerActions{}
-	actions.RequestUserAgent = fmt.Sprintf("scorecard-cli/%s", info.GitVersion)
 	opts := options.New()
 	if err := cmd.New(opts).Execute(); err != nil {
 		log.Fatalf("error during command execution: %v", err)


### PR DESCRIPTION
#### What kind of change does this PR introduce?
This PR introduces improvement to OSV API request by configuring versioned User-Agent for Scorecard.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Currently API requests to `osv.dev` are made without specifying a unique user-agent.

#### What is the new behavior (if this is a feature change)?**
Now a distinct, versioned user agent is set for the OSV API request:
- `scorecard/{version}` for CLI
- `scorecard-cron/{version}` for cron workers
- Uses `GetId()` and `GetAliases()` in `clients/osv.go` as per the latest updates in the osv scanner package.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
Fixes #4029 
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer
`osv-scanner/1.9.2` has been installed.

#### Does this PR introduce a user-facing change?
No

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->
