### PR TITLE
✨feat: Add Private Vulnerability Reporting probe to Security-Policy check

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -300,6 +300,12 @@ type SASTWorkflow struct {
 // for the Security-Policy check.
 type SecurityPolicyData struct {
 	PolicyFiles []SecurityPolicyFile
+	// PrivateVulnerabilityReportingEnabled indicates whether GitHub's Private Vulnerability Reporting is enabled.
+	// This is only meaningful when PrivateVulnerabilityReportingAvailable is true.
+	PrivateVulnerabilityReportingEnabled bool
+	// PrivateVulnerabilityReportingAvailable indicates whether the PVR check was available for this repo.
+	// This will be false for non-GitHub repositories where the feature is not supported.
+	PrivateVulnerabilityReportingAvailable bool
 }
 
 // BinaryArtifactData contains the raw results

--- a/checks/evaluation/security_policy.go
+++ b/checks/evaluation/security_policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ossf/scorecard/v5/checker"
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/privateVulnerabilityReportingEnabled"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsLinks"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsText"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsVulnerabilityDisclosure"
@@ -26,12 +27,13 @@ import (
 
 // SecurityPolicy applies the score policy for the Security-Policy check.
 func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLogger) checker.CheckResult {
-	// We have 4 unique probes, each should have a finding.
+	// We have 5 unique probes, each should have a finding.
 	expectedProbes := []string{
 		securityPolicyContainsVulnerabilityDisclosure.Probe,
 		securityPolicyContainsLinks.Probe,
 		securityPolicyContainsText.Probe,
 		securityPolicyPresent.Probe,
+		privateVulnerabilityReportingEnabled.Probe,
 	}
 	if !finding.UniqueProbesEqual(findings, expectedProbes) {
 		e := sce.WithMessage(sce.ErrScorecardInternal, "invalid probe results")
@@ -55,6 +57,9 @@ func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLo
 			case securityPolicyContainsText.Probe:
 				score += scoreProbeOnce(f.Probe, m, 3)
 			case securityPolicyPresent.Probe:
+				m[f.Probe] = true
+			case privateVulnerabilityReportingEnabled.Probe:
+				// Private vulnerability reporting is informational - doesn't affect score
 				m[f.Probe] = true
 			default:
 				e := sce.WithMessage(sce.ErrScorecardInternal, "unknown probe results")

--- a/checks/evaluation/security_policy_test.go
+++ b/checks/evaluation/security_policy_test.go
@@ -45,6 +45,10 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeFalse,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeFalse,
+				},
 			},
 			result: scut.TestReturn{
 				Score: checker.InconclusiveResultScore,
@@ -99,11 +103,15 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeTrue,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeFalse,
+				},
 			},
 			result: scut.TestReturn{
 				Score:        checker.MinResultScore,
 				NumberOfInfo: 1,
-				NumberOfWarn: 3,
+				NumberOfWarn: 4,
 			},
 		},
 		{
@@ -125,12 +133,16 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeFalse,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeTrue,
+				},
 			},
 			result: scut.TestReturn{
 				Score:        checker.InconclusiveResultScore,
 				Error:        sce.ErrScorecardInternal,
 				NumberOfWarn: 1,
-				NumberOfInfo: 3,
+				NumberOfInfo: 4,
 			},
 		},
 		{
@@ -152,10 +164,14 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeTrue,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeTrue,
+				},
 			},
 			result: scut.TestReturn{
 				Score:        6,
-				NumberOfInfo: 2,
+				NumberOfInfo: 3,
 				NumberOfWarn: 2,
 			},
 		},
@@ -178,10 +194,14 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeTrue,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeTrue,
+				},
 			},
 			result: scut.TestReturn{
 				Score:        checker.MaxResultScore,
-				NumberOfInfo: 4,
+				NumberOfInfo: 5,
 			},
 		},
 	}

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -151,6 +151,8 @@ func TestSecurityPolicy(t *testing.T) {
 				return os.Open(tt.path)
 			}).AnyTimes()
 
