### PR TITLE
:sparkles: Consider GitHub immutable releases as signed

### DIFF
--- a/checks/evaluation/signed_releases.go
+++ b/checks/evaluation/signed_releases.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ossf/scorecard/v5/checker"
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/releasesAreImmutable"
 	"github.com/ossf/scorecard/v5/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveProvenance"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveVerifiedProvenance"
@@ -37,6 +38,7 @@ func SignedReleases(name string,
 ) checker.CheckResult {
 	expectedProbes := []string{
 		releasesAreSigned.Probe,
+		releasesAreImmutable.Probe,
 		releasesHaveProvenance.Probe,
 	}
 
@@ -45,9 +47,11 @@ func SignedReleases(name string,
 		return checker.CreateRuntimeErrorResult(name, e)
 	}
 
-	// keep track of releases which have provenance so we don't log about signatures
-	// on our second pass through below
+	// keep track of releases which have provenance or signatures so we don't log
+	// redundant false findings on our second pass through below
 	hasProvenance := make(map[string]bool)
+	hasSignature := make(map[string]bool)
+	hasImmutable := make(map[string]bool)
 
 	// Debug all releases and check for OutcomeNotApplicable
 	// All probes have OutcomeNotApplicable in case the project has no
@@ -78,8 +82,15 @@ func SignedReleases(name string,
 			loggedReleases = append(loggedReleases, releaseName)
 		}
 
-		if f.Probe == releasesHaveProvenance.Probe && f.Outcome == finding.OutcomeTrue {
-			hasProvenance[releaseName] = true
+		if f.Outcome == finding.OutcomeTrue {
+			switch f.Probe {
+			case releasesHaveProvenance.Probe:
+				hasProvenance[releaseName] = true
+			case releasesAreSigned.Probe:
+				hasSignature[releaseName] = true
+			case releasesAreImmutable.Probe:
+				hasImmutable[releaseName] = true
+			}
 		}
 	}
 
@@ -108,7 +119,7 @@ func SignedReleases(name string,
 			logLevel = checker.DetailInfo
 			totalTrue++
 			switch f.Probe {
-			case releasesAreSigned.Probe:
+			case releasesAreSigned.Probe, releasesAreImmutable.Probe:
 				if _, ok := releaseMap[releaseName]; !ok {
 					releaseMap[releaseName] = 8
 				}
@@ -117,8 +128,15 @@ func SignedReleases(name string,
 			}
 		case finding.OutcomeFalse:
 			logLevel = checker.DetailWarn
-			if f.Probe == releasesAreSigned.Probe && hasProvenance[releaseName] {
-				continue
+			switch f.Probe {
+			case releasesAreSigned.Probe:
+				if hasProvenance[releaseName] || hasImmutable[releaseName] {
+					continue
+				}
+			case releasesAreImmutable.Probe:
+				if hasProvenance[releaseName] || hasSignature[releaseName] {
+					continue
+				}
 			}
 		default:
 			logLevel = checker.DetailDebug
@@ -161,6 +179,8 @@ func getReleaseName(f *finding.Finding) string {
 	switch f.Probe {
 	case releasesAreSigned.Probe:
 		key = releasesAreSigned.ReleaseNameKey
+	case releasesAreImmutable.Probe:
+		key = releasesAreImmutable.ReleaseNameKey
 	case releasesHaveProvenance.Probe:
 		key = releasesHaveProvenance.ReleaseNameKey
 	}

--- a/checks/evaluation/signed_releases_test.go
+++ b/checks/evaluation/signed_releases_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/ossf/scorecard/v5/checker"
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/releasesAreImmutable"
 	"github.com/ossf/scorecard/v5/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveProvenance"
 	scut "github.com/ossf/scorecard/v5/utests"
@@ -64,6 +65,16 @@ func provenanceProbe(release, asset int, outcome finding.Outcome) finding.Findin
 	}
 }
 
+func immutableProbe(release int, outcome finding.Outcome) finding.Finding {
+	return finding.Finding{
+		Probe:   releasesAreImmutable.Probe,
+		Outcome: outcome,
+		Values: map[string]string{
+			releasesAreImmutable.ReleaseNameKey: fmt.Sprintf("v%d", release),
+		},
+	}
+}
+
 func TestSignedReleases(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -75,6 +86,7 @@ func TestSignedReleases(t *testing.T) {
 			name: "Has one release that is signed but no provenance",
 			findings: []finding.Finding{
 				signedProbe(0, 0, finding.OutcomeTrue),
+				immutableProbe(0, finding.OutcomeFalse),
 				provenanceProbe(0, 0, finding.OutcomeFalse),
 			},
 			result: scut.TestReturn{
@@ -88,6 +100,7 @@ func TestSignedReleases(t *testing.T) {
 			name: "Has one release that is signed and has provenance",
 			findings: []finding.Finding{
 				signedProbe(0, 0, finding.OutcomeTrue),
+				immutableProbe(0, finding.OutcomeFalse),
 				provenanceProbe(0, 0, finding.OutcomeTrue),
 			},
 			result: scut.TestReturn{
@@ -100,11 +113,40 @@ func TestSignedReleases(t *testing.T) {
 			name: "Has one release that is not signed but has provenance",
 			findings: []finding.Finding{
 				signedProbe(0, 0, finding.OutcomeFalse),
+				immutableProbe(0, finding.OutcomeFalse),
 				provenanceProbe(0, 0, finding.OutcomeTrue),
 			},
 			result: scut.TestReturn{
 				Score:         checker.MaxResultScore,
 				NumberOfInfo:  1,
+				NumberOfWarn:  0,
+				NumberOfDebug: 1,
+			},
+		},
+		{
+			name: "Has one release that is immutable but not signed and no provenance",
+			findings: []finding.Finding{
+				signedProbe(0, 0, finding.OutcomeFalse),
+				immutableProbe(0, finding.OutcomeTrue),
+				provenanceProbe(0, 0, finding.OutcomeFalse),
+			},
+			result: scut.TestReturn{
+				Score:         8,
+				NumberOfInfo:  1,
+				NumberOfWarn:  1,
+				NumberOfDebug: 1,
+			},
+		},
+		{
+			name: "Has one release that is immutable and has provenance",
+			findings: []finding.Finding{
+				signedProbe(0, 0, finding.OutcomeFalse),
+				immutableProbe(0, finding.OutcomeTrue),
+				provenanceProbe(0, 0, finding.OutcomeTrue),
+			},
+			result: scut.TestReturn{
+				Score:         10,
+				NumberOfInfo:  2,
 				NumberOfWarn:  0,
 				NumberOfDebug: 1,
 			},
@@ -115,18 +157,21 @@ func TestSignedReleases(t *testing.T) {
 			findings: []finding.Finding{
 				// Release 1:
 				signedProbe(release0, asset1, finding.OutcomeTrue),
+				immutableProbe(release0, finding.OutcomeFalse),
 				provenanceProbe(release0, asset0, finding.OutcomeFalse),
 				// Release 2
 				signedProbe(release1, asset0, finding.OutcomeFalse),
+				immutableProbe(release1, finding.OutcomeFalse),
 				provenanceProbe(release1, asset0, finding.OutcomeFalse),
 				// Release 3
 				signedProbe(release2, asset0, finding.OutcomeFalse),
+				immutableProbe(release2, finding.OutcomeFalse),
 				provenanceProbe(release2, asset1, finding.OutcomeTrue),
 			},
 			result: scut.TestReturn{
 				Score:         6,
 				NumberOfInfo:  2,
-				NumberOfWarn:  3,
+				NumberOfWarn:  4,
 				NumberOfDebug: 3,
 			},
 		},
@@ -135,24 +180,29 @@ func TestSignedReleases(t *testing.T) {
 			findings: []finding.Finding{
 				// Release 1:
 				signedProbe(release0, asset1, finding.OutcomeTrue),
+				immutableProbe(release0, finding.OutcomeFalse),
 				provenanceProbe(release0, asset1, finding.OutcomeFalse),
 				// Release 2:
 				signedProbe(release1, asset0, finding.OutcomeTrue),
+				immutableProbe(release1, finding.OutcomeFalse),
 				provenanceProbe(release1, asset0, finding.OutcomeFalse),
 				// Release 3:
 				signedProbe(release2, asset0, finding.OutcomeFalse),
+				immutableProbe(release2, finding.OutcomeFalse),
 				provenanceProbe(release2, asset0, finding.OutcomeTrue),
 				// Release 4, Asset 1:
 				signedProbe(release3, asset0, finding.OutcomeFalse),
+				immutableProbe(release3, finding.OutcomeFalse),
 				provenanceProbe(release3, asset0, finding.OutcomeTrue),
 				// Release 5, Asset 1:
 				signedProbe(release4, asset0, finding.OutcomeFalse),
+				immutableProbe(release4, finding.OutcomeFalse),
 				provenanceProbe(release4, asset0, finding.OutcomeFalse),
 			},
 			result: scut.TestReturn{
 				Score:         7,
 				NumberOfInfo:  4,
-				NumberOfWarn:  4,
+				NumberOfWarn:  5,
 				NumberOfDebug: 5,
 			},
 		},
@@ -161,18 +211,54 @@ func TestSignedReleases(t *testing.T) {
 			findings: []finding.Finding{
 				// Release 1:
 				signedProbe(release0, asset1, finding.OutcomeTrue),
+				immutableProbe(release0, finding.OutcomeFalse),
 				provenanceProbe(release0, asset1, finding.OutcomeFalse),
 				// Release 2:
 				signedProbe(release1, asset0, finding.OutcomeTrue),
+				immutableProbe(release1, finding.OutcomeFalse),
 				provenanceProbe(release1, asset0, finding.OutcomeFalse),
 				// Release 3:
 				signedProbe(release2, asset0, finding.OutcomeTrue),
+				immutableProbe(release2, finding.OutcomeFalse),
 				provenanceProbe(release2, asset0, finding.OutcomeFalse),
 				// Release 4:
 				signedProbe(release3, asset0, finding.OutcomeTrue),
+				immutableProbe(release3, finding.OutcomeFalse),
 				provenanceProbe(release3, asset0, finding.OutcomeFalse),
 				// Release 5:
 				signedProbe(release4, asset0, finding.OutcomeTrue),
+				immutableProbe(release4, finding.OutcomeFalse),
+				provenanceProbe(release4, asset0, finding.OutcomeFalse),
+			},
+			result: scut.TestReturn{
+				Score:         8,
+				NumberOfInfo:  5,
+				NumberOfWarn:  5,
+				NumberOfDebug: 5,
+			},
+		},
+		{
+			name: "5 releases. All are immutable.",
+			findings: []finding.Finding{
+				// Release 1:
+				signedProbe(release0, asset1, finding.OutcomeFalse),
+				immutableProbe(release0, finding.OutcomeTrue),
+				provenanceProbe(release0, asset1, finding.OutcomeFalse),
+				// Release 2:
+				signedProbe(release1, asset0, finding.OutcomeFalse),
+				immutableProbe(release1, finding.OutcomeTrue),
+				provenanceProbe(release1, asset0, finding.OutcomeFalse),
+				// Release 3:
+				signedProbe(release2, asset0, finding.OutcomeFalse),
+				immutableProbe(release2, finding.OutcomeTrue),
+				provenanceProbe(release2, asset0, finding.OutcomeFalse),
+				// Release 4:
+				signedProbe(release3, asset0, finding.OutcomeFalse),
+				immutableProbe(release3, finding.OutcomeTrue),
+				provenanceProbe(release3, asset0, finding.OutcomeFalse),
+				// Release 5:
+				signedProbe(release4, asset0, finding.OutcomeFalse),
+				immutableProbe(release4, finding.OutcomeTrue),
 				provenanceProbe(release4, asset0, finding.OutcomeFalse),
 			},
 			result: scut.TestReturn{
@@ -188,22 +274,28 @@ func TestSignedReleases(t *testing.T) {
 				// Release 1:
 				// Release 1, Asset 1:
 				signedProbe(release0, asset0, finding.OutcomeTrue),
+				immutableProbe(release0, finding.OutcomeFalse),
 				provenanceProbe(release0, asset0, finding.OutcomeTrue),
 				// Release 2:
 				// Release 2, Asset 1:
 				signedProbe(release1, asset0, finding.OutcomeTrue),
+				immutableProbe(release1, finding.OutcomeFalse),
 				provenanceProbe(release1, asset0, finding.OutcomeTrue),
 				// Release 3, Asset 1:
 				signedProbe(release2, asset0, finding.OutcomeTrue),
+				immutableProbe(release2, finding.OutcomeFalse),
 				provenanceProbe(release2, asset0, finding.OutcomeTrue),
 				// Release 4, Asset 1:
 				signedProbe(release3, asset0, finding.OutcomeTrue),
+				immutableProbe(release3, finding.OutcomeFalse),
 				provenanceProbe(release3, asset0, finding.OutcomeTrue),
 				// Release 5, Asset 1:
 				signedProbe(release4, asset0, finding.OutcomeTrue),
+				immutableProbe(release4, finding.OutcomeFalse),
 				provenanceProbe(release4, asset0, finding.OutcomeTrue),
 				// Release 6, Asset 1:
 				signedProbe(release5, asset0, finding.OutcomeTrue),
+				immutableProbe(release5, finding.OutcomeFalse),
 				provenanceProbe(release5, asset0, finding.OutcomeTrue),
 			},
 			result: scut.TestReturn{
@@ -265,6 +357,18 @@ func Test_getReleaseName(t *testing.T) {
 						releasesAreSigned.AssetNameKey:   "artifact-1",
 					},
 					Probe: releasesAreSigned.Probe,
+				},
+			},
+			want: "v1",
+		},
+		{
+			name: "immutable release",
+			args: args{
+				f: &finding.Finding{
+					Values: map[string]string{
+						releasesAreImmutable.ReleaseNameKey: "v1",
+					},
+					Probe: releasesAreImmutable.Probe,
 				},
 			},
 			want: "v1",

--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -440,6 +440,98 @@ func TestSignedRelease(t *testing.T) {
 		},
 
 		{
+			name: "Releases with immutable release",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					IsImmutable:     true,
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.txt",
+							URL:  "http://foo.com/v1.0.0/foo.txt",
+						},
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 8,
+			},
+		},
+		{
+			name: "Releases with immutable release and signed artifact",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					IsImmutable:     true,
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.sig",
+							URL:  "http://foo.com/v1.0.0/foo.sig",
+						},
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 8,
+			},
+		},
+		{
+			name: "Releases with immutable release and provenance",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					IsImmutable:     true,
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.intoto.jsonl",
+							URL:  "http://foo.com/v1.0.0/foo.intoto.jsonl",
+						},
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 10,
+			},
+		},
+		{
+			name: "Multiple releases - some immutable, some not",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					IsImmutable:     true,
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.txt",
+							URL:  "http://foo.com/v1.0.0/foo.txt",
+						},
+					},
+				},
+				{
+					TagName:         "v2.0.0",
+					URL:             "http://foo.com/v2.0.0",
+					TargetCommitish: "master",
+					IsImmutable:     false,
+					Assets: []clients.ReleaseAsset{
+						{
+							Name: "foo.txt",
+							URL:  "http://foo.com/v2.0.0/foo.txt",
+						},
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 4,
+			},
+		},
+		{
 			name: "Error getting releases",
 			err:  errors.New("Error getting releases"),
 			expected: checker.CheckResult{

--- a/clients/githubrepo/releases.go
+++ b/clients/githubrepo/releases.go
@@ -73,6 +73,7 @@ func releasesFrom(data []*github.RepositoryRelease) []clients.Release {
 			TagName:         r.GetTagName(),
 			URL:             r.GetURL(),
 			TargetCommitish: r.GetTargetCommitish(),
+			IsImmutable:     r.GetImmutable(),
 		}
 		for _, a := range r.Assets {
 			release.Assets = append(release.Assets, clients.ReleaseAsset{

--- a/clients/release.go
+++ b/clients/release.go
@@ -20,6 +20,7 @@ type Release struct {
 	URL             string
 	TargetCommitish string
 	Assets          []ReleaseAsset
+	IsImmutable     bool
 }
 
 // ReleaseAsset is part of the Release bundle.

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -411,6 +411,21 @@ For supported ecosystem, the probe returns OutcomeFalse per unpinned dependency.
 If the project has no supported dependencies, the probe returns OutcomeNotApplicable.
 
 
+## releasesAreImmutable
+
+**Lifecycle**: experimental
+
+**Description**: Check that the project's GitHub releases are marked as immutable.
+
+**Motivation**: Immutable releases prevent release artifacts from being modified or deleted after publication, ensuring consumers always receive the same artifacts that were originally published.
+
+**Implementation**: The probe checks whether the last 5 releases on GitHub are marked as immutable.
+
+**Outcomes**: For each of the last 5 releases, the probe returns OutcomeTrue if the release is marked as immutable.
+For each of the last 5 releases, the probe returns OutcomeFalse if the release is not marked as immutable.
+If the project has no releases, the probe returns OutcomeNotApplicable.
+
+
 ## releasesAreSigned
 
 **Lifecycle**: stable

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ossf/scorecard/v5/probes/jobLevelPermissions"
 	"github.com/ossf/scorecard/v5/probes/packagedWithAutomatedWorkflow"
 	"github.com/ossf/scorecard/v5/probes/pinsDependencies"
+	"github.com/ossf/scorecard/v5/probes/releasesAreImmutable"
 	"github.com/ossf/scorecard/v5/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveProvenance"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveVerifiedProvenance"
@@ -140,6 +141,7 @@ var (
 	}
 	SignedReleases = []ProbeImpl{
 		releasesAreSigned.Run,
+		releasesAreImmutable.Run,
 		releasesHaveProvenance.Run,
 	}
 	BranchProtection = []ProbeImpl{

--- a/probes/releasesAreImmutable/def.yml
+++ b/probes/releasesAreImmutable/def.yml
@@ -1,0 +1,37 @@
+# Copyright 2025 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: releasesAreImmutable
+lifecycle: experimental
+short: Check that the project's GitHub releases are marked as immutable.
+motivation: >
+  Immutable releases prevent release artifacts from being modified or deleted after publication,
+  ensuring consumers always receive the same artifacts that were originally published.
+implementation: >
+  The probe checks whether the last 5 releases on GitHub are marked as immutable.
+outcome:
+  - For each of the last 5 releases, the probe returns OutcomeTrue if the release is marked as immutable.
+  - For each of the last 5 releases, the probe returns OutcomeFalse if the release is not marked as immutable.
+  - If the project has no releases, the probe returns OutcomeNotApplicable.
+remediation:
+  onOutcome: False
+  effort: Low
+  text:
+    - Enable immutable releases for your repository. See https://docs.github.com/repositories/releasing-projects-on-github/managing-releases-in-a-repository
+    - When creating a release, mark it as immutable to prevent future modification of release assets.
+ecosystem:
+  languages:
+    - all
+  clients:
+    - github

--- a/probes/releasesAreImmutable/impl.go
+++ b/probes/releasesAreImmutable/impl.go
@@ -1,0 +1,103 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package releasesAreImmutable
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/checknames"
+	"github.com/ossf/scorecard/v5/internal/probes"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/uerror"
+)
+
+func init() {
+	probes.MustRegister(Probe, Run, []checknames.CheckName{checknames.SignedReleases})
+}
+
+//go:embed *.yml
+var fs embed.FS
+
+const (
+	Probe           = "releasesAreImmutable"
+	ReleaseNameKey  = "releaseName"
+	releaseLookBack = 5
+)
+
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	if raw == nil {
+		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
+	}
+
+	var findings []finding.Finding
+
+	releases := raw.SignedReleasesResults.Releases
+
+	totalReleases := 0
+	for releaseIndex, release := range releases {
+		if releaseIndex >= releaseLookBack {
+			break
+		}
+
+		if len(release.Assets) == 0 {
+			continue
+		}
+
+		totalReleases++
+
+		loc := &finding.Location{
+			Type: finding.FileTypeURL,
+			Path: release.URL,
+		}
+
+		if release.IsImmutable {
+			f, err := finding.NewWith(fs, Probe,
+				fmt.Sprintf("immutable release: %s", release.TagName),
+				loc,
+				finding.OutcomeTrue)
+			if err != nil {
+				return nil, Probe, fmt.Errorf("create finding: %w", err)
+			}
+			f = f.WithValue(ReleaseNameKey, release.TagName)
+			findings = append(findings, *f)
+			continue
+		}
+
+		// Release is not immutable
+		f, err := finding.NewWith(fs, Probe,
+			fmt.Sprintf("release artifact %s is not immutable", release.TagName),
+			loc,
+			finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		f = f.WithValue(ReleaseNameKey, release.TagName)
+		findings = append(findings, *f)
+	}
+
+	if len(findings) == 0 {
+		f, err := finding.NewWith(fs, Probe,
+			"no GitHub releases found",
+			nil,
+			finding.OutcomeNotApplicable)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		findings = append(findings, *f)
+	}
+	return findings, Probe, nil
+}

--- a/probes/releasesAreImmutable/impl_test.go
+++ b/probes/releasesAreImmutable/impl_test.go
@@ -1,0 +1,188 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package releasesAreImmutable
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/test"
+)
+
+func Test_Run(t *testing.T) {
+	t.Parallel()
+	//nolint:govet
+	tests := []struct {
+		name     string
+		raw      *checker.RawResults
+		outcomes []finding.Outcome
+		err      error
+	}{
+		{
+			name: "No releases returns NotApplicable.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeNotApplicable,
+			},
+		},
+		{
+			name: "One immutable release.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						{
+							TagName:     "v1.0",
+							IsImmutable: true,
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+							},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
+			},
+		},
+		{
+			name: "One non-immutable release.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						{
+							TagName:     "v1.0",
+							IsImmutable: false,
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+							},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeFalse,
+			},
+		},
+		{
+			name: "Mix of immutable and non-immutable releases.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						{
+							TagName:     "v1.0",
+							IsImmutable: true,
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+							},
+						},
+						{
+							TagName:     "v2.0",
+							IsImmutable: false,
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+							},
+						},
+						{
+							TagName:     "v3.0",
+							IsImmutable: true,
+							Assets: []clients.ReleaseAsset{
+								{Name: "binary.tar.gz"},
+							},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
+				finding.OutcomeFalse,
+				finding.OutcomeTrue,
+			},
+		},
+		{
+			name: "Only checks last 5 releases.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						immutableRelease("v1.0"),
+						immutableRelease("v2.0"),
+						immutableRelease("v3.0"),
+						immutableRelease("v4.0"),
+						immutableRelease("v5.0"),
+						immutableRelease("v6.0"),
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+			},
+		},
+		{
+			name: "Release with no assets is skipped.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						immutableRelease("v1.0"),
+						{TagName: "v2.0", IsImmutable: true, Assets: []clients.ReleaseAsset{}},
+						immutableRelease("v3.0"),
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
+				finding.OutcomeTrue,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings, s, err := Run(tt.raw)
+			if !cmp.Equal(tt.err, err, cmpopts.EquateErrors()) {
+				t.Errorf("mismatch (-want +got):\n%s", cmp.Diff(tt.err, err, cmpopts.EquateErrors()))
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(Probe, s); diff != "" {
+				t.Errorf("mismatch (-want +got):\n%s", diff)
+			}
+			test.AssertOutcomes(t, findings, tt.outcomes)
+		})
+	}
+}
+
+func immutableRelease(version string) clients.Release {
+	return clients.Release{
+		TagName:     version,
+		IsImmutable: true,
+		Assets: []clients.ReleaseAsset{
+			{Name: "binary.tar.gz"},
+		},
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

New feature

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

GitHub release immutability is not considered.

#### What is the new behavior (if this is a feature change)?

Consider GitHub releases that are immutable as signed as they include a GitHub attestation for the release.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #4823

#### Special notes for your reviewer

None.

#### Does this PR introduce a user-facing change?

```release-note
Consider GitHub releases that are immutable as signed.
```
