### PR TITLE
:sparkles: CLI flag to skip unsupported repo checks

### DIFF
--- a/options/flags.go
+++ b/options/flags.go
@@ -80,6 +80,10 @@ const (
 	FlagCommitDepth = "commit-depth"
 
 	FlagProbes = "probes"
+
+	// FlagSkipUnsupportedChecks is the flag name for skipping checks that are
+	// not supported by the target repo type.
+	FlagSkipUnsupportedChecks = "skip-unsupported-checks"
 )
 
 // Command is an interface for handling options for command-line utilities.
@@ -206,6 +210,13 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		FlagProbes,
 		o.ProbesToRun,
 		"Probes to run.",
+	)
+
+	cmd.Flags().BoolVar(
+		&o.SkipUnsupportedChecks,
+		FlagSkipUnsupportedChecks,
+		o.SkipUnsupportedChecks,
+		"skip checks that don't support the repository type",
 	)
 
 	// TODO(options): Extract logic

--- a/options/flags_test.go
+++ b/options/flags_test.go
@@ -31,19 +31,20 @@ func TestOptions_AddFlags(t *testing.T) {
 		{
 			name: "custom options",
 			opts: &Options{
-				Repo:        "owner/repo",
-				Local:       "/path/to/local",
-				Commit:      "1234567890abcdef",
-				LogLevel:    "debug",
-				NPM:         "npm-package",
-				PyPI:        "pypi-package",
-				RubyGems:    "rubygems-package",
-				Metadata:    []string{"key1=value1", "key2=value2"},
-				ShowDetails: true,
-				ChecksToRun: []string{"check1", "check2"},
-				PolicyFile:  "policy-file",
-				Format:      "json",
-				ResultsFile: "result.json",
+				Repo:                  "owner/repo",
+				Local:                 "/path/to/local",
+				Commit:                "1234567890abcdef",
+				LogLevel:              "debug",
+				NPM:                   "npm-package",
+				PyPI:                  "pypi-package",
+				RubyGems:              "rubygems-package",
+				Metadata:              []string{"key1=value1", "key2=value2"},
+				ShowDetails:           true,
+				ChecksToRun:           []string{"check1", "check2"},
+				PolicyFile:            "policy-file",
+				Format:                "json",
+				ResultsFile:           "result.json",
+				SkipUnsupportedChecks: true,
 			},
 		},
 	}
@@ -113,6 +114,15 @@ func TestOptions_AddFlags(t *testing.T) {
 			if cmd.Flag(FlagResultsFile).Shorthand != ShorthandFlagResultsFile {
 				t.Errorf("expected ShorthandFlagResultsFile to be %q, but got %q", ShorthandFlagResultsFile,
 					cmd.Flag(FlagResultsFile).Shorthand)
+			}
+
+			// check FlagSkipUnsupportedChecks
+			value, err := cmd.Flags().GetBool(FlagSkipUnsupportedChecks)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.opts.SkipUnsupportedChecks != value {
+				t.Errorf("expected FlagSkipUnsupportedChecks to be %t, got %t", tt.opts.SkipUnsupportedChecks, value)
 			}
 		})
 	}

