### PR TITLE
:sparkles: Add private vulnerability reporting probe

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -299,7 +299,8 @@ type SASTWorkflow struct {
 // SecurityPolicyData contains the raw results
 // for the Security-Policy check.
 type SecurityPolicyData struct {
-	PolicyFiles []SecurityPolicyFile
+	PolicyFiles                          []SecurityPolicyFile
+	PrivateVulnerabilityReportingEnabled *bool
 }
 
 // BinaryArtifactData contains the raw results

--- a/checks/evaluation/security_policy.go
+++ b/checks/evaluation/security_policy.go
@@ -18,6 +18,7 @@ import (
 	"github.com/ossf/scorecard/v5/checker"
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/privateVulnerabilityReportingEnabled"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsLinks"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsText"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsVulnerabilityDisclosure"
@@ -26,12 +27,13 @@ import (
 
 // SecurityPolicy applies the score policy for the Security-Policy check.
 func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLogger) checker.CheckResult {
-	// We have 4 unique probes, each should have a finding.
+	// We have 5 unique probes, each should have a finding.
 	expectedProbes := []string{
 		securityPolicyContainsVulnerabilityDisclosure.Probe,
 		securityPolicyContainsLinks.Probe,
 		securityPolicyContainsText.Probe,
 		securityPolicyPresent.Probe,
+		privateVulnerabilityReportingEnabled.Probe,
 	}
 	if !finding.UniqueProbesEqual(findings, expectedProbes) {
 		e := sce.WithMessage(sce.ErrScorecardInternal, "invalid probe results")
@@ -55,6 +57,8 @@ func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLo
 			case securityPolicyContainsText.Probe:
 				score += scoreProbeOnce(f.Probe, m, 3)
 			case securityPolicyPresent.Probe:
+				m[f.Probe] = true
+			case privateVulnerabilityReportingEnabled.Probe:
 				m[f.Probe] = true
 			default:
 				e := sce.WithMessage(sce.ErrScorecardInternal, "unknown probe results")

--- a/checks/evaluation/security_policy_test.go
+++ b/checks/evaluation/security_policy_test.go
@@ -99,11 +99,16 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeTrue,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeNotApplicable,
+				},
 			},
 			result: scut.TestReturn{
-				Score:        checker.MinResultScore,
-				NumberOfInfo: 1,
-				NumberOfWarn: 3,
+				Score:         checker.MinResultScore,
+				NumberOfInfo:  1,
+				NumberOfWarn:  3,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -125,12 +130,17 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeFalse,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeNotApplicable,
+				},
 			},
 			result: scut.TestReturn{
-				Score:        checker.InconclusiveResultScore,
-				Error:        sce.ErrScorecardInternal,
-				NumberOfWarn: 1,
-				NumberOfInfo: 3,
+				Score:         checker.InconclusiveResultScore,
+				Error:         sce.ErrScorecardInternal,
+				NumberOfWarn:  1,
+				NumberOfInfo:  3,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -152,11 +162,16 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeTrue,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeNotApplicable,
+				},
 			},
 			result: scut.TestReturn{
-				Score:        6,
-				NumberOfInfo: 2,
-				NumberOfWarn: 2,
+				Score:         6,
+				NumberOfInfo:  2,
+				NumberOfWarn:  2,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -178,10 +193,14 @@ func TestSecurityPolicy(t *testing.T) {
 					Probe:   "securityPolicyPresent",
 					Outcome: finding.OutcomeTrue,
 				},
+				{
+					Probe:   "privateVulnerabilityReportingEnabled",
+					Outcome: finding.OutcomeTrue,
+				},
 			},
 			result: scut.TestReturn{
 				Score:        checker.MaxResultScore,
-				NumberOfInfo: 4,
+				NumberOfInfo: 5,
 			},
 		},
 	}

--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/checks/fileparser"
 	"github.com/ossf/scorecard/v5/clients"
+	"github.com/ossf/scorecard/v5/clients/githubrepo"
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
 )
@@ -37,10 +38,14 @@ type securityPolicyFilesWithURI struct {
 // SecurityPolicy checks for presence of security policy
 // and applicable content discovered by checkSecurityPolicyFileContent().
 func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error) {
+	privateReportingEnabled, err := privateVulnerabilityReportingEnabled(c.RepoClient)
+	if err != nil {
+		return checker.SecurityPolicyData{}, err
+	}
 	data := securityPolicyFilesWithURI{
 		uri: "", files: make([]checker.SecurityPolicyFile, 0),
 	}
-	err := fileparser.OnAllFilesDo(c.RepoClient, isSecurityPolicyFile, &data)
+	err = fileparser.OnAllFilesDo(c.RepoClient, isSecurityPolicyFile, &data)
 	if err != nil {
 		return checker.SecurityPolicyData{}, err
 	}
@@ -55,7 +60,10 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 				return checker.SecurityPolicyData{}, err
 			}
 		}
