### PR TITLE
docs: add remediation guidance for unpinned pip installs

### DIFF
--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -961,8 +961,18 @@ func collectUnpinnedPackageManagerDownload(startLine, endLine uint, node syntax.
 		return
 	}
 
-	// Pip install.
+		// Pip install.
 	if isPipDownload(c) {
+		pinned := !isPipUnpinnedDownload(c)
+		var remediation *finding.Remediation
+		if !pinned {
+			remediation = &finding.Remediation{
+				Text: "pin your Python dependencies by using a lockfile with hashes, e.g. `pip install --require-hashes -r requirements.txt`, " +
+					"or generate hashed requirements using pip-tools (pip-compile --generate-hashes). " +
+					"See https://pip.pypa.io/en/stable/topics/secure-installs/",
+			}
+		}
+
 		r.Dependencies = append(r.Dependencies,
 			checker.Dependency{
 				Location: &checker.File{
@@ -972,8 +982,9 @@ func collectUnpinnedPackageManagerDownload(startLine, endLine uint, node syntax.
 					EndOffset: endLine,
 					Snippet:   cmd,
 				},
-				Pinned: asBoolPointer(!isPipUnpinnedDownload(c)),
-				Type:   checker.DependencyUseTypePipCommand,
+				Pinned:      &pinned,
+				Type:        checker.DependencyUseTypePipCommand,
+				Remediation: remediation,
 			},
 		)
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?
Type: docs

This PR adds remediation guidance for unpinned pip installs.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Unpinned `pip install` commands are detected by the Pinned-Dependencies check, but no remediation guidance is provided to users.

#### What is the new behavior (if this is a feature change)?

When an unpinned `pip install` command is detected, the result now includes a remediation message suggesting:
- Using `--require-hashes`
- Using hashed lockfiles
- Generating hashed requirements with pip-tools
- Following pip secure install best practices

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #10871

#### Special notes for your reviewer

This change mirrors the remediation pattern already implemented for NuGet, providing more actionable guidance for Python users.

#### Does this PR introduce a user-facing change?

Yes. It adds remediation guidance for unpinned `pip install` commands in the Pinned-Dependencies check output.

```release-note
Adds remediation guidance for unpinned `pip install` commands in the Pinned-Dependencies check output.
```