### PR TITLE
🌱 Detect fork event names in dangerous workflows

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -51,7 +51,8 @@ func containsUntrustedContextPattern(variable string) bool {
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +
 			`pull_request\.head\.label|` +
-			`pull_request\.head\.repo\.default_branch).*`)
+			`pull_request\.head\.repo\.default_branch|` +
+			`fork\.forkee\.name).*`)
 
 	if strings.Contains(variable, "github.head_ref") {
 		return true

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -106,6 +106,21 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "issue comment body",
+			variable: "github.event.issue_comment.comment.body",
+			expected: true,
+		},
+		{
+			name:     "commit comment body",
+			variable: "github.event.commit_comment.comment.body",
+			expected: true,
+		},
+		{
+			name:     "fork forkee name",
+			variable: "github.event.fork.forkee.name",
+			expected: true,
+		},
+		{
 			name:     "toJSON github.event",
 			variable: "toJSON(github.event)",
 			expected: true,


### PR DESCRIPTION
## Summary

Fixes #3915.

This expands Dangerous-Workflow untrusted input detection to flag `github.event.fork.forkee.name`, which can be attacker controlled for fork events.

The PR also adds explicit unit test cases for the issue examples:

- `github.event.issue_comment.comment.body`
- `github.event.commit_comment.comment.body`
- `github.event.fork.forkee.name`

## Testing

- `git diff --check`
- Quick regex behavior check for the new and existing issue examples

I could not run `go test ./checks/raw` locally because this environment does not have the `go` command installed.