+			mockRepoClient.EXPECT().HasPrivateVulnerabilityReportingEnabled().Return(true, nil).AnyTimes()
+
 			dl := scut.TestDetailLogger{}
 			c := checker.CheckRequest{
 				RepoClient: mockRepoClient,

--- a/checks/security_policy_test.go
+++ b/checks/security_policy_test.go
@@ -43,7 +43,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        10,
-				NumberOfInfo: 4,
+				NumberOfInfo: 5,
 				NumberOfWarn: 0,
 			},
 		},
@@ -55,7 +55,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        10,
-				NumberOfInfo: 4,
+				NumberOfInfo: 5,
 				NumberOfWarn: 0,
 			},
 		},
@@ -67,7 +67,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        4,
-				NumberOfInfo: 3,
+				NumberOfInfo: 4,
 				NumberOfWarn: 1,
 			},
 		},
@@ -79,7 +79,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        3,
-				NumberOfInfo: 2,
+				NumberOfInfo: 3,
 				NumberOfWarn: 2,
 			},
 		},
@@ -91,7 +91,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        6,
-				NumberOfInfo: 2,
+				NumberOfInfo: 3,
 				NumberOfWarn: 2,
 			},
 		},
@@ -103,7 +103,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        6,
-				NumberOfInfo: 2,
+				NumberOfInfo: 3,
 				NumberOfWarn: 2,
 			},
 		},
@@ -115,7 +115,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        6,
-				NumberOfInfo: 2,
+				NumberOfInfo: 3,
 				NumberOfWarn: 2,
 			},
 		},
@@ -127,7 +127,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        9,
-				NumberOfInfo: 3,
+				NumberOfInfo: 4,
 				NumberOfWarn: 1,
 			},
 		},
@@ -139,7 +139,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        10,
-				NumberOfInfo: 4,
+				NumberOfInfo: 5,
 				NumberOfWarn: 0,
 			},
 		},
@@ -151,7 +151,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        0,
-				NumberOfInfo: 1,
+				NumberOfInfo: 2,
 				NumberOfWarn: 3,
 			},
 		},
@@ -163,7 +163,7 @@ func TestSecurityPolicy(t *testing.T) {
 			},
 			want: scut.TestReturn{
 				Score:        0,
-				NumberOfInfo: 1,
+				NumberOfInfo: 2,
 				NumberOfWarn: 3,
 			},
 		},
@@ -183,6 +183,8 @@ func TestSecurityPolicy(t *testing.T) {
 				}
 				return os.Open(tt.path)
 			}).AnyTimes()
