### PR TITLE
:seedling: cron: enable CDN purging in prod weekly scans

### DIFF
--- a/cron/config/config.yaml
+++ b/cron/config/config.yaml
@@ -39,6 +39,8 @@ additional-params:
     prefix-file:
     
   scorecard:
+    # for sending PURGE requests to CDN
+    api-base-url: https://api.scorecard.dev
     # API results bucket
     api-results-bucket-url: gs://ossf-scorecard-cron-results
     # TODO: Temporarily remove SAST and CI-Tests which require lot of GitHub API tokens.

--- a/cron/config/config_test.go
+++ b/cron/config/config_test.go
@@ -45,6 +45,7 @@ const (
 	prodInputBucketURL        = "gs://ossf-scorecard-input-projects"
 	prodInputBucketPrefix     = ""
 	prodInputBucketPrefixFile = ""
+	prodAPIBaseURL            = "https://api.scorecard.dev"
 )
 
 var (
@@ -54,6 +55,7 @@ var (
 		"prefix-file": prodInputBucketPrefixFile,
 	}
 	prodScorecardParams = map[string]string{
+		"api-base-url":               prodAPIBaseURL,
 		"api-results-bucket-url":     prodAPIBucketURL,
 		"blacklisted-checks":         prodBlacklistedChecks,
 		"cii-data-bucket-url":        prodCIIDataBucket,

--- a/cron/k8s/worker.release.yaml
+++ b/cron/k8s/worker.release.yaml
@@ -65,7 +65,7 @@ spec:
             - name: "SCORECARD_API_RESULTS_BUCKET_URL"
               value: "gs://ossf-scorecard-cron-releasetest-results"
             - name: "SCORECARD_API_BASE_URL"
-              value: "https://cdn.scorecard.dev"
+              value: "https://api-staging.scorecard.dev"
           volumeMounts:
             - name: config-volume
               mountPath: /etc/scorecard

--- a/cron/k8s/worker.yaml
+++ b/cron/k8s/worker.yaml
@@ -49,6 +49,11 @@ spec:
                 secretKeyRef:
                   name: gitlab
                   key: auth_token
+            - name: FASTLY_PURGE_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: fastly
+                  key: purge_token
           volumeMounts:
             - name: config-volume
               mountPath: /etc/scorecard


### PR DESCRIPTION
#### What kind of change does this PR introduce?

CDN update

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Only the release test version was purging the CDN, and using a temporary cdn.scorecard.dev

#### What is the new behavior (if this is a feature change)?**
Prod and staging both purge CDN results at the appropriate URL: api.scorecard.dev or api-staging.scorecard.dev

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
