### PR TITLE
:sparkles: Specific error message for branch protection permission failure.

### DIFF
--- a/clients/githubrepo/branches.go
+++ b/clients/githubrepo/branches.go
@@ -311,6 +311,9 @@ func (handler *branchesHandler) query(branchName string) (*clients.BranchRef, er
 	// Ignore permissions errors if we know the repository is using rulesets, so non-admins can still get a score.
 	queryData := new(branchData)
 	if err := handler.graphClient.Query(handler.ctx, queryData, vars); err != nil {
+		if strings.Contains(err.Error(), "resource not accessible by integration") {
+			return nil, sce.WithMessage(sce.ErrScorecardInternal, "Branch protection failed.Default token insufficient.Use PAT.")
+		}
 		// always report errors which aren't token permission related
 		if !isPermissionsError(err) {
 			return nil, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("githubv4.Query: %v", err))


### PR DESCRIPTION
#### What kind of change does this PR introduce?
This PR introduces a code change to provide specific error message when branch protection rule fails due to the use of `default GITHUB_TOKEN` which doesn't have permission to view branch protection rules.

(Is it a bug fix, feature, docs update, something else?)
feature
- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
When the CI fails because of branch protection rules, it shows generic error message which doesn't give the users an idea of what the actual underlying issue is.

#### What is the new behavior (if this is a feature change)?**
When error is shown, string matching is done based on which it shows error message specific to the failure of branch protection CI test.
- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->
Fixes #2946 
#### Special notes for your reviewer
Here `strings.Contains()` is case-sensitive so need to adjust the substring or the error message string accordingly.
#### Does this PR introduce a user-facing change?
Yes

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
No change needs to be done from the user side. Users will now see a clear message when instead of generic internal error message when the branch protection check fails due to GITHUB_TOKEN persmission limitations.
```