+
+			mockRepo.EXPECT().HasPrivateVulnerabilityReportingEnabled().Return(true, nil).AnyTimes()
 
 			dl := scut.TestDetailLogger{}
 			c := &checker.CheckRequest{

--- a/clients/azuredevopsrepo/client.go
+++ b/clients/azuredevopsrepo/client.go
@@ -179,6 +179,11 @@ func (c *Client) GetOrgRepoClient(context.Context) (clients.RepoClient, error) {
 	return nil, clients.ErrUnsupportedFeature
 }
 
+// HasPrivateVulnerabilityReportingEnabled implements RepoClient.HasPrivateVulnerabilityReportingEnabled.
+func (c *Client) HasPrivateVulnerabilityReportingEnabled() (bool, error) {
+	return false, clients.ErrUnsupportedFeature
+}
+
 func (c *Client) ListCommits() ([]clients.Commit, error) {
 	return c.commits.listCommits()
 }

--- a/clients/git/client.go
+++ b/clients/git/client.go
@@ -337,6 +337,11 @@ func (c *Client) GetOrgRepoClient(ctx context.Context) (clients.RepoClient, erro
 	return nil, clients.ErrUnsupportedFeature
 }
 
+// HasPrivateVulnerabilityReportingEnabled implements RepoClient.HasPrivateVulnerabilityReportingEnabled.
+func (c *Client) HasPrivateVulnerabilityReportingEnabled() (bool, error) {
+	return false, clients.ErrUnsupportedFeature
+}
+
 func (c *Client) ListIssues() ([]clients.Issue, error) {
 	return nil, clients.ErrUnsupportedFeature
 }

--- a/clients/gitlabrepo/client.go
+++ b/clients/gitlabrepo/client.go
@@ -240,6 +240,11 @@ func (client *Client) GetOrgRepoClient(ctx context.Context) (clients.RepoClient,
 	return nil, fmt.Errorf("GetOrgRepoClient (GitLab): %w", clients.ErrUnsupportedFeature)
 }
 
+// HasPrivateVulnerabilityReportingEnabled implements RepoClient.HasPrivateVulnerabilityReportingEnabled.
+func (client *Client) HasPrivateVulnerabilityReportingEnabled() (bool, error) {
+	return false, fmt.Errorf("HasPrivateVulnerabilityReportingEnabled (GitLab): %w", clients.ErrUnsupportedFeature)
+}
+
 func (client *Client) ListWebhooks() ([]clients.Webhook, error) {
 	return client.webhook.listWebhooks()
 }

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -273,6 +273,11 @@ func (client *Client) GetOrgRepoClient(ctx context.Context) (clients.RepoClient,
 	return nil, fmt.Errorf("GetOrgRepoClient: %w", clients.ErrUnsupportedFeature)
 }
 
+// HasPrivateVulnerabilityReportingEnabled implements RepoClient.HasPrivateVulnerabilityReportingEnabled.
+func (client *Client) HasPrivateVulnerabilityReportingEnabled() (bool, error) {
+	return false, fmt.Errorf("HasPrivateVulnerabilityReportingEnabled: %w", clients.ErrUnsupportedFeature)
+}
+
 // CreateLocalDirClient returns a client which implements RepoClient interface.
 func CreateLocalDirClient(ctx context.Context, logger *log.Logger) clients.RepoClient {
 	return &Client{

--- a/clients/mockclients/repo_client.go
+++ b/clients/mockclients/repo_client.go
@@ -162,6 +162,21 @@ func (mr *MockRepoClientMockRecorder) GetOrgRepoClient(arg0 any) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrgRepoClient", reflect.TypeOf((*MockRepoClient)(nil).GetOrgRepoClient), arg0)
 }
 
+// HasPrivateVulnerabilityReportingEnabled mocks base method.
+func (m *MockRepoClient) HasPrivateVulnerabilityReportingEnabled() (bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "HasPrivateVulnerabilityReportingEnabled")
+	ret0, _ := ret[0].(bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// HasPrivateVulnerabilityReportingEnabled indicates an expected call of HasPrivateVulnerabilityReportingEnabled.
+func (mr *MockRepoClientMockRecorder) HasPrivateVulnerabilityReportingEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "HasPrivateVulnerabilityReportingEnabled", reflect.TypeOf((*MockRepoClient)(nil).HasPrivateVulnerabilityReportingEnabled))
+}
+
 // InitRepo mocks base method.
 func (m *MockRepoClient) InitRepo(repo clients.Repo, commitSHA string, commitDepth int) error {
 	m.ctrl.T.Helper()

--- a/clients/ossfuzz/client.go
+++ b/clients/ossfuzz/client.go
@@ -202,6 +202,11 @@ func (c *client) GetOrgRepoClient(ctx context.Context) (clients.RepoClient, erro
 	return nil, fmt.Errorf("GetOrgRepoClient: %w", clients.ErrUnsupportedFeature)
 }
 
+// HasPrivateVulnerabilityReportingEnabled implements RepoClient.HasPrivateVulnerabilityReportingEnabled.
+func (c *client) HasPrivateVulnerabilityReportingEnabled() (bool, error) {
+	return false, fmt.Errorf("HasPrivateVulnerabilityReportingEnabled: %w", clients.ErrUnsupportedFeature)
+}
+
 // GetDefaultBranchName implements RepoClient.GetDefaultBranchName.
 func (c *client) GetDefaultBranchName() (string, error) {
 	return "", fmt.Errorf("GetDefaultBranchName: %w", clients.ErrUnsupportedFeature)

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -45,6 +45,7 @@ type RepoClient interface {
 	GetDefaultBranchName() (string, error)
 	GetDefaultBranch() (*BranchRef, error)
 	GetOrgRepoClient(context.Context) (RepoClient, error)
+	HasPrivateVulnerabilityReportingEnabled() (bool, error)
 	ListCommits() ([]Commit, error)
 	ListIssues() ([]Issue, error)
 	ListLicenses() ([]License, error)

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ossf/scorecard/v5/probes/jobLevelPermissions"
 	"github.com/ossf/scorecard/v5/probes/packagedWithAutomatedWorkflow"
 	"github.com/ossf/scorecard/v5/probes/pinsDependencies"
+	"github.com/ossf/scorecard/v5/probes/privateVulnerabilityReportingEnabled"
 	"github.com/ossf/scorecard/v5/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveProvenance"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveVerifiedProvenance"
@@ -83,6 +84,7 @@ var (
 		securityPolicyContainsLinks.Run,
 		securityPolicyContainsVulnerabilityDisclosure.Run,
 		securityPolicyContainsText.Run,
+		privateVulnerabilityReportingEnabled.Run,
 	}
 	// DependencyToolUpdates is all the probes for the
 	// DependencyUpdateTool check.

--- a/probes/privateVulnerabilityReportingEnabled/def.yml
+++ b/probes/privateVulnerabilityReportingEnabled/def.yml
@@ -1,0 +1,44 @@
+# Copyright 2024 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: privateVulnerabilityReportingEnabled
+lifecycle: experimental
+short: Check if private vulnerability reporting is enabled for the repository.
+motivation: >
+  Private vulnerability reporting allows security researchers to privately report
+  vulnerabilities to maintainers, promoting responsible disclosure. This feature
+  helps projects receive vulnerability reports without exposing sensitive details
+  publicly before a fix is available.
+implementation: >
+  Checks if the repository has GitHub's Private Vulnerability Reporting feature enabled.
+  This data is retrieved from the GitHub repository metadata.
+outcome:
+  - If private vulnerability reporting is enabled, one finding with OutcomeTrue is returned.
+  - If private vulnerability reporting is not enabled, one finding with OutcomeFalse is returned.
+  - If the check is not applicable (e.g., not a GitHub repository), one finding with OutcomeNotApplicable is returned.
+remediation:
+  onOutcome: False
+  effort: Low
+  text:
+    - 'Enable private vulnerability reporting in your repository settings.'
+    - 'Go to Settings > Security > Private vulnerability reporting and enable it.'
+    - 'See https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository'
+  markdown:
+    - Enable private vulnerability reporting in your [repository settings](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository).
+    - Go to **Settings > Security > Private vulnerability reporting** and enable it.
+ecosystem:
+  languages:
+    - all
+  clients:
+    - github

--- a/probes/privateVulnerabilityReportingEnabled/impl.go
+++ b/probes/privateVulnerabilityReportingEnabled/impl.go
@@ -1,0 +1,83 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package privateVulnerabilityReportingEnabled implements a probe that checks
+// if GitHub's Private Vulnerability Reporting feature is enabled for the repository.
+package privateVulnerabilityReportingEnabled
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/checknames"
+	"github.com/ossf/scorecard/v5/internal/probes"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/uerror"
+)
+
+func init() {
+	probes.MustRegister(Probe, Run, []checknames.CheckName{checknames.SecurityPolicy})
+}
+
+//go:embed *.yml
+var fs embed.FS
+
+// Probe is the unique identifier for this probe.
+const Probe = "privateVulnerabilityReportingEnabled"
+
+// Run checks if private vulnerability reporting is enabled for the repository.
+// Returns:
+//   - OutcomeTrue: PVR is enabled
+//   - OutcomeFalse: PVR is not enabled (but available for this platform)
+//   - OutcomeNotApplicable: PVR is not available for this platform (e.g., non-GitHub repos)
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	if raw == nil {
+		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
+	}
+
+	securityPolicy := &raw.SecurityPolicyResults
+
+	// Check if PVR is available for this platform
+	if !securityPolicy.PrivateVulnerabilityReportingAvailable {
+		f, err := finding.NewWith(fs, Probe,
+			"private vulnerability reporting is not available for this repository type",
+			nil, finding.OutcomeNotApplicable)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		return []finding.Finding{*f}, Probe, nil
+	}
+
+	// PVR is available - check if it's enabled
+	var f *finding.Finding
+	var err error
+
+	if securityPolicy.PrivateVulnerabilityReportingEnabled {
+		f, err = finding.NewWith(fs, Probe,
+			"private vulnerability reporting is enabled",
+			nil, finding.OutcomeTrue)
+	} else {
+		f, err = finding.NewWith(fs, Probe,
+			"private vulnerability reporting is not enabled",
+			nil, finding.OutcomeFalse)
+	}
+
+	if err != nil {
+		return nil, Probe, fmt.Errorf("create finding: %w", err)
+	}
+
+	f = f.WithRemediationMetadata(raw.Metadata.Metadata)
+	return []finding.Finding{*f}, Probe, nil
+}

--- a/probes/privateVulnerabilityReportingEnabled/impl_test.go
+++ b/probes/privateVulnerabilityReportingEnabled/impl_test.go
@@ -1,0 +1,96 @@
+// Copyright 2024 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privateVulnerabilityReportingEnabled
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		raw      *checker.RawResults
+		expected finding.Outcome
+		wantMsg  string
+	}{
+		{
+			name: "PVR enabled",
+			raw: &checker.RawResults{
+				SecurityPolicyResults: checker.SecurityPolicyData{
+					PrivateVulnerabilityReportingEnabled:   true,
+					PrivateVulnerabilityReportingAvailable: true,
+				},
+			},
+			expected: finding.OutcomeTrue,
+			wantMsg:  "private vulnerability reporting is enabled",
+		},
+		{
+			name: "PVR disabled",
+			raw: &checker.RawResults{
+				SecurityPolicyResults: checker.SecurityPolicyData{
+					PrivateVulnerabilityReportingEnabled:   false,
+					PrivateVulnerabilityReportingAvailable: true,
+				},
+			},
+			expected: finding.OutcomeFalse,
+			wantMsg:  "private vulnerability reporting is not enabled",
+		},
+		{
+			name: "PVR not available (non-GitHub)",
+			raw: &checker.RawResults{
+				SecurityPolicyResults: checker.SecurityPolicyData{
+					PrivateVulnerabilityReportingEnabled:   false,
+					PrivateVulnerabilityReportingAvailable: false,
+				},
+			},
+			expected: finding.OutcomeNotApplicable,
+			wantMsg:  "private vulnerability reporting is not available for this repository type",
+		},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			findings, probe, err := Run(tt.raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if probe != Probe {
+				t.Errorf("expected probe %q, got %q", Probe, probe)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("expected 1 finding, got %d", len(findings))
+			}
+			if findings[0].Outcome != tt.expected {
+				t.Errorf("expected outcome %v, got %v", tt.expected, findings[0].Outcome)
+			}
+			if findings[0].Message != tt.wantMsg {
+				t.Errorf("expected message %q, got %q", tt.wantMsg, findings[0].Message)
+			}
+		})
+	}
+}
+
+func TestRun_NilRaw(t *testing.T) {
+	t.Parallel()
+	_, _, err := Run(nil)
+	if err == nil {
+		t.Fatal("expected error for nil raw, got nil")
+	}
+}