--- a/options/options.go
+++ b/options/options.go
@@ -30,26 +30,27 @@ import (
 
 // Options define common options for configuring scorecard.
 type Options struct {
-	Repo            string
-	Repos           []string
-	Org             string
-	Local           string
-	Commit          string
-	LogLevel        string
-	Format          string
-	NPM             string
-	PyPI            string
-	RubyGems        string
-	Nuget           string
-	PolicyFile      string
-	ResultsFile     string
-	FileMode        string
-	ChecksToRun     []string
-	ProbesToRun     []string
-	Metadata        []string
-	CommitDepth     int
-	ShowDetails     bool
-	ShowAnnotations bool
+	Repo                  string
+	Repos                 []string
+	Org                   string
+	Local                 string
+	Commit                string
+	LogLevel              string
+	Format                string
+	NPM                   string
+	PyPI                  string
+	RubyGems              string
+	Nuget                 string
+	PolicyFile            string
+	ResultsFile           string
+	FileMode              string
+	ChecksToRun           []string
+	ProbesToRun           []string
+	Metadata              []string
+	CommitDepth           int
+	ShowDetails           bool
+	ShowAnnotations       bool
+	SkipUnsupportedChecks bool
 	// Feature flags.
 	EnableSarif                 bool `env:"ENABLE_SARIF"`
 	EnableScorecardV6           bool `env:"SCORECARD_V6"`

--- a/pkg/scorecard/repo.go
+++ b/pkg/scorecard/repo.go
@@ -1,0 +1,47 @@
+package scorecard
+
+import (
+	"strings"
+
+	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/clients/azuredevopsrepo"
+	"github.com/ossf/scorecard/v5/clients/githubrepo"
+	"github.com/ossf/scorecard/v5/clients/gitlabrepo"
+	"github.com/ossf/scorecard/v5/clients/localdir"
+)
+
+type RepoType string
+
+const (
+	RepoUnknown     RepoType = "unknown"
+	RepoLocal       RepoType = "local"
+	RepoGitLocal    RepoType = "git-local" // is not supported by any check yet.
+	RepoGitHub      RepoType = "github"
+	RepoGitLab      RepoType = "gitlab"
+	RepoAzureDevOPs RepoType = "azuredevops"
+)
+
+func GetRepoType(repo clients.Repo) RepoType {
+	switch repo.(type) {
+	case *localdir.Repo:
+		return RepoLocal
+	case *githubrepo.Repo:
+		return RepoGitHub
+	case *gitlabrepo.Repo:
+		return RepoGitLab
+	case *azuredevopsrepo.Repo:
+		return RepoAzureDevOPs
+	default:
+		return RepoUnknown
+	}
+}
+
+func RepoTypeFromString(repo string) RepoType {
+	rt := RepoType(strings.ToLower(strings.TrimSpace(repo)))
+	switch rt {
+	case RepoLocal, RepoGitLocal, RepoGitHub, RepoGitLab, RepoAzureDevOPs:
+		return rt
+	default:
+		return RepoUnknown
+	}
+}

--- a/pkg/scorecard/repo_test.go
+++ b/pkg/scorecard/repo_test.go
@@ -1,0 +1,168 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scorecard
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/clients/azuredevopsrepo"
+	"github.com/ossf/scorecard/v5/clients/githubrepo"
+	"github.com/ossf/scorecard/v5/clients/gitlabrepo"
+	"github.com/ossf/scorecard/v5/clients/localdir"
+)
+
+func TestGetRepoType(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		repo clients.Repo
+		want RepoType
+	}{
+		{
+			name: "local directory repo",
+			repo: &localdir.Repo{},
+			want: RepoLocal,
+		},
+		{
+			name: "github repo",
+			repo: &githubrepo.Repo{},
+			want: RepoGitHub,
+		},
+		{
+			name: "gitlab repo",
+			repo: &gitlabrepo.Repo{},
+			want: RepoGitLab,
+		},
+		{
+			name: "azure devops repo",
+			repo: &azuredevopsrepo.Repo{},
+			want: RepoAzureDevOPs,
+		},
+		{
+			name: "unknown repo type",
+			repo: nil,
+			want: RepoUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := GetRepoType(tt.repo)
+			if got != tt.want {
+				t.Errorf("getRepoType() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRepoTypeFromString(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		repo string
+		want RepoType
+	}{
+		{
+			name: "local lowercase",
+			repo: "local",
+			want: RepoLocal,
+		},
+		{
+			name: "local uppercase",
+			repo: "LOCAL",
+			want: RepoLocal,
+		},
+		{
+			name: "local mixed case",
+			repo: "LoCaL",
+			want: RepoLocal,
+		},
+		{
+			name: "local with whitespace",
+			repo: "  local  ",
+			want: RepoLocal,
+		},
+		{
+			name: "git-local",
+			repo: "git-local",
+			want: RepoGitLocal,
+		},
+		{
+			name: "github lowercase",
+			repo: "github",
+			want: RepoGitHub,
+		},
+		{
+			name: "github uppercase",
+			repo: "GITHUB",
+			want: RepoGitHub,
+		},
+		{
+			name: "github mixedcase",
+			repo: "GitHub",
+			want: RepoGitHub,
+		},
+		{
+			name: "gitlab lowercase",
+			repo: "gitlab",
+			want: RepoGitLab,
+		},
+		{
+			name: "gitlab uppercase",
+			repo: "GITLAB",
+			want: RepoGitLab,
+		},
+		{
+			name: "gitlab mixedcase",
+			repo: "GitLab",
+			want: RepoGitLab,
+		},
+		{
+			name: "azuredevops lowercase",
+			repo: "azuredevops",
+			want: RepoAzureDevOPs,
+		},
+		{
+			name: "azuredevops uppercase",
+			repo: "AZUREDEVOPS",
+			want: RepoAzureDevOPs,
+		},
+		{
+			name: "unknown type",
+			repo: "unknown",
+			want: RepoUnknown,
+		},
+		{
+			name: "empty string",
+			repo: "",
+			want: RepoUnknown,
+		},
+		{
+			name: "invalid type",
+			repo: "bitbucket",
+			want: RepoUnknown,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := RepoTypeFromString(tt.repo)
+			if got != tt.want {
+				t.Errorf("repoTypeFromString() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Introduces a new `--skip-unsupported-checks` CLI flag to skip checks that are not supported by a repo type (e.g. when running against a GitLab repo, it will skip checks that don't have GitLab support, not including them in the final report and score).

For a bit of context, we run Scorecard in an air-gapped environment to score private repositories hosted on a self-hosted GitLab CE instance. Since most of the checks are not supported by GitLab, the score will never be 10/10, being a bit deceptive to our developers in that they cannot do anything to fix that. This change allows the scores to be more representative of what developers can actually achieve for their repository.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

When running Scorecard against non-GitHub repositories (e.g., GitLab, Azure DevOps, local), all checks are executed regardless of whether they support the repository type. This results in misleading scores where checks that are incompatible with the repo type fail, producing gaps in the score that developers cannot fix or address since their repository hosting platform doesn't support those checks.

#### What is the new behavior (if this is a feature change)?

With the new `--skip-unsupported-checks` flag, Scorecard will:
1. Detect the repository type (GitHub, GitLab, Azure DevOps, local)
2. Check each check's supported repository types in `checks.yaml`
3. Skip any checks that don't explicitly support the detected repository type
4. Only run supported checks, providing a score that accurately reflects what's achievable for that repository type

When the flag is enabled with the default format, skipped checks are printed to stderr for visibility: `Skipping (<repo-uri>) [<check-name>]`

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4795

#### Special notes for your reviewer

When using this flag, the number of checks run may be significantly lower than the full suite, particularly for non-GitHub repositories. For GitLab, most checks already have experimental support but are not listed as supported in `checks.yaml`. This can probably be addressed in a follow-up PR (related issue #4700).

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
A new `--skip-unsupported-checks` CLI flag is now available to skip checks that don't support the repository type. When enabled, Scorecard will only run checks that explicitly support the detected repository type (GitHub, GitLab, Azure DevOps, or local). This provides more accurate scoring for non-GitHub repositories by excluding incompatible checks from the report and final score.
```