### PR TITLE
:bug: Fix scorecard completion generates

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -49,7 +49,7 @@ var errChecksFailed = errors.New("one or more checks failed during execution")
 
 const (
 	scorecardLong = "A program that shows the OpenSSF scorecard for an open source software."
-	scorecardUse  = `./scorecard (--repo=<repo> | --local=<folder> | --org=<organization> | ` +
+	scorecardUse  = `scorecard (--repo=<repo> | --local=<folder> | --org=<organization> | ` +
 		`--{npm,pypi,rubygems,nuget}=<package_name>) [--checks=check1,...] [--show-details] [--show-annotations]`
 	scorecardShort = "OpenSSF Scorecard"
 )


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Now you could run:
```
source <(scorecard completion bash)
```
and then use competion for installed scorecard:
```
./scorecard ver<TAB>  # works
scorecard ver<TAB>    # doesn't work
```

#### What is the new behavior

Changed `./scorecard` command in help message and completion to `scorecard`.
Now you could run:
```
source <(scorecard completion bash)
```
and then use competion for installed scorecard:
```
scorecard ver<TAB> 
```
#### Which issue(s) this PR fixes
Fixes #5019 


#### Special notes for your reviewer

It will break completion for users who put scorecard in local directory and run it from there.

#### Does this PR introduce a user-facing change?

```release-note
Fixed competion for scorecard installed in PATH
```

