### PR TITLE
fix: detect committer name/email as untrusted input in Dangerous Workflow check

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -45,8 +45,12 @@ func containsUntrustedContextPattern(variable string) bool {
 			`head_commit\.message|` +
 			`head_commit\.author\.email|` +
 			`head_commit\.author\.name|` +
+			`head_commit\.committer\.email|` +
+			`head_commit\.committer\.name|` +
 			`commits.*\.author\.email|` +
 			`commits.*\.author\.name|` +
+			`commits.*\.committer\.email|` +
+			`commits.*\.committer\.name|` +
 			`blocked_user\.name|` +
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -86,6 +86,26 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "head_commit committer name",
+			variable: "github.event.head_commit.committer.name",
+			expected: true,
+		},
+		{
+			name:     "head_commit committer email",
+			variable: "github.event.head_commit.committer.email",
+			expected: true,
+		},
+		{
+			name:     "commits committer name",
+			variable: "github.event.commits[0].committer.name",
+			expected: true,
+		},
+		{
+			name:     "commits committer email",
+			variable: "github.event.commits[0].committer.email",
+			expected: true,
+		},
+		{
 			name:     "blocked_user name",
 			variable: "github.event.pull_request.organization.blocked_user.name",
 			expected: true,


### PR DESCRIPTION
## Summary

- Adds missing `committer.name` and `committer.email` patterns to the `containsUntrustedContextPattern` function for both `head_commit` and `commits[*]` contexts
- The existing check detects `author.name`/`author.email` but misses the equivalent `committer` fields, which are independently controllable by attackers and equally dangerous for script injection
- Includes 4 new unit test cases covering all added patterns

Fixes #3915 (partially -- addresses the committer gap identified by @pnacht in the issue comments)

## Context

As noted by @pnacht in https://github.com/ossf/scorecard/issues/3915#issuecomment-2179226710, git committer identity is a separate field from author identity. An attacker can set arbitrary committer name/email values (e.g., via `GIT_COMMITTER_NAME`/`GIT_COMMITTER_EMAIL`), making these variables unsafe to use in inline shell scripts without sanitization.

## Test plan

- [x] Added unit tests for `head_commit.committer.name`, `head_commit.committer.email`, `commits[*].committer.name`, `commits[*].committer.email`
- [ ] Existing tests continue to pass

---

🤖 Generated with [Claude Code](https://claude.ai/code)