-		return checker.SecurityPolicyData{PolicyFiles: data.files}, nil
+		return checker.SecurityPolicyData{
+			PolicyFiles:                          data.files,
+			PrivateVulnerabilityReportingEnabled: privateReportingEnabled,
+		}, nil
 	}
 
 	// Check if present in parent org.
@@ -95,7 +103,22 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 			}
 		}
 	}
-	return checker.SecurityPolicyData{PolicyFiles: data.files}, nil
+	return checker.SecurityPolicyData{
+		PolicyFiles:                          data.files,
+		PrivateVulnerabilityReportingEnabled: privateReportingEnabled,
+	}, nil
+}
+
+func privateVulnerabilityReportingEnabled(repoClient clients.RepoClient) (*bool, error) {
+	githubClient, ok := repoClient.(*githubrepo.Client)
+	if !ok {
+		return nil, nil
+	}
+	enabled, err := githubClient.PrivateVulnerabilityReportingEnabled()
+	if err != nil {
+		return nil, fmt.Errorf("check private vulnerability reporting: %w", err)
+	}
+	return enabled, nil
 }
 
 // Check repository for repository-specific policy.

--- a/checks/security_policy_test.go
+++ b/checks/security_policy_test.go
@@ -42,9 +42,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"security.md",
 			},
 			want: scut.TestReturn{
-				Score:        10,
-				NumberOfInfo: 4,
-				NumberOfWarn: 0,
+				Score:         10,
+				NumberOfInfo:  4,
+				NumberOfWarn:  0,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -54,9 +55,10 @@ func TestSecurityPolicy(t *testing.T) {
 				".github/security.md",
 			},
 			want: scut.TestReturn{
-				Score:        10,
-				NumberOfInfo: 4,
-				NumberOfWarn: 0,
+				Score:         10,
+				NumberOfInfo:  4,
+				NumberOfWarn:  0,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -66,9 +68,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"docs/security.md",
 			},
 			want: scut.TestReturn{
-				Score:        4,
-				NumberOfInfo: 3,
-				NumberOfWarn: 1,
+				Score:         4,
+				NumberOfInfo:  3,
+				NumberOfWarn:  1,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -78,9 +81,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"security.rst",
 			},
 			want: scut.TestReturn{
-				Score:        3,
-				NumberOfInfo: 2,
-				NumberOfWarn: 2,
+				Score:         3,
+				NumberOfInfo:  2,
+				NumberOfWarn:  2,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -90,9 +94,10 @@ func TestSecurityPolicy(t *testing.T) {
 				".github/security.rst",
 			},
 			want: scut.TestReturn{
-				Score:        6,
-				NumberOfInfo: 2,
-				NumberOfWarn: 2,
+				Score:         6,
+				NumberOfInfo:  2,
+				NumberOfWarn:  2,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -102,9 +107,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"docs/security.rst",
 			},
 			want: scut.TestReturn{
-				Score:        6,
-				NumberOfInfo: 2,
-				NumberOfWarn: 2,
+				Score:         6,
+				NumberOfInfo:  2,
+				NumberOfWarn:  2,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -114,9 +120,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"doc/security.rst",
 			},
 			want: scut.TestReturn{
-				Score:        6,
-				NumberOfInfo: 2,
-				NumberOfWarn: 2,
+				Score:         6,
+				NumberOfInfo:  2,
+				NumberOfWarn:  2,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -126,9 +133,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"security.adoc",
 			},
 			want: scut.TestReturn{
-				Score:        9,
-				NumberOfInfo: 3,
-				NumberOfWarn: 1,
+				Score:         9,
+				NumberOfInfo:  3,
+				NumberOfWarn:  1,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -138,9 +146,10 @@ func TestSecurityPolicy(t *testing.T) {
 				".github/security.adoc",
 			},
 			want: scut.TestReturn{
-				Score:        10,
-				NumberOfInfo: 4,
-				NumberOfWarn: 0,
+				Score:         10,
+				NumberOfInfo:  4,
+				NumberOfWarn:  0,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -150,9 +159,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"docs/security.adoc",
 			},
 			want: scut.TestReturn{
-				Score:        0,
-				NumberOfInfo: 1,
-				NumberOfWarn: 3,
+				Score:         0,
+				NumberOfInfo:  1,
+				NumberOfWarn:  3,
+				NumberOfDebug: 1,
 			},
 		},
 		{
@@ -162,9 +172,10 @@ func TestSecurityPolicy(t *testing.T) {
 				"dOCs/SeCuRIty.rsT",
 			},
 			want: scut.TestReturn{
-				Score:        0,
-				NumberOfInfo: 1,
-				NumberOfWarn: 3,
+				Score:         0,
+				NumberOfInfo:  1,
+				NumberOfWarn:  3,
+				NumberOfDebug: 1,
 			},
 		},
 	}

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -284,6 +284,20 @@ func (client *Client) GetOrgRepoClient(ctx context.Context) (clients.RepoClient,
 	return c, nil
 }
 
+// PrivateVulnerabilityReportingEnabled returns whether GitHub private vulnerability reporting is enabled.
+func (client *Client) PrivateVulnerabilityReportingEnabled() (*bool, error) {
+	enabled, resp, err := client.repoClient.Repositories.IsPrivateReportingEnabled(
+		client.ctx, client.repourl.owner, client.repourl.repo)
+	if err != nil {
+		if resp != nil && (resp.StatusCode == http.StatusNotFound ||
+			resp.StatusCode == http.StatusUnprocessableEntity) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("private vulnerability reporting: %w", err)
+	}
+	return &enabled, nil
+}
+
 // ListWebhooks implements RepoClient.ListWebhooks.
 func (client *Client) ListWebhooks() ([]clients.Webhook, error) {
 	return client.webhook.listWebhooks()

--- a/clients/githubrepo/private_vulnerability_reporting_test.go
+++ b/clients/githubrepo/private_vulnerability_reporting_test.go
@@ -1,0 +1,122 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubrepo
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v82/github"
+)
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestPrivateVulnerabilityReportingEnabled(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		status    int
+		body      string
+		want      *bool
+		wantError bool
+	}{
+		{
+			name:   "enabled",
+			status: http.StatusOK,
+			body:   `{"enabled":true}`,
+			want:   boolPtr(true),
+		},
+		{
+			name:   "disabled",
+			status: http.StatusOK,
+			body:   `{"enabled":false}`,
+			want:   boolPtr(false),
+		},
+		{
+			name:   "not found",
+			status: http.StatusNotFound,
+			body:   `{"message":"not found"}`,
+		},
+		{
+			name:   "unprocessable",
+			status: http.StatusUnprocessableEntity,
+			body:   `{"message":"bad request"}`,
+		},
+		{
+			name:      "server error",
+			status:    http.StatusInternalServerError,
+			body:      `{"message":"server error"}`,
+			wantError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var gotPath string
+			httpClient := &http.Client{
+				Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+					gotPath = req.URL.Path
+					return &http.Response{
+						StatusCode: tt.status,
+						Status:     http.StatusText(tt.status),
+						Header:     make(http.Header),
+						Body:       io.NopCloser(strings.NewReader(tt.body)),
+						Request:    req,
+					}, nil
+				}),
+			}
+			client := &Client{
+				repoClient: github.NewClient(httpClient),
+				repourl: &Repo{
+					owner: "owner",
+					repo:  "repo",
+				},
+				ctx: t.Context(),
+			}
+
+			got, err := client.PrivateVulnerabilityReportingEnabled()
+			if (err != nil) != tt.wantError {
+				t.Fatalf("PrivateVulnerabilityReportingEnabled() error = %v, wantError %v", err, tt.wantError)
+			}
+			if gotPath != "/repos/owner/repo/private-vulnerability-reporting" {
+				t.Fatalf("request path = %q", gotPath)
+			}
+			if tt.want == nil {
+				if got != nil {
+					t.Fatalf("PrivateVulnerabilityReportingEnabled() = %v, want nil", *got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("PrivateVulnerabilityReportingEnabled() = nil, want %v", *tt.want)
+			}
+			if *got != *tt.want {
+				t.Fatalf("PrivateVulnerabilityReportingEnabled() = %v, want %v", *got, *tt.want)
+			}
+		})
+	}
+}
+
+func boolPtr(v bool) *bool {
+	return &v
+}

