### PR TITLE
:seedling: cron: Add ability to purge cached results from a CDN

### DIFF
--- a/cron/config/config.go
+++ b/cron/config/config.go
@@ -56,6 +56,7 @@ const (
 	apiResultsBucketURL     string = "SCORECARD_API_RESULTS_BUCKET_URL"
 	inputBucketURL          string = "SCORECARD_INPUT_BUCKET_URL"
 	inputBucketPrefix       string = "SCORECARD_INPUT_BUCKET_PREFIX"
+	apiBaseURL              string = "SCORECARD_API_BASE_URL"
 )
 
 var (
@@ -356,4 +357,9 @@ func GetScorecardValues() (map[string]string, error) {
 // GetCriticalityValues() returns a map of key, value pairs containing additional, criticality specific values.
 func GetCriticalityValues() (map[string]string, error) {
 	return GetAdditionalParams("criticality")
+}
+
+// GetAPIBaseURL returns the base URL for the Scorecard API.
+func GetAPIBaseURL() (string, error) {
+	return getStringConfigValue(apiBaseURL, configYAML, "APIBaseURL", "api-base-url")
 }

--- a/cron/internal/cdn/client.go
+++ b/cron/internal/cdn/client.go
@@ -1,0 +1,77 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cdn implements clients for CDN operations.
+package cdn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+var errPurgeFailed = errors.New("purge failed")
+
+// Purger is the interface for purging URLs from a CDN.
+type Purger interface {
+	Purge(ctx context.Context, url string) error
+}
+
+// FastlyClient implements Purger for Fastly.
+type FastlyClient struct {
+	token   string
+	baseURL string
+}
+
+// NewFastlyClient creates a new FastlyClient.
+func NewFastlyClient(token, baseURL string) *FastlyClient {
+	baseURL = strings.TrimSuffix(baseURL, "/")
+	return &FastlyClient{token: token, baseURL: baseURL}
+}
+
+// Purge purges the given URL from Fastly.
+// It sends a PURGE request to the given URL with the Fastly-Key header.
+func (c *FastlyClient) Purge(ctx context.Context, path string) error {
+	req, err := http.NewRequestWithContext(ctx, "PURGE", c.baseURL+path, nil)
+	if err != nil {
+		return fmt.Errorf("http.NewRequest: %w", err)
+	}
+	req.Header.Set("Fastly-Key", c.token)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("http.Do: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: %s", errPurgeFailed, resp.Status)
+	}
+	return nil
+}
+
+// NoOpClient is a no-op implementation of PurgeClient.
+type NoOpClient struct{}
+
+// NewNoOpClient creates a new NoOpClient.
+func NewNoOpClient() *NoOpClient {
+	return &NoOpClient{}
+}
+
+// Purge does nothing.
+func (c *NoOpClient) Purge(ctx context.Context, url string) error {
+	return nil
+}

--- a/cron/internal/cdn/client_test.go
+++ b/cron/internal/cdn/client_test.go
@@ -1,0 +1,54 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cdn
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+const token = "test-token"
+
+func TestFastlyClient_Purge(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "PURGE" {
+			t.Errorf("expected method PURGE, got %s", r.Method)
+		}
+		if r.Header.Get("Fastly-Key") != token {
+			t.Errorf("expected Fastly-Key header %s, got %s", token, r.Header.Get("Fastly-Key"))
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+	client := NewFastlyClient(token, server.URL)
+	if err := client.Purge(context.Background(), "/foo"); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestFastlyClient_Purge_Error(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer server.Close()
+	client := NewFastlyClient(token, server.URL)
+	if err := client.Purge(context.Background(), "/foo"); err == nil {
+		t.Error("expected error, got nil")
+	}
+}

--- a/cron/k8s/worker.release.yaml
+++ b/cron/k8s/worker.release.yaml
@@ -57,8 +57,15 @@ spec:
                 secretKeyRef:
                   name: gitlab
                   key: auth_token
+            - name: FASTLY_PURGE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: fastly
+                  key: purge_token
             - name: "SCORECARD_API_RESULTS_BUCKET_URL"
               value: "gs://ossf-scorecard-cron-releasetest-results"
+            - name: "SCORECARD_API_BASE_URL"
+              value: "https://cdn.scorecard.dev"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/scorecard


### PR DESCRIPTION
#### What kind of change does this PR introduce?

cron update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
No CDN usage, so no results purging.

#### What is the new behavior (if this is a feature change)?**
If configured, the cron worker will purge results from a URL behind a CDN.

- [X] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
