### PR TITLE
:book: docs: expand SAST check description to list all detected tools

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -529,20 +529,36 @@ SAST is testing run on source code before the application is run. Using SAST
 tools can prevent known classes of bugs from being inadvertently introduced in the
 codebase.
 
-The checks currently looks for known GitHub apps such as
-[CodeQL](https://codeql.github.com/) (github-code-scanning) or
-[SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
-of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
-[LGTM](https://lgtm.com/) service until its forthcoming shutdown.
+The check currently detects the following SAST tools, either via known
+GitHub apps in recent (~30) merged pull requests or via GitHub workflow
+definitions:
+- [CodeQL](https://codeql.github.com/) - GitHub workflow uses
+  `github/codeql-action/analyze`, or the `github-code-scanning` app
+  appears on recent PRs.
+- [SonarCloud / SonarQube](https://www.sonarsource.com/) - detected via
+  the `<sonar.host.url>` element in `pom.xml`, or via the `sonarcloud` /
+  `sonarqubecloud` GitHub apps on recent PRs.
+- [Snyk](https://snyk.io/) - any GitHub workflow that uses an action
+  matching `snyk/actions/*`.
+- [Pysa](https://github.com/facebook/pysa-action) - GitHub workflow
+  uses `facebook/pysa-action`.
+- [Qodana](https://www.jetbrains.com/qodana/) - GitHub workflow uses
+  `JetBrains/qodana-action`.
+
+The check also retains historical detection logic for the
+[LGTM](https://lgtm.com/) service (`lgtm-com` GitHub app), but LGTM was
+[sunset in December 2022](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)
+and no longer produces a usable detection signal in practice.
 
 Note: A project that fulfills this criterion with other tools may still receive
 a low score on this test. There are many ways to implement SAST, and it is
-challenging for an automated tool like Scorecard to detect them all. A low score
-is therefore not a definitive indication that the project is at risk.
+challenging for an automated tool like Scorecard to detect them all. A low
+score is therefore not a definitive indication that the project is at risk.
  
 
 **Remediation steps**
 - Run CodeQL checks in your CI/CD by following the instructions [here](https://github.com/github/codeql-action#usage).
+- If CodeQL is not suitable for your stack, configure one of the other Scorecard-detected SAST integrations: SonarCloud / SonarQube, Snyk (`snyk/actions/*`), Pysa (`facebook/pysa-action`), or Qodana (`JetBrains/qodana-action`).
 
 ## SBOM 
 

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -546,20 +546,40 @@ checks:
       tools can prevent known classes of bugs from being inadvertently introduced in the
       codebase.
 
-      The checks currently looks for known GitHub apps such as
-      [CodeQL](https://codeql.github.com/) (github-code-scanning) or
-      [SonarCloud](https://sonarcloud.io/) in the recent (~30) merged PRs, or the use
-      of "github/codeql-action" in a GitHub workflow. It also checks for the deprecated
-      [LGTM](https://lgtm.com/) service until its forthcoming shutdown.
+      The check currently detects the following SAST tools, either via known
+      GitHub apps in recent (~30) merged pull requests or via GitHub workflow
+      definitions:
+      - [CodeQL](https://codeql.github.com/) - GitHub workflow uses
+        `github/codeql-action/analyze`, or the `github-code-scanning` app
+        appears on recent PRs.
+      - [SonarCloud / SonarQube](https://www.sonarsource.com/) - detected via
+        the `<sonar.host.url>` element in `pom.xml`, or via the `sonarcloud` /
+        `sonarqubecloud` GitHub apps on recent PRs.
+      - [Snyk](https://snyk.io/) - any GitHub workflow that uses an action
+        matching `snyk/actions/*`.
+      - [Pysa](https://github.com/facebook/pysa-action) - GitHub workflow
+        uses `facebook/pysa-action`.
+      - [Qodana](https://www.jetbrains.com/qodana/) - GitHub workflow uses
+        `JetBrains/qodana-action`.
+
+      The check also retains historical detection logic for the
+      [LGTM](https://lgtm.com/) service (`lgtm-com` GitHub app), but LGTM was
+      [sunset in December 2022](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/)
+      and no longer produces a usable detection signal in practice.
 
       Note: A project that fulfills this criterion with other tools may still receive
       a low score on this test. There are many ways to implement SAST, and it is
-      challenging for an automated tool like Scorecard to detect them all. A low score
-      is therefore not a definitive indication that the project is at risk.
+      challenging for an automated tool like Scorecard to detect them all. A low
+      score is therefore not a definitive indication that the project is at risk.
     remediation:
       - >-
         Run CodeQL checks in your CI/CD by following the instructions
         [here](https://github.com/github/codeql-action#usage).
+      - >-
+        If CodeQL is not suitable for your stack, configure one of the other
+        Scorecard-detected SAST integrations: SonarCloud / SonarQube, Snyk
+        (`snyk/actions/*`), Pysa (`facebook/pysa-action`), or Qodana
+        (`JetBrains/qodana-action`).
 
   SBOM:
     risk: Medium


### PR DESCRIPTION
The SAST check (`checks/raw/sast.go`) detects CodeQL, SonarCloud/SonarQube, Snyk, Pysa, and Qodana, but the description in `checks.yaml` only mentions CodeQL and SonarCloud. The description also notes LGTM is awaiting its "forthcoming shutdown," but LGTM was sunset in December 2022. This commit updates the description to enumerate all five currently-detected SAST tools with their specific detection mechanisms (workflow action names or GitHub app slugs), corrects the LGTM status, and adds a remediation alternative for projects that cannot use CodeQL. Both `checks.yaml` and the auto-generated `docs/checks.md` are updated together per `CONTRIBUTING.md`.

#### What kind of change does this PR introduce?

Documentation update — no code changes.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The SAST check description in `docs/checks/internal/checks.yaml` mentions only CodeQL and SonarCloud as detected SAST tools, even though `checks/raw/sast.go` also detects Snyk (`snyk/actions/*`), Pysa (`facebook/pysa-action`), and Qodana (`JetBrains/qodana-action`). The description also states LGTM is "awaiting its forthcoming shutdown," but LGTM was [sunset in December 2022](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/) — that wording has been stale for over three years.

#### What is the new behavior (if this is a feature change)?

The description now enumerates all five SAST tools the check detects, each with its specific detection mechanism:

| Tool | Detection mechanism in code |
|---|---|
| CodeQL | Workflow uses `github/codeql-action/analyze`; `github-code-scanning` GitHub app on recent PRs |
| SonarCloud / SonarQube | `<sonar.host.url>` in `pom.xml`; `sonarcloud` / `sonarqubecloud` GitHub apps |
| Snyk | Workflow uses any action matching `snyk/actions/*` |
| Pysa | Workflow uses `facebook/pysa-action` |
| Qodana | Workflow uses `JetBrains/qodana-action` |
| LGTM | `lgtm-com` GitHub app (sunset Dec 2022, no usable signal) |

The LGTM language is corrected to reflect that the service is sunset. A remediation alternative is added listing the other four detected SAST integrations as fallback options for projects where CodeQL is not suitable.

- [ ] Tests for the changes have been added (for bug fixes/features)

(Documentation-only change — no test additions required.)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

- Docs-only change. No modifications to `checks/raw/sast.go` or any other Go source. This PR aligns the user-facing documentation with what the existing detection logic already does.
- Both `docs/checks/internal/checks.yaml` and the auto-generated `docs/checks.md` were updated together, per the guidance in `CONTRIBUTING.md`.
- Adding detection for new SAST tools (e.g., Semgrep) is intentionally out of scope; that would require Go changes and is a candidate for a follow-up PR.
- DCO sign-off included on the commit (`-s` flag).

#### Does this PR introduce a user-facing change?

Yes — readers of `docs/checks.md` and the website-rendered checks page will see updated SAST documentation. No changes to scoring or check behavior; only documentation.

```release-note
SAST check description updated to enumerate all five tools the check detects (CodeQL, SonarCloud/SonarQube, Snyk, Pysa, Qodana) with their detection mechanisms; corrected the stale LGTM "forthcoming shutdown" wording.
```