### PR TITLE
:bug: Improve error messages for branch-protection and pip-install checks

### DIFF
--- a/clients/githubrepo/branches.go
+++ b/clients/githubrepo/branches.go
@@ -32,7 +32,8 @@ import (
 const (
 	refPrefix = "refs/heads/"
 	//nolint:lll
-	classicBranchErrMsg = "some github tokens can't read classic branch protection rules: https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md"
+	classicBranchErrMsg = "branch protection rules are not accessible with the current token (GITHUB_TOKEN lacks admin read permission on branch protection); " +
+		"use a fine-grained personal access token with 'administration: read' instead — see https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md"
 )
 
 // See https://github.community/t/graphql-api-protected-branch/14380
@@ -474,7 +475,10 @@ func getBranchRefFrom(data *branch, rules []*repoRuleSet) *clients.BranchRef {
 }
 
 func isPermissionsError(err error) bool {
-	return strings.Contains(err.Error(), "Resource not accessible")
+	// GitHub GraphQL may return "Resource not accessible by integration" (when using
+	// GITHUB_TOKEN or a fine-grained token without admin permission).  Check
+	// case-insensitively to guard against capitalisation differences across API versions.
+	return strings.Contains(strings.ToLower(err.Error()), "resource not accessible")
 }
 
 const (

--- a/probes/pinsDependencies/impl.go
+++ b/probes/pinsDependencies/impl.go
@@ -127,6 +127,11 @@ func generateTextUnpinned(rr *checker.Dependency) string {
 		return fmt.Sprintf("%s not pinned by hash", owner)
 	}
 
+	if rr.Type == checker.DependencyUseTypePipCommand {
+		return "pipCommand not pinned by hash: add --require-hashes to pin package hashes, " +
+			"or use a requirements file with hashes (see https://pip.pypa.io/en/stable/topics/secure-installs/)"
+	}
+
 	return fmt.Sprintf("%s not pinned by hash", rr.Type)
 }
 


### PR DESCRIPTION
Fixes #2946
Fixes #2444

### Branch-protection token error (#2946)
- `isPermissionsError` now compares case-insensitively, so `resource not accessible by integration` (any capitalisation from the GitHub API) is always detected instead of falling through to the generic `githubv4.Query: ...` message.
- Rewrote `classicBranchErrMsg` to explain the cause (GITHUB_TOKEN lacks `administration: read`) and the fix (use a fine-grained PAT) with a direct link.

### pip install hash message (#2444)
- `generateTextUnpinned` now emits a specialised message for `DependencyUseTypePipCommand` that tells users to add `--require-hashes` or use a hashed requirements file, with a link to pip's secure-installs guide — instead of the generic `pipCommand not pinned by hash`.