### PR DESCRIPTION
<head></head><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Overview</h2><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">This PR introduces a new probe that detects whether GitHub's Private Vulnerability Reporting (PVR) feature is enabled on repositories, enhancing the Security-Policy check with visibility into GitHub's native vulnerability reporting mechanism.</p><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Implementation Details</h2><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Core Changes</h3><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>Interface Extension</strong></p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">Added<span class="Apple-converted-space"> </span><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">HasPrivateVulnerabilityReportingEnabled()</code><span class="Apple-converted-space"> </span>method to the<span class="Apple-converted-space"> </span><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">RepoClient</code><span class="Apple-converted-space"> </span>interface</li></ul><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>GitHub Client Implementation</strong></p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">Implemented API integration using the<span class="Apple-converted-space"> </span><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">/repos/{owner}/{repo}/private-vulnerability-reporting</code><span class="Apple-converted-space"> </span>endpoint</li><li class="whitespace-normal break-words pl-2">Requires read-only access to repository metadata</li></ul><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>Multi-Platform Support</strong></p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">Added stub implementations returning<span class="Apple-converted-space"> </span><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">ErrUnsupportedFeature</code><span class="Apple-converted-space"> </span>for:<ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3"><li class="whitespace-normal break-words pl-2">GitLab</li><li class="whitespace-normal break-words pl-2">Local directory</li><li class="whitespace-normal break-words pl-2">Git</li><li class="whitespace-normal break-words pl-2">Azure DevOps</li><li class="whitespace-normal break-words pl-2">OSS-Fuzz</li></ul></li></ul><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>Probe Implementation</strong></p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">Created<span class="Apple-converted-space"> </span><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">privateVulnerabilityReportingEnabled</code><span class="Apple-converted-space"> </span>probe with three outcome states</li><li class="whitespace-normal break-words pl-2">Integrated probe into Security-Policy check workflow</li><li class="whitespace-normal break-words pl-2">Added comprehensive test coverage</li></ul><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Outcome States</h3><div class="overflow-x-auto w-full px-2 mb-6" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">
Outcome | Description
-- | --
OutcomeTrue | Private Vulnerability Reporting is enabled
OutcomeFalse | Private Vulnerability Reporting is available but not enabled
OutcomeNotApplicable | Feature not available (non-GitHub repositories)

