### PR TITLE
fix: detect committer fields as untrusted input in dangerous workflows

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -45,8 +45,12 @@ func containsUntrustedContextPattern(variable string) bool {
 			`head_commit\.message|` +
 			`head_commit\.author\.email|` +
 			`head_commit\.author\.name|` +
+			`head_commit\.committer\.email|` +
+			`head_commit\.committer\.name|` +
 			`commits.*\.author\.email|` +
 			`commits.*\.author\.name|` +
+			`commits.*\.committer\.email|` +
+			`commits.*\.committer\.name|` +
 			`blocked_user\.name|` +
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -86,6 +86,26 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "commits committer name",
+			variable: "github.event.commits[2].committer.name",
+			expected: true,
+		},
+		{
+			name:     "commits committer email",
+			variable: "github.event.commits[2].committer.email",
+			expected: true,
+		},
+		{
+			name:     "head_commit committer name",
+			variable: "github.event.head_commit.committer.name",
+			expected: true,
+		},
+		{
+			name:     "head_commit committer email",
+			variable: "github.event.head_commit.committer.email",
+			expected: true,
+		},
+		{
 			name:     "blocked_user name",
 			variable: "github.event.pull_request.organization.blocked_user.name",
 			expected: true,


### PR DESCRIPTION
## Summary

The dangerous workflow check detects `head_commit.author.{email,name}` and `commits[*].author.{email,name}` as untrusted input, but does not detect the equivalent `committer` fields. The `committer` fields are equally attacker-controlled and should be flagged as dangerous.

## Changes

- Added `head_commit.committer.{email,name}` and `commits[*].committer.{email,name}` to the untrusted context pattern regex
- Added corresponding test cases for all new patterns

## References

- Mentioned in #3915: @pnacht noted that `github.event.{head_commit/commits[*]}.committer.{name/email}` are potentially risky but not covered
- [GitHub's untrusted input documentation](https://securitylab.github.com/research/github-actions-untrusted-input/)