### PR TITLE
🌱 Add support for prow for CI and SAST checks

### DIFF
--- a/checks/code_review_test.go
+++ b/checks/code_review_test.go
@@ -122,6 +122,55 @@ func TestCodereview(t *testing.T) {
 			},
 		},
 		{
+			name: "Prow PR with both lgtm and approved labels - 2 approvals",
+			commits: []clients.Commit{
+				{
+					SHA: "sha",
+					Committer: clients.User{
+						Login: "alice",
+					},
+					AssociatedMergeRequest: clients.PullRequest{
+						Number:   1,
+						MergedAt: time.Now(),
+						Labels: []clients.Label{
+							{
+								Name: "lgtm",
+							},
+							{
+								Name: "approved",
+							},
+						},
+					},
+				},
+			},
+			expected: scut.TestReturn{
+				Score: 10,
+			},
+		},
+		{
+			name: "Prow PR with only approved label",
+			commits: []clients.Commit{
+				{
+					SHA: "sha",
+					Committer: clients.User{
+						Login: "bob",
+					},
+					AssociatedMergeRequest: clients.PullRequest{
+						Number:   1,
+						MergedAt: time.Now(),
+						Labels: []clients.Label{
+							{
+								Name: "approved",
+							},
+						},
+					},
+				},
+			},
+			expected: scut.TestReturn{
+				Score: 10,
+			},
+		},
+		{
 			name: "Valid PR's and commits with merged by someone else",
 			commits: []clients.Commit{
 				{

--- a/checks/raw/prow_config.go
+++ b/checks/raw/prow_config.go
@@ -1,0 +1,183 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/checks/fileparser"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+var errProwInvalidArgs = errors.New("invalid arguments")
+
+// ProwConfig represents a Prow configuration file.
+type ProwConfig struct {
+	Presubmits  map[string][]ProwJob `yaml:"presubmits"`
+	Postsubmits map[string][]ProwJob `yaml:"postsubmits"`
+	Periodics   []ProwJob            `yaml:"periodics"`
+}
+
+// ProwJob represents a single Prow job definition.
+type ProwJob struct {
+	Name    string   `yaml:"name"`
+	Command []string `yaml:"command"`
+	Args    []string `yaml:"args"`
+}
+
+// CommandContainsSASTTool checks if a command/args contains SAST tool indicators.
+// Uses the same pattern list as checkRun/status detection for consistency.
+func CommandContainsSASTTool(command []string) bool {
+	commandStr := strings.ToLower(strings.Join(command, " "))
+	// Reuse sastToolPatterns from sast.go for consistency
+	for _, pattern := range sastToolPatterns {
+		if strings.Contains(commandStr, pattern) {
+			return true
+		}
+	}
+	// Also check for generic "lint" which is common in commands
+	if strings.Contains(commandStr, "lint") {
+		return true
+	}
+	return false
+}
+
+// logDebugProwf logs debug messages for Prow detection.
+func logDebugProwf(c *checker.CheckRequest, format string, args ...interface{}) {
+	if c.Dlogger != nil {
+		c.Dlogger.Debug(&checker.LogMessage{
+			Text: fmt.Sprintf("[Prow] "+format, args...),
+		})
+	}
+}
+
+// getProwSASTJobs scans local Prow config files for SAST tools.
+// This mirrors the GitHub workflow scanning approach.
+func getProwSASTJobs(c *checker.CheckRequest) ([]checker.SASTWorkflow, error) {
+	var configPaths []string
+	var sastWorkflows []checker.SASTWorkflow
+
+	logDebugProwf(c, "Scanning for Prow configuration files...")
+
+	// Scan common Prow config file patterns
+	patterns := []string{".prow.yaml", ".prow/*.yaml", "prow/*.yaml"}
+
+	for _, pattern := range patterns {
+		logDebugProwf(c, "Scanning pattern: %s", pattern)
+		err := fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
+			Pattern:       pattern,
+			CaseSensitive: false,
+		}, searchProwConfigForSAST, &configPaths)
+		if err != nil {
+			return sastWorkflows, err
+		}
+	}
+
+	if len(configPaths) > 0 {
+		logDebugProwf(c, "Found %d Prow config file(s) with SAST tools:", len(configPaths))
+		for _, path := range configPaths {
+			logDebugProwf(c, "  ✓ %s", path)
+		}
+	} else {
+		logDebugProwf(c, "No Prow config files with SAST tools found")
+	}
+
+	// Convert paths to SASTWorkflow objects
+	for _, path := range configPaths {
+		sastWorkflow := checker.SASTWorkflow{
+			File: checker.File{
+				Path:   path,
+				Offset: checker.OffsetDefault,
+				Type:   finding.FileTypeSource,
+			},
+			Type: "Prow",
+		}
+		sastWorkflows = append(sastWorkflows, sastWorkflow)
+	}
+
+	return sastWorkflows, nil
+}
+
+// searchProwConfigForSAST searches a Prow config file for SAST tools.
+var searchProwConfigForSAST fileparser.DoWhileTrueOnFileContent = func(path string,
+	content []byte,
+	args ...interface{},
+) (bool, error) {
+	if len(args) != 1 {
+		return false, fmt.Errorf("searchProwConfigForSAST requires exactly 1 argument: %w", errProwInvalidArgs)
+	}
+
+	paths, ok := args[0].(*[]string)
+	if !ok {
+		return false, fmt.Errorf("searchProwConfigForSAST expects arg[0] of type *[]string: %w", errProwInvalidArgs)
+	}
+
+	var config ProwConfig
+	if err := yaml.Unmarshal(content, &config); err != nil {
+		// Skip files that aren't valid Prow configs
+		return true, nil
+	}
+
+	// Check all job types for SAST tools
+	hasSAST := false
+
+	// Check presubmits
+	for _, jobs := range config.Presubmits {
+		for _, job := range jobs {
+			if jobContainsSAST(job) {
+				hasSAST = true
+				break
+			}
+		}
+	}
+
+	// Check postsubmits
+	if !hasSAST {
+		for _, jobs := range config.Postsubmits {
+			for _, job := range jobs {
+				if jobContainsSAST(job) {
+					hasSAST = true
+					break
+				}
+			}
+		}
+	}
+
+	// Check periodics
+	if !hasSAST {
+		for _, job := range config.Periodics {
+			if jobContainsSAST(job) {
+				hasSAST = true
+				break
+			}
+		}
+	}
+
+	if hasSAST {
+		*paths = append(*paths, path)
+	}
+
+	return true, nil
+}
+
+// jobContainsSAST checks if a Prow job contains SAST tools.
+func jobContainsSAST(job ProwJob) bool {
+	return CommandContainsSASTTool(job.Command) || CommandContainsSASTTool(job.Args)
+}

--- a/checks/raw/prow_config_test.go
+++ b/checks/raw/prow_config_test.go
@@ -1,0 +1,192 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func TestCommandContainsSASTTool(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		command  []string
+		expected bool
+	}{
+		{
+			name:     "golangci-lint command",
+			command:  []string{"golangci-lint", "run"},
+			expected: true,
+		},
+		{
+			name:     "codeql command",
+			command:  []string{"codeql", "database", "analyze"},
+			expected: true,
+		},
+		{
+			name:     "trivy security scan",
+			command:  []string{"trivy", "fs", "--security-checks", "vuln", "."},
+			expected: true,
+		},
+		{
+			name:     "regular build command",
+			command:  []string{"make", "build"},
+			expected: false,
+		},
+		{
+			name:     "test command",
+			command:  []string{"go", "test", "./..."},
+			expected: false,
+		},
+		{
+			name:     "shellcheck",
+			command:  []string{"shellcheck", "scripts/*.sh"},
+			expected: true,
+		},
+		{
+			name:     "gosec",
+			command:  []string{"gosec", "./..."},
+			expected: true,
+		},
+		{
+			name:     "empty command",
+			command:  []string{},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := CommandContainsSASTTool(tt.command)
+			if result != tt.expected {
+				t.Errorf("CommandContainsSASTTool(%v) = %v, want %v", tt.command, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestJobContainsSAST(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		job      ProwJob
+		expected bool
+	}{
+		{
+			name: "job with SAST in command",
+			job: ProwJob{
+				Name:    "lint",
+				Command: []string{"golangci-lint", "run"},
+				Args:    []string{},
+			},
+			expected: true,
+		},
+		{
+			name: "job with SAST in args",
+			job: ProwJob{
+				Name:    "security-scan",
+				Command: []string{"sh", "-c"},
+				Args:    []string{"trivy fs ."},
+			},
+			expected: true,
+		},
+		{
+			name: "job without SAST",
+			job: ProwJob{
+				Name:    "build",
+				Command: []string{"make", "build"},
+				Args:    []string{},
+			},
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			result := jobContainsSAST(tt.job)
+			if result != tt.expected {
+				t.Errorf("jobContainsSAST(%v) = %v, want %v", tt.job, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestProwConfigParsing(t *testing.T) {
+	t.Parallel()
+
+	yamlContent := `
+presubmits:
+  org/repo:
+    - name: pull-lint
+      command:
+        - golangci-lint
+        - run
+    - name: pull-test
+      command:
+        - make
+        - test
+
+postsubmits:
+  org/repo:
+    - name: post-scan
+      command:
+        - trivy
+        - fs
+        - .
+
+periodics:
+  - name: nightly-check
+    command:
+      - codeql
+      - analyze
+`
+
+	var config ProwConfig
+	if err := yaml.Unmarshal([]byte(yamlContent), &config); err != nil {
+		t.Fatalf("Failed to parse YAML: %v", err)
+	}
+
+	// Check presubmits
+	if len(config.Presubmits["org/repo"]) != 2 {
+		t.Errorf("Expected 2 presubmits, got %d", len(config.Presubmits["org/repo"]))
+	}
+
+	// Check postsubmits
+	if len(config.Postsubmits["org/repo"]) != 1 {
+		t.Errorf("Expected 1 postsubmit, got %d", len(config.Postsubmits["org/repo"]))
+	}
+
+	// Check periodics
+	if len(config.Periodics) != 1 {
+		t.Errorf("Expected 1 periodic, got %d", len(config.Periodics))
+	}
+
+	// Check if SAST tools are detected
+	lintJob := config.Presubmits["org/repo"][0]
+	if !jobContainsSAST(lintJob) {
+		t.Error("Expected lint job to contain SAST tool")
+	}
+
+	testJob := config.Presubmits["org/repo"][1]
+	if jobContainsSAST(testJob) {
+		t.Error("Expected test job to NOT contain SAST tool")
+	}
+}

--- a/checks/raw/sast_statuses_test.go
+++ b/checks/raw/sast_statuses_test.go
@@ -1,0 +1,79 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"testing"
+	"time"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
+)
+
+func TestSASTWithStatuses(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+
+	mergedAt := time.Now().Add(time.Hour * time.Duration(-1))
+
+	// Prow job with govulncheck in status context name
+	mockRepoClient.EXPECT().ListCommits().Return([]clients.Commit{
+		{
+			AssociatedMergeRequest: clients.PullRequest{
+				Number:   1,
+				HeadSHA:  "sha1",
+				MergedAt: mergedAt,
+			},
+		},
+	}, nil)
+
+	// No CheckRuns
+	mockRepoClient.EXPECT().ListCheckRunsForRef("sha1").Return([]clients.CheckRun{}, nil)
+
+	// But has Statuses with govulncheck
+	mockRepoClient.EXPECT().ListStatuses("sha1").Return([]clients.Status{
+		{
+			State:   "success",
+			Context: "govulncheck_myproject",
+			URL:     "https://prow.example.com/view/govulncheck",
+		},
+	}, nil)
+
+	// No workflow files
+	mockRepoClient.EXPECT().ListFiles(gomock.Any()).Return([]string{}, nil).AnyTimes()
+
+	req := &checker.CheckRequest{
+		RepoClient: mockRepoClient,
+	}
+
+	result, err := SAST(req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.Commits) != 1 {
+		t.Errorf("expected 1 commit, got %d", len(result.Commits))
+	}
+
+	if !result.Commits[0].Compliant {
+		t.Error("expected commit to be compliant (SAST tool detected in status)")
+	}
+}

--- a/checks/raw/sast_test.go
+++ b/checks/raw/sast_test.go
@@ -249,6 +249,132 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
+			name: "Prow job with CodeQL in name - detected via pattern",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number:   1,
+						MergedAt: mergedOneHourAgo,
+					},
+				},
+			},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "pull-ci-org-repo-master-codeql",
+					},
+					URL: "https://prow.k8s.io/view/gs/kubernetes-jenkins/pr-logs/pull/12345",
+				},
+			},
+			expected: checker.SASTData{
+				Commits: []checker.SASTCommit{
+					{
+						AssociatedMergeRequest: clients.PullRequest{
+							Number:   1,
+							MergedAt: mergedOneHourAgo,
+						},
+						Compliant: true,
+					},
+				},
+			},
+		},
+		{
+			name: "Prow job with Sonar in URL - detected via pattern",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number:   1,
+						MergedAt: mergedOneHourAgo,
+					},
+				},
+			},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "prow-job",
+					},
+					URL: "https://prow.example.com/sonarqube-scan/results",
+				},
+			},
+			expected: checker.SASTData{
+				Commits: []checker.SASTCommit{
+					{
+						AssociatedMergeRequest: clients.PullRequest{
+							Number:   1,
+							MergedAt: mergedOneHourAgo,
+						},
+						Compliant: true,
+					},
+				},
+			},
+		},
+		{
+			name: "Jenkins job with Snyk in name - detected via pattern",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number:   1,
+						MergedAt: mergedOneHourAgo,
+					},
+				},
+			},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "jenkins-snyk-security-scan",
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Commits: []checker.SASTCommit{
+					{
+						AssociatedMergeRequest: clients.PullRequest{
+							Number:   1,
+							MergedAt: mergedOneHourAgo,
+						},
+						Compliant: true,
+					},
+				},
+			},
+		},
+		{
+			name: "Multiple SAST tools - Semgrep in CheckRun name",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number:   1,
+						MergedAt: mergedOneHourAgo,
+					},
+				},
+			},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "semgrep-ci-check",
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Commits: []checker.SASTCommit{
+					{
+						AssociatedMergeRequest: clients.PullRequest{
+							Number:   1,
+							MergedAt: mergedOneHourAgo,
+						},
+						Compliant: true,
+					},
+				},
+			},
+		},
+		{
 			name:  "Has Hadolint",
 			files: []string{".github/workflows/github-hadolint-workflow.yaml"},
 			commits: []clients.Commit{

--- a/checks/raw/testdata/.prow-no-sast.yaml
+++ b/checks/raw/testdata/.prow-no-sast.yaml
@@ -1,0 +1,17 @@
+presubmits:
+  org/repo:
+    - name: pull-build
+      decorate: true
+      always_run: true
+      command:
+        - make
+        - build
+      args:
+        - -j4
+
+    - name: pull-unit-test
+      decorate: true
+      command:
+        - go
+        - test
+        - ./...

--- a/checks/raw/testdata/.prow.yaml
+++ b/checks/raw/testdata/.prow.yaml
@@ -1,0 +1,36 @@
+presubmits:
+  org/repo:
+    - name: pull-lint
+      decorate: true
+      always_run: true
+      command:
+        - golangci-lint
+        - run
+      args:
+        - --timeout=5m
+
+    - name: pull-test
+      decorate: true
+      command:
+        - make
+        - test
+
+postsubmits:
+  org/repo:
+    - name: post-security-scan
+      decorate: true
+      command:
+        - trivy
+        - fs
+        - --security-checks
+        - vuln
+        - .
+
+periodics:
+  - name: nightly-codeql
+    interval: 24h
+    decorate: true
+    command:
+      - codeql
+      - database
+      - analyze

--- a/checks/sast_test.go
+++ b/checks/sast_test.go
@@ -50,8 +50,9 @@ func Test_SAST(t *testing.T) {
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
 			expected: scut.TestReturn{
-				Score:        checker.MinResultScore,
-				NumberOfWarn: 1,
+				Score:         checker.MinResultScore,
+				NumberOfWarn:  1,
+				NumberOfDebug: 8,
 			},
 		},
 		{
@@ -61,8 +62,9 @@ func Test_SAST(t *testing.T) {
 			searchresult: clients.SearchResponse{},
 			checkRuns:    []clients.CheckRun{},
 			expected: scut.TestReturn{
-				Score: checker.InconclusiveResultScore,
-				Error: sce.ErrScorecardInternal,
+				Score:         checker.InconclusiveResultScore,
+				Error:         sce.ErrScorecardInternal,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -87,7 +89,7 @@ func Test_SAST(t *testing.T) {
 			expected: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
-				NumberOfDebug: 1,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -112,7 +114,7 @@ func Test_SAST(t *testing.T) {
 			expected: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
-				NumberOfDebug: 1,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -138,7 +140,7 @@ func Test_SAST(t *testing.T) {
 			expected: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
-				NumberOfDebug: 1,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -163,7 +165,7 @@ func Test_SAST(t *testing.T) {
 			expected: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
-				NumberOfDebug: 1,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -179,9 +181,10 @@ func Test_SAST(t *testing.T) {
 			searchresult: clients.SearchResponse{},
 			path:         ".github/workflows/airflow-codeql-workflow.yaml",
 			expected: scut.TestReturn{
-				Score:        7,
-				NumberOfWarn: 1,
-				NumberOfInfo: 1,
+				Score:         7,
+				NumberOfWarn:  1,
+				NumberOfInfo:  1,
+				NumberOfDebug: 8,
 			},
 		},
 		{
@@ -215,7 +218,7 @@ func Test_SAST(t *testing.T) {
 			expected: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  2,
-				NumberOfDebug: 1,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -250,7 +253,7 @@ func Test_SAST(t *testing.T) {
 			expected: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  2,
-				NumberOfDebug: 1,
+				NumberOfDebug: 9,
 			},
 		},
 		{
@@ -288,9 +291,10 @@ func Test_SAST(t *testing.T) {
 			},
 			path: ".github/workflows/airflow-codeql-workflow.yaml",
 			expected: scut.TestReturn{
-				Score:        7,
-				NumberOfWarn: 1,
-				NumberOfInfo: 1,
+				Score:         7,
+				NumberOfWarn:  1,
+				NumberOfInfo:  1,
+				NumberOfDebug: 8,
 			},
 		},
 		{
@@ -312,9 +316,10 @@ func Test_SAST(t *testing.T) {
 			searchresult: clients.SearchResponse{},
 			path:         ".github/workflows/github-hadolint-workflow.yaml",
 			expected: scut.TestReturn{
-				Score:        checker.MaxResultScore,
-				NumberOfWarn: 1,
-				NumberOfInfo: 1,
+				Score:         checker.MaxResultScore,
+				NumberOfWarn:  1,
+				NumberOfInfo:  1,
+				NumberOfDebug: 8,
 			},
 		},
 	}
@@ -334,6 +339,7 @@ func Test_SAST(t *testing.T) {
 				return tt.commits, tt.err
 			})
 			mockRepoClient.EXPECT().ListCheckRunsForRef("").Return(tt.checkRuns, nil).AnyTimes()
+			mockRepoClient.EXPECT().ListStatuses("").Return([]clients.Status{}, nil).AnyTimes()
 			mockRepoClient.EXPECT().Search(searchRequest).Return(tt.searchresult, nil).AnyTimes()
 			mockRepoClient.EXPECT().ListFiles(gomock.Any()).DoAndReturn(
 				func(predicate func(string) (bool, error)) ([]string, error) {

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -531,20 +531,20 @@ codebase.
 
 The check uses multiple detection methods:
 
-1. **GitHub Apps and Actions**: Looks for known GitHub apps such as
+1.GitHub Apps and Actions: Looks for known GitHub apps such as
    [CodeQL](https://codeql.github.com/) (github-code-scanning) or
    [SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
    of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
    [LGTM](https://lgtm.com/) service until its forthcoming shutdown.
 
-2. **Prow CI Integration**: For projects using [Prow](https://docs.prow.k8s.io/),
+2. Prow CI Integration: For projects using [Prow](https://docs.prow.k8s.io/),
    the check provides comprehensive SAST detection through:
-   - **Pattern matching**: Detects 30+ SAST tools (gosec, golangci-lint, semgrep, etc.) in commit status names
-   - **Config file scanning**: Analyzes `.prow.yaml` and `prow/*.yaml` files for SAST tool commands
-   - **Log analysis**: Fetches and scans Prow job logs using execution signatures to verify actual tool runs
-   - **Parallel processing**: Uses concurrent log fetching for improved performance on large projects
+   - Pattern matching: Detects 30+ SAST tools (gosec, golangci-lint, semgrep, etc.) in commit status names
+   - Config file scanning: Analyzes `.prow.yaml` and `prow/*.yaml` files for SAST tool commands
+   - Log analysis: Fetches and scans Prow job logs using execution signatures to verify actual tool runs
+   - Parallel processing: Uses concurrent log fetching for improved performance on large projects
 
-3. **Check Runs and Statuses**: Analyzes GitHub check runs and commit statuses to detect
+3. Check Runs and Statuses: Analyzes GitHub check runs and commit statuses to detect
    SAST tool execution across various CI systems including Prow, Jenkins, and others.
 
 Note: A project that fulfills this criterion with other tools may still receive

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -529,11 +529,25 @@ SAST is testing run on source code before the application is run. Using SAST
 tools can prevent known classes of bugs from being inadvertently introduced in the
 codebase.
 
-The checks currently looks for known GitHub apps such as
-[CodeQL](https://codeql.github.com/) (github-code-scanning) or
-[SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
-of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
-[LGTM](https://lgtm.com/) service until its forthcoming shutdown.
+The check uses multiple detection methods:
+
+1. **GitHub Workflows**: Scans `.github/workflows/` directory for workflow files
+   that use known SAST tools such as [CodeQL](https://codeql.github.com/) 
+   (`github/codeql-action/analyze`), [SonarCloud](https://sonarcloud.io/),
+   [Snyk](https://snyk.io/), and others.
+
+2. **GitHub Apps**: Checks for GitHub apps like github-code-scanning running on
+   recent (~30) merged PRs. Also checks for the deprecated [LGTM](https://lgtm.com/)
+   service.
+
+3. **Prow Configuration Files**: For projects using [Prow](https://docs.prow.k8s.io/),
+   scans `.prow.yaml` and `.prow/*.yaml` files for job definitions that contain
+   SAST tools (e.g., `golangci-lint`, `staticcheck`, `semgrep`, `trivy`, etc.)
+   in their commands.
+
+4. **CI Status Checks**: Analyzes commit status checks from any CI system (including
+   Prow, Jenkins, etc.) by pattern matching against known SAST tool names in status
+   contexts and URLs.
 
 Note: A project that fulfills this criterion with other tools may still receive
 a low score on this test. There are many ways to implement SAST, and it is

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -531,23 +531,21 @@ codebase.
 
 The check uses multiple detection methods:
 
-1. **GitHub Workflows**: Scans `.github/workflows/` directory for workflow files
-   that use known SAST tools such as [CodeQL](https://codeql.github.com/) 
-   (`github/codeql-action/analyze`), [SonarCloud](https://sonarcloud.io/),
-   [Snyk](https://snyk.io/), and others.
+1. **GitHub Apps and Actions**: Looks for known GitHub apps such as
+   [CodeQL](https://codeql.github.com/) (github-code-scanning) or
+   [SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
+   of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
+   [LGTM](https://lgtm.com/) service until its forthcoming shutdown.
 
-2. **GitHub Apps**: Checks for GitHub apps like github-code-scanning running on
-   recent (~30) merged PRs. Also checks for the deprecated [LGTM](https://lgtm.com/)
-   service.
+2. **Prow CI Integration**: For projects using [Prow](https://docs.prow.k8s.io/),
+   the check provides comprehensive SAST detection through:
+   - **Pattern matching**: Detects 30+ SAST tools (gosec, golangci-lint, semgrep, etc.) in commit status names
+   - **Config file scanning**: Analyzes `.prow.yaml` and `prow/*.yaml` files for SAST tool commands
+   - **Log analysis**: Fetches and scans Prow job logs using execution signatures to verify actual tool runs
+   - **Parallel processing**: Uses concurrent log fetching for improved performance on large projects
 
-3. **Prow Configuration Files**: For projects using [Prow](https://docs.prow.k8s.io/),
-   scans `.prow.yaml` and `.prow/*.yaml` files for job definitions that contain
-   SAST tools (e.g., `golangci-lint`, `staticcheck`, `semgrep`, `trivy`, etc.)
-   in their commands.
-
-4. **CI Status Checks**: Analyzes commit status checks from any CI system (including
-   Prow, Jenkins, etc.) by pattern matching against known SAST tool names in status
-   contexts and URLs.
+3. **Check Runs and Statuses**: Analyzes GitHub check runs and commit statuses to detect
+   SAST tool execution across various CI systems including Prow, Jenkins, and others.
 
 Note: A project that fulfills this criterion with other tools may still receive
 a low score on this test. There are many ways to implement SAST, and it is
@@ -557,6 +555,7 @@ is therefore not a definitive indication that the project is at risk.
 
 **Remediation steps**
 - Run CodeQL checks in your CI/CD by following the instructions [here](https://github.com/github/codeql-action#usage).
+- For Prow-based projects, configure SAST tools in your `.prow.yaml` or Prow job configurations. Popular tools include gosec, golangci-lint, staticcheck, and semgrep.
 
 ## SBOM 
 

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -548,16 +548,21 @@ checks:
 
       The check uses multiple detection methods:
 
-      1. **GitHub Apps and Actions**: Looks for known GitHub apps such as
+      1.GitHub Apps and Actions: Looks for known GitHub apps such as
          [CodeQL](https://codeql.github.com/) (github-code-scanning) or
          [SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
          of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
          [LGTM](https://lgtm.com/) service until its forthcoming shutdown.
 
-      2. **Prow CI Integration**: For projects using [Prow](https://docs.prow.k8s.io/),
-         the check analyzes commit statuses using a two-layered approach:
-         - Pattern matching against known SAST tool names in job names
-         - Parsing Prow configuration files to identify SAST tools in job commands
+      2. Prow CI Integration: For projects using [Prow](https://docs.prow.k8s.io/),
+         the check provides comprehensive SAST detection through:
+         - Pattern matching: Detects 30+ SAST tools (gosec, golangci-lint, semgrep, etc.) in commit status names
+         - Config file scanning: Analyzes `.prow.yaml` and `prow/*.yaml` files for SAST tool commands
+         - Log analysis: Fetches and scans Prow job logs using execution signatures to verify actual tool runs
+         - Parallel processing: Uses concurrent log fetching for improved performance on large projects
+
+      3. Check Runs and Statuses: Analyzes GitHub check runs and commit statuses to detect
+         SAST tool execution across various CI systems including Prow, Jenkins, and others.
 
       Note: A project that fulfills this criterion with other tools may still receive
       a low score on this test. There are many ways to implement SAST, and it is
@@ -567,6 +572,9 @@ checks:
       - >-
         Run CodeQL checks in your CI/CD by following the instructions
         [here](https://github.com/github/codeql-action#usage).
+      - >-
+        For Prow-based projects, configure SAST tools in your `.prow.yaml` or Prow job
+        configurations. Popular tools include gosec, golangci-lint, staticcheck, and semgrep.
 
   SBOM:
     risk: Medium

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -546,11 +546,18 @@ checks:
       tools can prevent known classes of bugs from being inadvertently introduced in the
       codebase.
 
-      The checks currently looks for known GitHub apps such as
-      [CodeQL](https://codeql.github.com/) (github-code-scanning) or
-      [SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
-      of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
-      [LGTM](https://lgtm.com/) service until its forthcoming shutdown.
+      The check uses multiple detection methods:
+
+      1. **GitHub Apps and Actions**: Looks for known GitHub apps such as
+         [CodeQL](https://codeql.github.com/) (github-code-scanning) or
+         [SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
+         of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
+         [LGTM](https://lgtm.com/) service until its forthcoming shutdown.
+
+      2. **Prow CI Integration**: For projects using [Prow](https://docs.prow.k8s.io/),
+         the check analyzes commit statuses using a two-layered approach:
+         - Pattern matching against known SAST tool names in job names
+         - Parsing Prow configuration files to identify SAST tools in job commands
 
       Note: A project that fulfills this criterion with other tools may still receive
       a low score on this test. There are many ways to implement SAST, and it is

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -555,7 +555,7 @@ If the project does not use a SAST tool, or uses a tool we dont currently detect
 
 **Motivation**: SAST is testing run on source code before the application is run. Using SAST tools can prevent known classes of bugs from being inadvertently introduced in the codebase.
 
-**Implementation**: The implementation iterates through the projects commits and checks whether any of the check runs for the commits associated merge request was any of the SAST tools that Scorecard supports.
+**Implementation**: The implementation iterates through the projects commits and checks whether any of the check runs or statuses for the commits associated merge request indicate SAST tool execution. For GitHub-hosted projects, it checks GitHub Apps and Actions. For Prow-based CI systems, it analyzes commit statuses, configuration files, and optionally fetches job logs to verify tool execution using signature-based pattern matching. The probe supports detection of 30+ SAST tools including CodeQL, gosec, golangci-lint, semgrep, snyk, and others.
 
 **Outcomes**: If the project had no commits merged, the probe returns a finding with OutcomeNotApplicable.
 If the project runs SAST tools successfully on every pull request before merging, the probe returns one finding with OutcomeTrue (1). In addition, the finding will include two values. 1) How many commits were tested by a SAST tool, and 2) How many commits in total were merged.

--- a/probes/sastToolRunsOnAllCommits/def.yml
+++ b/probes/sastToolRunsOnAllCommits/def.yml
@@ -18,7 +18,7 @@ short: Checks that a SAST tool runs on all commits in the projects CI.
 motivation: >
   SAST is testing run on source code before the application is run. Using SAST tools can prevent known classes of bugs from being inadvertently introduced in the codebase.
 implementation: >
-  The implementation iterates through the projects commits and checks whether any of the check runs for the commits associated merge request was any of the SAST tools that Scorecard supports.
+  The implementation iterates through the projects commits and checks whether any of the check runs or statuses for the commits associated merge request indicate SAST tool execution. For GitHub-hosted projects, it checks GitHub Apps and Actions. For Prow-based CI systems, it analyzes commit statuses, configuration files, and optionally fetches job logs to verify tool execution using signature-based pattern matching. The probe supports detection of 30+ SAST tools including CodeQL, gosec, golangci-lint, semgrep, snyk, and others.
 outcome:
   - If the project had no commits merged, the probe returns a finding with OutcomeNotApplicable.
   - If the project runs SAST tools successfully on every pull request before merging, the probe returns one finding with OutcomeTrue (1). In addition, the finding will include two values. 1) How many commits were tested by a SAST tool, and 2) How many commits in total were merged.

--- a/probes/testsRunInCI/impl.go
+++ b/probes/testsRunInCI/impl.go
@@ -165,7 +165,7 @@ func isTest(s string) bool {
 		"appveyor", "buildkite", "circleci", "e2e", "github-actions", "jenkins",
 		"mergeable", "packit-as-a-service", "semaphoreci", "test", "travis-ci",
 		"flutter-dashboard", "cirrus-ci", "Cirrus CI", "azure-pipelines", "ci/woodpecker",
-		"vstfs:///build/build",
+		"vstfs:///build/build", "prow",
 	} {
 		if strings.Contains(l, pattern) {
 			return true

--- a/probes/testsRunInCI/impl_test.go
+++ b/probes/testsRunInCI/impl_test.go
@@ -243,6 +243,20 @@ func Test_isTest(t *testing.T) {
 			},
 			want: true,
 		},
+		{
+			name: "prow",
+			args: args{
+				s: "prow",
+			},
+			want: true,
+		},
+		{
+			name: "prow-job-name",
+			args: args{
+				s: "pull-ci-org-repo-master-unit-tests",
+			},
+			want: true, // matches "test" pattern
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

This adds support for Prow for the Code review check and the SAST check. It allows Scorecard to consider approvals in the format that Prow users leave as well as whether security SAST tools run in Prow - Scorecard already had limited support for this but does not extract the reviews to consider them in the CI check. This PR fixes that. The CI fix is fairly simple. The SAST fix has a bit more to it; It allows Scorecard to parse Prow config files and look for SAST tools. A limitation in this is that most projects don't place their Prow config files in the same repository. As such, this won't work with a lot of projects, however, I think we should leave it since there may be project with which it will work. In addition, it will be easy to add support for projects to specify where their Prow configuration file is. The PR also adds support for reading Prow CI logs and look for the invocation of security SAST tools. This requires Scorecard to first get the URL of the logs, download them and then scan them. The log scanning part could be optimized in the future, but it does a fair job for now. For example, when I run it on Kubernetes (see blow), I only see that it runs `golangci` which seems correct, judging from the the logs, its workflows and [this old comment](https://github.com/kubernetes/kubernetes/issues/105662#issuecomment-942806370) indicating that Kubernetes does not run the popular gosec.

This can be tested on Kubernetes:

Before this PR:

```
go run main.go --repo=github.com/kubernetes/kubernetes --checks=SAST --show-details --verbosity=debug
```

```
RESULTS
-------
Aggregate score: 0.0 / 10

Check scores:
|--------|------|--------------------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------|
| SCORE  | NAME |                            REASON                            |                        DETAILS                         |                   DOCUMENTATION / REMEDIATION                   |
|--------|------|--------------------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------|
| 0 / 10 | SAST | SAST tool is not run on all commits -- score normalized to 0 | Warn: 0 commits out of 30 are checked with a SAST tool | https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast |
|--------|------|--------------------------------------------------------------|--------------------------------------------------------|-----------------------------------------------------------------|
```

After this PR:

```
go run main.go --repo=github.com/kubernetes/kubernetes --checks=SAST --show-details --verbosity=debug
```

```
RESULTS                                                                                                                                                                                                                                                                                                                                                                       
-------                                                                                                                                                                                                                                                                                                                                                                       
Aggregate score: 10.0 / 10                                                                                                                                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                                                                                                                              
Check scores:                                                                                                                                                                                                                                                                                                                                                                 
|---------|------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
|  SCORE  | NAME |             REASON              |                                                                                       DETAILS                                                                                       |                   DOCUMENTATION / REMEDIATION                   |
|---------|------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------|
| 10 / 10 | SAST | SAST tool is run on all commits | Debug: Starting SAST check - looking for static analysis tools...                                                                                                                   | https://github.com/ossf/scorecard/blob/main/docs/checks.md#sast |
|         |      |                                 | Debug: [CheckRuns] Analyzing 30 commit(s) for SAST tools                                                                                                                            |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135330/pull-kubernetes-verify/2005573653218988032       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135912/pull-kubernetes-verify/2005556029835710464       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135954/pull-kubernetes-verify/2005331042004635648       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/134350/pull-kubernetes-verify/2005058754957021184       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135954/pull-kubernetes-verify/2005331042004635648       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135946/pull-kubernetes-verify/2004672198282842112       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135933/pull-kubernetes-verify/2004634951894437888       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135947/pull-kubernetes-linter-hints/2004600212831604736 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135947/pull-kubernetes-verify/2004600212139544576       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135947/pull-kubernetes-linter-hints/2004600212831604736 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135947/pull-kubernetes-verify/2004600212139544576       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135938/pull-kubernetes-linter-hints/2004487936187305984 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135938/pull-kubernetes-verify/2004487935398776832       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135946/pull-kubernetes-verify/2004672198282842112       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135938/pull-kubernetes-linter-hints/2004487936187305984 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135938/pull-kubernetes-verify/2004487935398776832       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135933/pull-kubernetes-verify/2004634951894437888       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135918/pull-kubernetes-linter-hints/2003715284485017600 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135918/pull-kubernetes-verify/2003715283960729600       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135918/pull-kubernetes-linter-hints/2003715284485017600 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135918/pull-kubernetes-verify/2003715283960729600       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135912/pull-kubernetes-verify/2005556029835710464       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135903/pull-kubernetes-linter-hints/2003444229807804416 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135903/pull-kubernetes-verify/2003444228973137920       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135903/pull-kubernetes-verify/2003444228973137920       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135903/pull-kubernetes-linter-hints/2003444229807804416 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135886/pull-kubernetes-verify/2003348989432303616       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135805/pull-kubernetes-verify/2003248322042662912       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135391/pull-kubernetes-linter-hints/1991867715425406976 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135391/pull-kubernetes-verify/1991867714586546176       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135859/pull-kubernetes-linter-hints/2003159379993432064 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135859/pull-kubernetes-linter-hints/2003159379993432064 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135859/pull-kubernetes-verify/2003159379167154176       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135859/pull-kubernetes-verify/2003159379167154176       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135862/pull-kubernetes-linter-hints/2002930730329444352 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135862/pull-kubernetes-verify/2002930729570275328       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135501/pull-kubernetes-verify/2003135576772972544       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135886/pull-kubernetes-verify/2003348989432303616       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135807/pull-kubernetes-verify/2002931727290339328       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135869/pull-kubernetes-verify/2002743487660822528       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135829/pull-kubernetes-linter-hints/2002729177307942912 |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135829/pull-kubernetes-verify/2002729176473276416       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135829/pull-kubernetes-verify/2002729176473276416       |                                                                 |
|         |      |                                 | Debug: [Prow Logs] SAST tool 'golangci' detected in job output: https://prow.k8s.io/view/gs/kubernetes-ci-logs/pr-logs/pull/135829/pull-kubernetes-linter-hints/2002729177307942912 |                                                                 |
|         |      |                                 | Debug: [Prow] Scanning for Prow configuration files...                                                                                                                              |                                                                 |
|         |      |                                 | Debug: [Prow] Scanning pattern: .prow.yaml                                                                                                                                          |                                                                 |
|         |      |                                 | Debug: [Prow] Scanning pattern: .prow/*.yaml                                                                                                                                        |                                                                 |
|         |      |                                 | Debug: [Prow] Scanning pattern: prow/*.yaml                                                                                                                                         |                                                                 |                                                                  
|         |      |                                 | Debug: [Prow] No Prow config files with SAST tools found                                                                                                                            |                                                                 |                                                                  
|         |      |                                 | Debug: SAST check complete: found 0 workflow(s), analyzed 30 commit(s)                                                                                                              |                                                                 |                                                                  
|         |      |                                 | Info: all commits (30) are checked with a SAST tool                                                                                                                                 |                                                                 |                                                                  
|---------|------|---------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------| 
```


- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

#### What is the new behavior (if this is a feature change)?**

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes


#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
