### PR TITLE
:seedling: Add Jamie Magee as a maintainer for Azure DevOps

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,3 +9,6 @@
 # Docs
 *.md @ossf/scorecard-doc-maintainers
 /docs/ @ossf/scorecard-doc-maintainers
+
+# Azure DevOps
+/clients/azuredevopsrepo/ @ossf/scorecard-azure-maintainers

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -18,6 +18,10 @@ The current standing Steering Committee members are as follows:
 - Adam Korczynski ([@AdamKorcz](https://github.com/AdamKorcz)), ADA Logics
 - Spencer Schrock ([@spencerschrock](https://github.com/spencerschrock)), Google
 
+## `scorecard-azure-maintainers`
+
+- Jamie Magee ([@JamieMagee](https://github.com/JamieMagee)), Microsoft
+
 ## `scorecard-doc-maintainers`
 
 -


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Adds a CODEOWNERS entry so I get review requests for changes to `/clients/azuredevopsrepo/`.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Changes to `/clients/azuredevopsrepo/` only notify `@ossf/scorecard-maintainers` for review.

#### What is the new behavior (if this is a feature change)?

I am also requested for review on changes to `/clients/azuredevopsrepo/`.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

NONE

#### Does this PR introduce a user-facing change?

```release-note
Add Jamie Magee as a maintainer for Azure DevOps
```