--- a/docs/osps-baseline-coverage.md
+++ b/docs/osps-baseline-coverage.md
@@ -79,7 +79,7 @@ coverage status and evidence columns accordingly.
 | OSPS-SA-02.01 | Docs describe external interfaces | GAP | None | Documentation control. Requires attestation. |
 | OSPS-SA-03.01 | Security assessment performed | GAP | None | Process control. Requires attestation with evidence link. |
 | OSPS-VM-01.01 | CVD policy with response timeframe | PARTIAL | `securityPolicyContainsVulnerabilityDisclosure`, `securityPolicyContainsText` | Security-Policy check detects disclosure language. Does not verify explicit timeframe commitment. |
-| OSPS-VM-03.01 | Private vulnerability reporting method | PARTIAL | `securityPolicyContainsLinks` | Detects links in SECURITY.md. Does not verify private reporting is actually enabled (e.g., GitHub PSIRT feature). |
+| OSPS-VM-03.01 | Private vulnerability reporting method | PARTIAL | `securityPolicyContainsLinks`, `privateVulnerabilityReportingEnabled` | Detects links in SECURITY.md and checks GitHub private vulnerability reporting when available. Other platforms still need separate evidence. |
 | OSPS-VM-04.01 | Publicly publish vulnerability data | GAP | None | No probe checks for GitHub Security Advisories, OSV entries, or CVE publication. |
 
 ## Level 3 controls (17)