</div><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Change Type</h2><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><span class="Apple-converted-space"> </span><strong>Feature</strong><span class="Apple-converted-space"> </span>- New capability for detecting GitHub Private Vulnerability Reporting status</p><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Behavioral Changes</h2><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Before</h3><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">The Security-Policy check evaluated only:</p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">Presence of security policy files</li><li class="whitespace-normal break-words pl-2">Content quality of security documentation</li></ul><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">After</h3><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">The Security-Policy check now additionally evaluates:</p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">Whether GitHub's Private Vulnerability Reporting feature is enabled</li><li class="whitespace-normal break-words pl-2">Provides actionable insights for improving vulnerability disclosure processes</li></ul><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Testing</h2><ul class="contains-task-list" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="task-list-item"><input disabled="" type="checkbox" checked=""><span class="Apple-converted-space"> </span>Comprehensive unit tests added</li><li class="task-list-item"><input disabled="" type="checkbox" checked=""><span class="Apple-converted-space"> </span>Integration tests for GitHub client</li><li class="task-list-item"><input disabled="" type="checkbox" checked=""><span class="Apple-converted-space"> </span>Edge case handling verified</li><li class="task-list-item"><input disabled="" type="checkbox" checked=""><span class="Apple-converted-space"> </span>Multi-platform stub implementations tested</li></ul><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Compliance Checklist</h2><ul class="contains-task-list" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="task-list-item"><input disabled="" type="checkbox"><span class="Apple-converted-space"> </span>PR title follows project contribution guidelines</li><li class="task-list-item"><input disabled="" type="checkbox" checked=""><span class="Apple-converted-space"> </span>Code changes include appropriate tests</li><li class="task-list-item"><input disabled="" type="checkbox" checked=""><span class="Apple-converted-space"> </span>Documentation updated where applicable</li></ul><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">GitHub Issue</h2><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">None - This is a new feature enhancement</p><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Reviewer Notes</h2><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Important Considerations</h3><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>Scoring Impact</strong></p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">This probe is informational only</li><li class="whitespace-normal break-words pl-2">Does not currently affect Security-Policy scores</li><li class="whitespace-normal break-words pl-2">Provides visibility for future policy decisions</li></ul><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>Platform Compatibility</strong></p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">GitHub repositories: Full functionality</li><li class="whitespace-normal break-words pl-2">Non-GitHub platforms: Returns<span class="Apple-converted-space"> </span><code class="bg-text-200/5 border border-0.5 border-border-300 text-danger-000 whitespace-pre-wrap rounded-[0.4rem] px-1 py-px text-[0.9rem]">OutcomeNotApplicable</code></li><li class="whitespace-normal break-words pl-2">No breaking changes to existing checks</li></ul><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><strong>API Requirements</strong></p><ul class="[li_&amp;]:mb-0 [li_&amp;]:mt-1 [li_&amp;]:gap-1 [&amp;:not(:last-child)_ul]:pb-1 [&amp;:not(:last-child)_ol]:pb-1 list-disc flex flex-col gap-1 pl-8 mb-3" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><li class="whitespace-normal break-words pl-2">Uses GitHub's standard REST API</li><li class="whitespace-normal break-words pl-2">Requires only read access to public repository metadata</li><li class="whitespace-normal break-words pl-2">No authentication changes needed</li></ul><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">User Impact</h2><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">What Users Will See</h3><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Users running the Security-Policy check will now receive information about whether their GitHub repository has Private Vulnerability Reporting enabled. This helps teams understand their vulnerability disclosure posture and make informed decisions about security reporting mechanisms.</p><h3 class="text-text-100 mt-2 -mb-1 text-base font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Example Output</h3><div class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><div class="sticky opacity-0 group-hover/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md active:scale-95 backdrop-blur-md Button_ghost__BUAoh" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3C13.3284 3 14 3.67157 14 4.5V6H15.5C16.3284 6 17 6.67157 17 7.5V15.5C17 16.3284 16.3284 17 15.5 17H7.5C6.67157 17 6 16.3284 6 15.5V14H4.5C3.67157 14 3 13.3284 3 12.5V4.5C3 3.67157 3.67157 3 4.5 3H12.5ZM14 12.5C14 13.3284 13.3284 14 12.5 14H7V15.5C7 15.7761 7.22386 16 7.5 16H15.5C15.7761 16 16 15.7761 16 15.5V7.5C16 7.22386 15.7761 7 15.5 7H14V12.5ZM4.5 4C4.22386 4 4 4.22386 4 4.5V12.5C4 12.7761 4.22386 13 4.5 13H12.5C12.7761 13 13 12.7761 13 12.5V4.5C13 4.22386 12.7761 4 12.5 4H4.5Z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.1883 5.10908C15.3699 4.96398 15.6346 4.96153 15.8202 5.11592C16.0056 5.27067 16.0504 5.53125 15.9403 5.73605L15.8836 5.82003L8.38354 14.8202C8.29361 14.9279 8.16242 14.9925 8.02221 14.9989C7.88203 15.0051 7.74545 14.9526 7.64622 14.8534L4.14617 11.3533L4.08172 11.2752C3.95384 11.0811 3.97542 10.817 4.14617 10.6463C4.31693 10.4755 4.58105 10.4539 4.77509 10.5818L4.85321 10.6463L7.96556 13.7586L15.1161 5.1794L15.1883 5.10908Z"></path></svg></div></div></div></button></div></div><div><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed" style="background: none; color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; font-family: var(--font-mono); direction: ltr; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; line-height: 1.5; tab-size: 2; hyphens: none; padding: 1em; margin: 0.5em 0px; overflow: auto; border-radius: 0.3em;"><code style="background: none; color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; font-family: var(--font-mono); direction: ltr; text-align: left; white-space: pre-wrap; word-spacing: normal; word-break: normal; line-height: 1.5; tab-size: 2; hyphens: none;"><span><span>✓ Security policy file exists
</span></span><span>✓ Security policy contains contact information
</span><span>ℹ Private Vulnerability Reporting: Enabled</span></code></pre></div></div><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Release Notes</h2><div class="relative group/copy bg-bg-000/50 border-0.5 border-border-400 rounded-lg" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);"><div class="sticky opacity-0 group-hover/copy:opacity-100 top-2 py-2 h-12 w-0 float-right"><div class="absolute right-0 h-8 px-2 items-center inline-flex z-10"><button class="inline-flex
  items-center
  justify-center
  relative
  shrink-0
  can-focus
  select-none
  disabled:pointer-events-none
  disabled:opacity-50
  disabled:shadow-none
  disabled:drop-shadow-none border-transparent
          transition
          font-base
          duration-300
          ease-[cubic-bezier(0.165,0.85,0.45,1)] h-8 w-8 rounded-md active:scale-95 backdrop-blur-md Button_ghost__BUAoh" type="button" aria-label="Copy to clipboard" data-state="closed"><div class="relative"><div class="transition-all opacity-100 scale-100" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-100 scale-100" aria-hidden="true" style="flex-shrink: 0;"><path d="M12.5 3C13.3284 3 14 3.67157 14 4.5V6H15.5C16.3284 6 17 6.67157 17 7.5V15.5C17 16.3284 16.3284 17 15.5 17H7.5C6.67157 17 6 16.3284 6 15.5V14H4.5C3.67157 14 3 13.3284 3 12.5V4.5C3 3.67157 3.67157 3 4.5 3H12.5ZM14 12.5C14 13.3284 13.3284 14 12.5 14H7V15.5C7 15.7761 7.22386 16 7.5 16H15.5C15.7761 16 16 15.7761 16 15.5V7.5C16 7.22386 15.7761 7 15.5 7H14V12.5ZM4.5 4C4.22386 4 4 4.22386 4 4.5V12.5C4 12.7761 4.22386 13 4.5 13H12.5C12.7761 13 13 12.7761 13 12.5V4.5C13 4.22386 12.7761 4 12.5 4H4.5Z"></path></svg></div><div class="absolute inset-0 flex items-center justify-center"><div class="transition-all opacity-0 scale-50" style="width: 20px; height: 20px; display: flex; align-items: center; justify-content: center;"><svg width="20" height="20" viewBox="0 0 20 20" fill="currentColor" xmlns="http://www.w3.org/2000/svg" class="transition-all opacity-0 scale-50" aria-hidden="true" style="flex-shrink: 0;"><path d="M15.1883 5.10908C15.3699 4.96398 15.6346 4.96153 15.8202 5.11592C16.0056 5.27067 16.0504 5.53125 15.9403 5.73605L15.8836 5.82003L8.38354 14.8202C8.29361 14.9279 8.16242 14.9925 8.02221 14.9989C7.88203 15.0051 7.74545 14.9526 7.64622 14.8534L4.14617 11.3533L4.08172 11.2752C3.95384 11.0811 3.97542 10.817 4.14617 10.6463C4.31693 10.4755 4.58105 10.4539 4.77509 10.5818L4.85321 10.6463L7.96556 13.7586L15.1161 5.1794L15.1883 5.10908Z"></path></svg></div></div></div></button></div></div><div class="text-text-500 font-small p-3.5 pb-0">release</div><div><pre class="code-block__code !my-0 !rounded-lg !text-sm !leading-relaxed" style="background: none; color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; font-family: var(--font-mono); direction: ltr; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; line-height: 1.5; tab-size: 2; hyphens: none; padding: 1em; margin: 0.5em 0px; overflow: auto; border-radius: 0.3em;"><code class="language-release" style="background: none; color: rgb(171, 178, 191); text-shadow: rgba(0, 0, 0, 0.3) 0px 1px; font-family: var(--font-mono); direction: ltr; text-align: left; white-space: pre; word-spacing: normal; word-break: normal; line-height: 1.5; tab-size: 2; hyphens: none;"><span><span>Security-Policy check now detects GitHub Private Vulnerability Reporting status via new privateVulnerabilityReportingEnabled probe</span></span></code></pre></div></div><hr class="border-border-200 border-t-0.5 my-3 mx-1.5" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid;"><h2 class="text-text-100 mt-3 -mb-1 text-[1.125rem] font-bold" style="font-style: normal; font-variant-caps: normal; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Additional Context</h2><p class="font-claude-response-body break-words whitespace-normal leading-[1.7]" style="font-style: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; white-space: normal; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; text-decoration-line: none; text-decoration-thickness: auto; text-decoration-style: solid; caret-color: rgb(255, 255, 255); color: rgb(255, 255, 255);">Private Vulnerability Reporting is GitHub's built-in feature that allows security researchers to privately report vulnerabilities directly through the GitHub interface. This probe helps maintainers understand whether they're leveraging this native GitHub capability alongside traditional SECURITY.md files.</p>