### PR TITLE
:book: Clarify references to the Scorecard webviewer

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ metrics. Prominent projects that use Scorecard include:
 
 ### View a Project's Score
 
-To see scores for projects regularly scanned by Scorecard, navigate to the [webviewer](The web UI available at https://scorecard.dev/viewer/ and allows viewing Scorecard results for public repositories)(https://scorecard.dev/viewer/?uri=). You can also replace the placeholder text (platform, user/org, and repository name) in the following template URL Template to generate a custom Scorecard link for a repo:
+To see scores for projects regularly scanned by Scorecard, navigate to the [webviewer](The web UI available at https://scorecard.dev/viewer/ and allows viewing Scorecard results for public repositories)(https://scorecard.dev/viewer/). You can also replace the placeholder text (platform, user/org, and repository name) in the following template URL Template to generate a custom Scorecard link for a repo:
 `https://scorecard.dev/viewer/?uri=<github_or_gitlab>.com/<user_name_or_org>/<repository_name>`
 
 For example:

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ This page answers frequently asked questions about Scorecard, including its purp
 
 Yes.
 
-Over a million projects are automatically tracked by the Scorecard project. Use the [webviewer](The Web UI available at https://scorecard.dev/viewer/ and allows viewing Scorecard results for public repositories) to see these scores, replacing the placeholder text with the platform, user/org, and repository name: https://scorecard.dev/viewer/?uri=<github_or_gitlab>.com/<user_name_or_org>/<repository_name>.
+Over a million projects are automatically tracked by the Scorecard project. Use the [webviewer](The Web UI available at https://scorecard.dev/viewer/ and allows viewing Scorecard results for public repositories) to see these scores, replacing the placeholder text with the platform, user/org, and repository name: https://scorecard.dev/viewer/<github_or_gitlab>.com/<user_name_or_org>/<repository_name>.
 
 For example: 
  - [https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard](https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This PR introduces a documentation update to clarify what the “Scorecard webviewer” refers to and how it should be used.

- [x] PR title follows the guidelines defined in our pull request documentation

#### What is the current behavior?

The documentation refers to a “webviewer” without clearly explaining what it is, where it is hosted, or how users should interpret the term.

#### What is the new behavior (if this is a feature change)?

The documentation now explicitly explains that the Scorecard webviewer is the web UI available at https://scorecard.dev/viewer/ and clarifies how the URL template should be used.

- [ ] Tests for the changes have been added (not applicable for documentation-only changes)

#### Which issue(s) this PR fixes

Fixes #3986

#### Special notes for your reviewer

This change is documentation-only and does not affect Scorecard behavior or outputs.

#### Does this PR introduce a user-facing change?

```release-note
Clarified documentation describing the Scorecard webviewer and its URL template.
