### PR TITLE
:bug: checks/pinned: strip inline comments from uses value before evaluatingchecks/pinned: strip inline comments from uses value before evaluating

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -831,6 +831,9 @@ func newGHActionDependency(uses, pathfn string, line int) checker.Dependency {
 }
 
 func isActionDependencyPinned(actionUses string) bool {
+	// Strip inline YAML comment (e.g. "# pinned to main") before evaluating.
+	actionUses = strings.SplitN(actionUses, " #", 2)[0]
+
 	localActionRegex := regexp.MustCompile(`^\..+[^/]`)
 	if localActionRegex.MatchString(actionUses) {
 		return true

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -184,6 +184,16 @@ func TestGithubWorkflowPinningPattern(t *testing.T) {
 			uses:     "docker://rhysd/actionlint:latest@sha256:5f957b2a08d223e48133e1a914ed046bea12e578fe2f6ae4de47fdbe691a2468",
 			ispinned: true,
 		},
+		{
+			desc:     "pinned SHA with inline comment should be pinned",
+			uses:     "actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # main",
+			ispinned: true,
+		},
+		{
+			desc:     "mutable branch ref remains unpinned",
+			uses:     "actions/checkout@main",
+			ispinned: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {


### PR DESCRIPTION
Fixes #5004

## Problem
GitHub Actions workflow steps can include inline YAML comments after the `uses` value:
```yaml
- uses: actions/checkout@a81bbbf8298c0fa03ea29cdc473d45769f953675 # main
```
The comment was being included in the ref evaluation, causing valid pinned SHAs to be flagged as unpinned dependencies.

## Fix
Strip everything from ` #` onwards inside `isActionDependencyPinned` before evaluating the ref. This is the single evaluation point so fixing it here handles all callers.

## Tests
Added two regression tests to `TestGithubWorkflowPinningPattern`:
- `pinned SHA with inline comment should be pinned` → `true`
- `mutable branch ref remains unpinned` → `false`