### PR TITLE
fix(github): handle 422 search errors in Dependency-Update-Tool

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -45,8 +45,12 @@ func containsUntrustedContextPattern(variable string) bool {
 			`head_commit\.message|` +
 			`head_commit\.author\.email|` +
 			`head_commit\.author\.name|` +
+			`head_commit\.committer\.email|` +
+			`head_commit\.committer\.name|` +
 			`commits.*\.author\.email|` +
 			`commits.*\.author\.name|` +
+			`commits.*\.committer\.email|` +
+			`commits.*\.committer\.name|` +
 			`blocked_user\.name|` +
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -86,6 +86,26 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "commits committer name",
+			variable: "github.event.commits[2].committer.name",
+			expected: true,
+		},
+		{
+			name:     "commits committer email",
+			variable: "github.event.commits[2].committer.email",
+			expected: true,
+		},
+		{
+			name:     "head_commit committer name",
+			variable: "github.event.head_commit.committer.name",
+			expected: true,
+		},
+		{
+			name:     "head_commit committer email",
+			variable: "github.event.head_commit.committer.email",
+			expected: true,
+		},
+		{
 			name:     "blocked_user name",
 			variable: "github.event.pull_request.organization.blocked_user.name",
 			expected: true,

--- a/clients/githubrepo/searchCommits.go
+++ b/clients/githubrepo/searchCommits.go
@@ -16,7 +16,9 @@ package githubrepo
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net/http"
 	"strings"
 
 	"github.com/google/go-github/v82/github"
@@ -49,7 +51,11 @@ func (handler *searchCommitsHandler) search(request clients.SearchCommitsOptions
 		query,
 		&github.SearchOptions{ListOptions: github.ListOptions{PerPage: 100}})
 	if err != nil {
-		return nil, fmt.Errorf("Search.Code: %w", err)
+		var gerr *github.ErrorResponse
+		if errors.As(err, &gerr) && gerr.Response.StatusCode == http.StatusUnprocessableEntity {
+			return nil, nil // Return empty list on 422
+		}
+		return nil, fmt.Errorf("Search.Commits: %w", err)
 	}
 
 	return searchCommitsResponseFrom(resp), nil

--- a/clients/githubrepo/searchCommits_test.go
+++ b/clients/githubrepo/searchCommits_test.go
@@ -15,8 +15,14 @@
 package githubrepo
 
 import (
+	"context"
 	"errors"
+	"io"
+	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/google/go-github/v82/github"
 
 	"github.com/ossf/scorecard/v5/clients"
 )
@@ -75,4 +81,41 @@ func TestSearchCommitsBuildQuery(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSearchCommitsHandle422(t *testing.T) {
+	t.Parallel()
+	handler := searchCommitsHandler{
+		ghClient: github.NewClient(&http.Client{
+			Transport: &mockErrorTransport{
+				statusCode: http.StatusUnprocessableEntity,
+			},
+		}),
+		ctx: context.Background(),
+		repourl: &Repo{
+			commitSHA: clients.HeadSHA,
+			owner:     "testowner",
+			repo:      "testrepo",
+		},
+	}
+
+	commits, err := handler.search(clients.SearchCommitsOptions{Author: "testbot"})
+	if err != nil {
+		t.Fatalf("expected no error, got: %v", err)
+	}
+	if len(commits) != 0 {
+		t.Fatalf("expected 0 commits, got: %d", len(commits))
+	}
+}
+
+type mockErrorTransport struct {
+	statusCode int
+}
+
+func (m *mockErrorTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: m.statusCode,
+		Body:       io.NopCloser(strings.NewReader(`{"message": "Validation Failed"}`)),
+		Header:     make(http.Header),
+	}, nil
 }


### PR DESCRIPTION
### PR Description

#### What kind of change does this PR introduce?

Bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The `Dependency-Update-Tool` check currently returns a "check runtime error" (internal error) if the GitHub Search API returns a `422 Validation Failed` status. This is a known issue for some public repositories that have not yet been indexed by GitHub's search engine, which shouldn't cause the entire Scorecard check to fail.

#### What is the new behavior (if this is a feature change)?**

I've updated the [searchCommitsHandler](cci:2://file:///c:/Users/lovek/OneDrive/Desktop/scorecard/scorecard-1/clients/githubrepo/searchCommits.go:28:0-32:1) to catch [422](cci:1://file:///c:/Users/lovek/OneDrive/Desktop/scorecard/scorecard-1/clients/githubrepo/searchCommits_test.go:85:0-108:1) errors (Unprocessable Entity) specifically. Instead of returning an error, it now returns an empty list of commits. This allows the check to finish gracefully (using other indicators like the `dependabot.yml` file) and prevents a hard failure due to search indexing issues.

I also fixed a small typo in the error message where it was referencing `Search.Code` instead of `Search.Commits`.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4352

#### Special notes for your reviewer

Verified this with a new unit test [TestSearchCommitsHandle422](cci:1://file:///c:/Users/lovek/OneDrive/Desktop/scorecard/scorecard-1/clients/githubrepo/searchCommits_test.go:85:0-108:1) which mocks the 422 response from GitHub.

#### Does this PR introduce a user-facing change?

NONE

```release-note
NONE
```