### PR TITLE
:seedling: Add SonarQube Cloud SAST check run coverage

### DIFF
--- a/checks/raw/sast_test.go
+++ b/checks/raw/sast_test.go
@@ -180,6 +180,37 @@ func TestSAST(t *testing.T) {
 			},
 		},
 		{
+			name: "Recognizes SonarQube Cloud check run",
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number:   1,
+						MergedAt: mergedOneHourAgo,
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Commits: []checker.SASTCommit{
+					{
+						AssociatedMergeRequest: clients.PullRequest{
+							Number:   1,
+							MergedAt: mergedOneHourAgo,
+						},
+						Compliant: true,
+					},
+				},
+			},
+			checkRuns: []clients.CheckRun{
+				{
+					Status:     "completed",
+					Conclusion: "success",
+					App: clients.CheckRunApp{
+						Slug: "sonarqubecloud",
+					},
+				},
+			},
+		},
+		{
 			name:  "Has Snyk",
 			files: []string{".github/workflows/github-workflow-snyk.yaml"},
 			commits: []clients.Commit{


### PR DESCRIPTION
## Summary
- add SAST unit coverage for the sonarqubecloud check-run app slug
- lock in the currently supported SonarQube Cloud detection path

## Rationale
Scorecard already recognizes the current SonarQube Cloud GitHub App slug in sastTools. This test keeps that behavior covered and helps prevent regressions for repositories relying on SonarQube Cloud check runs for SAST scoring.

## Validation
- inspected the targeted SAST test diff
- local Go test execution was not run because Go is not installed in this workstation environment