### PR TITLE
:seedling: ci: remove all e2e test references to gitlab.com/gitlab-org/gitlab

### DIFF
--- a/e2e/ci_tests_test.go
+++ b/e2e/ci_tests_test.go
@@ -106,12 +106,12 @@ var _ = Describe("E2E TEST:"+checks.CheckCITests, func() {
 			skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
 
 			dl := scut.TestDetailLogger{}
-			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/gitlab-org/gitlab")
+			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/gitlab-org/api/client-go")
 			Expect(err).Should(BeNil())
 			repoClient, err := gitlabrepo.CreateGitlabClient(context.Background(), repo.Host())
 			Expect(err).Should(BeNil())
-			// url to commit is https://gitlab.com/gitlab-org/gitlab/-/commit/8ae23fa220d73fa07501aabd94214c9e83fe61a0
-			err = repoClient.InitRepo(repo, "8ae23fa220d73fa07501aabd94214c9e83fe61a0", 0)
+			// url to commit is https://gitlab.com/gitlab-org/api/client-go/-/commit/1f279e473b9fd7a145db0dd099527c2b1f81d881
+			err = repoClient.InitRepo(repo, "1f279e473b9fd7a145db0dd099527c2b1f81d881", 0)
 			Expect(err).Should(BeNil())
 			req := checker.CheckRequest{
 				Ctx:        context.Background(),
@@ -121,10 +121,10 @@ var _ = Describe("E2E TEST:"+checks.CheckCITests, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         6,
+				Score:         10,
 				NumberOfWarn:  0,
 				NumberOfInfo:  0,
-				NumberOfDebug: 22,
+				NumberOfDebug: 13,
 			}
 			result := checks.CITests(&req)
 			scut.ValidateTestReturn(GinkgoTB(), "CI tests at commit - GitLab", &expected, &result, &dl)

--- a/e2e/code_review_test.go
+++ b/e2e/code_review_test.go
@@ -157,12 +157,11 @@ var _ = Describe("E2E TEST:"+checks.CheckCodeReview, func() {
 		skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
 
 		dl := scut.TestDetailLogger{}
-		repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/gitlab-org/gitlab")
+		repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/gitlab-org/api/client-go")
 		Expect(err).Should(BeNil())
 		repoClient, err := gitlabrepo.CreateGitlabClient(context.Background(), repo.Host())
 		Expect(err).Should(BeNil())
 		err = repoClient.InitRepo(repo, clients.HeadSHA, 0)
-		// err = repoClient.InitRepo(repo, "0b5ba5049f3e5b8e945305acfa45c44d63df21b1", 0)
 		Expect(err).Should(BeNil())
 
 		req := checker.CheckRequest{

--- a/e2e/maintained_test.go
+++ b/e2e/maintained_test.go
@@ -60,7 +60,7 @@ var _ = Describe("E2E TEST:"+checks.CheckMaintained, func() {
 			skipIfTokenIsNot(gitlabPATTokenType, "GitLab only")
 
 			dl := scut.TestDetailLogger{}
-			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/gitlab-org/gitlab")
+			repo, err := gitlabrepo.MakeGitlabRepo("gitlab.com/gitlab-org/api/client-go")
 			Expect(err).Should(BeNil())
 			repoClient, err := gitlabrepo.CreateGitlabClientWithToken(context.Background(),
 				os.Getenv("GITLAB_AUTH_TOKEN"), repo.Host())


### PR DESCRIPTION
#### What kind of change does this PR introduce?

CI

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The gitlab e2e tests which require a token [timeout](https://github.com/ossf/scorecard/actions/runs/21595386920/job/62226308025). 

```
      [It] Should return valid maintained status - GitLab
      /home/runner/work/scorecard/scorecard/e2e/maintained_test.go:59
  
    Timeline >>
    > Enter [It] Should return valid maintained status - GitLab - /home/runner/work/scorecard/scorecard/e2e/maintained_test.go:59 @ 02/02/26 15:18:19.553
    [FAILED] active repo: (-expected +actual)  utests.TestReturn{
    - 	Error:         nil,
    + 	Error:         e"internal error: couldn't query gitlab graphql for merge requests: Timeout on CommitConnection.nodes",
    - 	Score:         10,
    + 	Score:         -1,
      	NumberOfWarn:  0,
      	NumberOfInfo:  0,
      	NumberOfDebug: 0,
      }
  
    
    In [It] at: /home/runner/work/scorecard/scorecard/e2e/maintained_test.go:85 @ 02/02/26 15:18:52.062
    < Exit [It] Should return valid maintained status - GitLab - /home/runner/work/scorecard/scorecard/e2e/maintained_test.go:59 @ 02/02/26 15:18:52.062 (32.509s)
```



#### What is the new behavior (if this is a feature change)?**

All e2e references to `gitlab.com/gitlab-org/gitlab` are removed. This is a followup to ac18bf8, which removed references from the e2e tests which run on PRs, however there were a few more tests which only run when pushed to main (because they need a token).

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
