### PR TITLE
:seedling: ci: use smaller repo for gitlab e2e tests to avoid timeouts

### DIFF
--- a/clients/gitlabrepo/graphql_e2e_test.go
+++ b/clients/gitlabrepo/graphql_e2e_test.go
@@ -28,7 +28,7 @@ var _ = Describe("E2E TEST: gitlabrepo.graphqlHandler", func() {
 
 	Context("E2E TEST: Confirm query result - GitLab", func() {
 		It("Should have sufficient number of merge requests", func() {
-			repo, err := MakeGitlabRepo("gitlab.com/gitlab-org/gitlab")
+			repo, err := MakeGitlabRepo("gitlab.com/gitlab-org/api/client-go")
 			Expect(err).Should(BeNil())
 
 			glRepo, ok := repo.(*Repo)
@@ -50,7 +50,7 @@ var _ = Describe("E2E TEST: gitlabrepo.graphqlHandler", func() {
 
 	Context("E2E TEST: Validate query cost - GitLab", func() {
 		It("Should not have increased for HEAD query", func() {
-			repo, err := MakeGitlabRepo("gitlab.com/gitlab-org/gitlab")
+			repo, err := MakeGitlabRepo("gitlab.com/gitlab-org/api/client-go")
 			Expect(err).Should(BeNil())
 
 			glRepo, ok := repo.(*Repo)


### PR DESCRIPTION

#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The previous repo had 500k+ commits, which would cause some CI tests to timeout. See #4923 

#### What is the new behavior (if this is a feature change)?**
A smaller repo is used, which should hopefully not timeout.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