@@ -180,7 +180,8 @@ Direct match for Phase 2 deliverable.
 - [#2465](https://github.com/ossf/scorecard/issues/2465) — Factor whether or not private vulnerability reporting is enabled into the scorecard
 
 Direct match. GitHub's private vulnerability reporting API could provide
-platform-level evidence.
+platform-level evidence; `privateVulnerabilityReportingEnabled` now reports the
+GitHub setting when available.
 
 ### Vulnerability disclosure improvements (OSPS-VM-01.01, VM-04.01)
 - [#4192](https://github.com/ossf/scorecard/issues/4192) — Test for security policy in other places than SECURITY.md

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -411,6 +411,21 @@ For supported ecosystem, the probe returns OutcomeFalse per unpinned dependency.
 If the project has no supported dependencies, the probe returns OutcomeNotApplicable.
 
 
+## privateVulnerabilityReportingEnabled
+
+**Lifecycle**: experimental
+
+**Description**: Check if GitHub private vulnerability reporting is enabled.
+
+**Motivation**: Private vulnerability reporting gives security researchers a private channel for reporting vulnerabilities to maintainers.
+
+**Implementation**: The probe checks GitHub's private vulnerability reporting setting when the repository client supports it.
+
+**Outcomes**: If private vulnerability reporting is enabled, one finding with OutcomeTrue is returned.
+If private vulnerability reporting is disabled, one finding with OutcomeFalse is returned.
+If the setting is not available for the repository client, one finding with OutcomeNotApplicable is returned.
+
+
 ## releasesAreSigned
 
 **Lifecycle**: stable

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -46,6 +46,7 @@ import (
 	"github.com/ossf/scorecard/v5/probes/jobLevelPermissions"
 	"github.com/ossf/scorecard/v5/probes/packagedWithAutomatedWorkflow"
 	"github.com/ossf/scorecard/v5/probes/pinsDependencies"
+	"github.com/ossf/scorecard/v5/probes/privateVulnerabilityReportingEnabled"
 	"github.com/ossf/scorecard/v5/probes/releasesAreSigned"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveProvenance"
 	"github.com/ossf/scorecard/v5/probes/releasesHaveVerifiedProvenance"
@@ -83,6 +84,7 @@ var (
 		securityPolicyContainsLinks.Run,
 		securityPolicyContainsVulnerabilityDisclosure.Run,
 		securityPolicyContainsText.Run,
+		privateVulnerabilityReportingEnabled.Run,
 	}
 	// DependencyToolUpdates is all the probes for the
 	// DependencyUpdateTool check.

--- a/probes/privateVulnerabilityReportingEnabled/def.yml
+++ b/probes/privateVulnerabilityReportingEnabled/def.yml
@@ -1,0 +1,39 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: privateVulnerabilityReportingEnabled
+lifecycle: experimental
+short: Check if GitHub private vulnerability reporting is enabled.
+motivation: >
+  Private vulnerability reporting gives security researchers a private channel for reporting vulnerabilities to maintainers.
+implementation: >
+  The probe checks GitHub's private vulnerability reporting setting when the repository client supports it.
+outcome:
+  - If private vulnerability reporting is enabled, one finding with OutcomeTrue is returned.
+  - If private vulnerability reporting is disabled, one finding with OutcomeFalse is returned.
+  - If the setting is not available for the repository client, one finding with OutcomeNotApplicable is returned.
+remediation:
+  onOutcome: False
+  effort: Low
+  text:
+    - Enable private vulnerability reporting in the repository settings.
+    - See https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository .
+  markdown:
+    - Enable private vulnerability reporting in the repository settings.
+    - See [Configuring private vulnerability reporting for a repository](https://docs.github.com/en/code-security/security-advisories/repository-security-advisories/configuring-private-vulnerability-reporting-for-a-repository).
+ecosystem:
+  languages:
+    - all
+  clients:
+    - github

--- a/probes/privateVulnerabilityReportingEnabled/impl.go
+++ b/probes/privateVulnerabilityReportingEnabled/impl.go
@@ -1,0 +1,71 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privateVulnerabilityReportingEnabled
+
+import (
+	"embed"
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/checknames"
+	"github.com/ossf/scorecard/v5/internal/probes"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/uerror"
+)
+
+func init() {
+	probes.MustRegister(Probe, Run, []checknames.CheckName{checknames.SecurityPolicy})
+}
+
+//go:embed *.yml
+var fs embed.FS
+
+const Probe = "privateVulnerabilityReportingEnabled"
+
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	if raw == nil {
+		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
+	}
+
+	enabled := raw.SecurityPolicyResults.PrivateVulnerabilityReportingEnabled
+	switch {
+	case enabled == nil:
+		f, err := finding.NewWith(fs, Probe,
+			"private vulnerability reporting setting is not available", nil,
+			finding.OutcomeNotApplicable)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		return []finding.Finding{*f}, Probe, nil
+	case *enabled:
+		f, err := finding.NewWith(fs, Probe,
+			"private vulnerability reporting is enabled", nil,
+			finding.OutcomeTrue)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		f = f.WithRemediationMetadata(raw.Metadata.Metadata)
+		return []finding.Finding{*f}, Probe, nil
+	default:
+		f, err := finding.NewWith(fs, Probe,
+			"private vulnerability reporting is not enabled", nil,
+			finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		f = f.WithRemediationMetadata(raw.Metadata.Metadata)
+		return []finding.Finding{*f}, Probe, nil
+	}
+}

--- a/probes/privateVulnerabilityReportingEnabled/impl_test.go
+++ b/probes/privateVulnerabilityReportingEnabled/impl_test.go
@@ -1,0 +1,90 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package privateVulnerabilityReportingEnabled
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	enabled := true
+	disabled := false
+
+	tests := []struct {
+		name    string
+		enabled *bool
+		outcome finding.Outcome
+		message string
+	}{
+		{
+			name:    "enabled",
+			enabled: &enabled,
+			outcome: finding.OutcomeTrue,
+			message: "private vulnerability reporting is enabled",
+		},
+		{
+			name:    "disabled",
+			enabled: &disabled,
+			outcome: finding.OutcomeFalse,
+			message: "private vulnerability reporting is not enabled",
+		},
+		{
+			name:    "not available",
+			enabled: nil,
+			outcome: finding.OutcomeNotApplicable,
+			message: "private vulnerability reporting setting is not available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			raw := &checker.RawResults{
+				SecurityPolicyResults: checker.SecurityPolicyData{
+					PrivateVulnerabilityReportingEnabled: tt.enabled,
+				},
+			}
+
+			findings, probe, err := Run(raw)
+			if err != nil {
+				t.Fatalf("Run() unexpected error: %v", err)
+			}
+			if probe != Probe {
+				t.Fatalf("Run() probe = %q, want %q", probe, Probe)
+			}
+			if len(findings) != 1 {
+				t.Fatalf("Run() findings length = %d, want 1", len(findings))
+			}
+			if findings[0].Outcome != tt.outcome {
+				t.Errorf("Run() outcome = %v, want %v", findings[0].Outcome, tt.outcome)
+			}
+			if findings[0].Message != tt.message {
+				t.Errorf("Run() message = %q, want %q", findings[0].Message, tt.message)
+			}
+		})
+	}
+}
+
+func TestRunNilRaw(t *testing.T) {
+	t.Parallel()
+	_, _, err := Run(nil)
+	if err == nil {
+		t.Fatal("Run() expected error for nil raw")
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Feature.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Security-Policy checks SECURITY.md files and their contents, but it does not report whether GitHub private vulnerability reporting is enabled.

#### What is the new behavior (if this is a feature change)?

This adds an experimental Security-Policy probe for GitHub private vulnerability reporting. For GitHub repositories it uses the existing go-github client method; for other clients, or when the setting is not available, the probe returns NotApplicable.

This keeps the smaller shape discussed on #4929: no new RepoClient method while #4049 is still open. The probe is informational for now and does not change the Security-Policy score.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Refs #2465

#### Special notes for your reviewer

I kept this to the GitHub-specific setting check plus the Security-Policy probe wiring.

#### Does this PR introduce a user-facing change?

```release-note
Security-Policy now reports whether GitHub private vulnerability reporting is enabled when that setting is available.
```