### PR TITLE
:bug: Fix StepSecurity remediation link labels

### DIFF
--- a/probes/hasNoGitHubWorkflowPermissionUnknown/def.yml
+++ b/probes/hasNoGitHubWorkflowPermissionUnknown/def.yml
@@ -31,7 +31,7 @@ remediation:
     - Untick other options
     - "NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead."
   markdown:
-    - Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/${{ metadata.repository.uri }}/${{ metadata.workflow }}/${{ metadata.repository.defaultBranch }}?enable=permissions).
+    - Visit [StepSecurity Secure Workflow](https://app.stepsecurity.io/secureworkflow/${{ metadata.repository.uri }}/${{ metadata.workflow }}/${{ metadata.repository.defaultBranch }}?enable=permissions).
     - Tick the 'Restrict permissions for GITHUB_TOKEN'
     - Untick other options
     - "NOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."

--- a/probes/hasNoGitHubWorkflowPermissionUnknown/impl_test.go
+++ b/probes/hasNoGitHubWorkflowPermissionUnknown/impl_test.go
@@ -94,3 +94,39 @@ func Test_Run(t *testing.T) {
 		})
 	}
 }
+
+func TestRunSecureWorkflowRemediationLink(t *testing.T) {
+	t.Parallel()
+
+	locationType := checker.PermissionLocationTop
+	value := "unknown"
+	workflow := "scorecard-analysis.yml"
+	raw := &checker.RawResults{
+		Metadata: checker.MetadataData{
+			Metadata: map[string]string{
+				"repository.uri":           "github.com/ossf/scorecard",
+				"repository.defaultBranch": "main",
+			},
+		},
+		TokenPermissionsResults: checker.TokenPermissionsData{
+			NumTokens: 1,
+			TokenPermissions: []checker.TokenPermission{
+				{
+					LocationType: &locationType,
+					Value:        &value,
+					Type:         checker.PermissionLevelUnknown,
+					File:         &checker.File{Path: ".github/workflows/" + workflow},
+				},
+			},
+		},
+	}
+
+	findings, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("Run() got %d findings, want 1", len(findings))
+	}
+	test.AssertSecureWorkflowRemediation(t, findings[0].Remediation, workflow)
+}

--- a/probes/internal/utils/test/test.go
+++ b/probes/internal/utils/test/test.go
@@ -15,6 +15,7 @@
 package test
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/ossf/scorecard/v5/checker"
@@ -32,6 +33,25 @@ func AssertOutcomes(t *testing.T, got []finding.Finding, want []finding.Outcome)
 		if got[i].Outcome != want[i] {
 			t.Errorf("got outcome %v, wanted %v for finding: %v", got[i].Outcome, want[i], got[i])
 		}
+	}
+}
+
+// AssertSecureWorkflowRemediation checks that remediation markdown points to the
+// generated workflow URL without using an auto-linked bare URL as the label.
+func AssertSecureWorkflowRemediation(t *testing.T, got *finding.Remediation, workflow string) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("expected remediation")
+	}
+
+	want := "Visit [StepSecurity Secure Workflow]" +
+		"(https://app.stepsecurity.io/secureworkflow/github.com/ossf/scorecard/" +
+		workflow + "/main?enable=permissions)."
+	if !strings.Contains(got.Markdown, want) {
+		t.Errorf("remediation markdown %q does not contain %q", got.Markdown, want)
+	}
+	if strings.Contains(got.Markdown, "[https://app.stepsecurity.io/secureworkflow]") {
+		t.Errorf("remediation markdown contains a bare secureworkflow link label: %q", got.Markdown)
 	}
 }
 

--- a/probes/jobLevelPermissions/def.yml
+++ b/probes/jobLevelPermissions/def.yml
@@ -31,7 +31,7 @@ remediation:
     - Untick other options
     - "NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead."
   markdown:
-    - Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/${{ metadata.repository.uri }}/${{ metadata.workflow }}/${{ metadata.repository.defaultBranch }}?enable=permissions).
+    - Visit [StepSecurity Secure Workflow](https://app.stepsecurity.io/secureworkflow/${{ metadata.repository.uri }}/${{ metadata.workflow }}/${{ metadata.repository.defaultBranch }}?enable=permissions).
     - Tick the 'Restrict permissions for GITHUB_TOKEN'
     - Untick other options
     - "NOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."

--- a/probes/jobLevelPermissions/impl_test.go
+++ b/probes/jobLevelPermissions/impl_test.go
@@ -53,3 +53,41 @@ func Test_Run(t *testing.T) {
 		})
 	}
 }
+
+func TestRunSecureWorkflowRemediationLink(t *testing.T) {
+	t.Parallel()
+
+	locationType := checker.PermissionLocationJob
+	name := "contents"
+	value := "write"
+	workflow := "scorecard-analysis.yml"
+	raw := &checker.RawResults{
+		Metadata: checker.MetadataData{
+			Metadata: map[string]string{
+				"repository.uri":           "github.com/ossf/scorecard",
+				"repository.defaultBranch": "main",
+			},
+		},
+		TokenPermissionsResults: checker.TokenPermissionsData{
+			NumTokens: 1,
+			TokenPermissions: []checker.TokenPermission{
+				{
+					LocationType: &locationType,
+					Name:         &name,
+					Value:        &value,
+					Type:         checker.PermissionLevelWrite,
+					File:         &checker.File{Path: ".github/workflows/" + workflow},
+				},
+			},
+		},
+	}
+
+	findings, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("Run() got %d findings, want 1", len(findings))
+	}
+	test.AssertSecureWorkflowRemediation(t, findings[0].Remediation, workflow)
+}

--- a/probes/topLevelPermissions/def.yml
+++ b/probes/topLevelPermissions/def.yml
@@ -31,7 +31,7 @@ remediation:
     - Untick other options
     - "NOTE: If you want to resolve multiple issues at once, you can visit https://app.stepsecurity.io/securerepo instead."
   markdown:
-    - Visit [https://app.stepsecurity.io/secureworkflow](https://app.stepsecurity.io/secureworkflow/${{ metadata.repository.uri }}/${{ metadata.workflow }}/${{ metadata.repository.defaultBranch }}?enable=permissions).
+    - Visit [StepSecurity Secure Workflow](https://app.stepsecurity.io/secureworkflow/${{ metadata.repository.uri }}/${{ metadata.workflow }}/${{ metadata.repository.defaultBranch }}?enable=permissions).
     - Tick the 'Restrict permissions for GITHUB_TOKEN'
     - Untick other options
     - "NOTE: If you want to resolve multiple issues at once, you can visit [https://app.stepsecurity.io/securerepo](https://app.stepsecurity.io/securerepo) instead."

--- a/probes/topLevelPermissions/impl_test.go
+++ b/probes/topLevelPermissions/impl_test.go
@@ -53,3 +53,41 @@ func Test_Run(t *testing.T) {
 		})
 	}
 }
+
+func TestRunSecureWorkflowRemediationLink(t *testing.T) {
+	t.Parallel()
+
+	locationType := checker.PermissionLocationTop
+	name := "contents"
+	value := "write"
+	workflow := "scorecard-analysis.yml"
+	raw := &checker.RawResults{
+		Metadata: checker.MetadataData{
+			Metadata: map[string]string{
+				"repository.uri":           "github.com/ossf/scorecard",
+				"repository.defaultBranch": "main",
+			},
+		},
+		TokenPermissionsResults: checker.TokenPermissionsData{
+			NumTokens: 1,
+			TokenPermissions: []checker.TokenPermission{
+				{
+					LocationType: &locationType,
+					Name:         &name,
+					Value:        &value,
+					Type:         checker.PermissionLevelWrite,
+					File:         &checker.File{Path: ".github/workflows/" + workflow},
+				},
+			},
+		},
+	}
+
+	findings, _, err := Run(raw)
+	if err != nil {
+		t.Fatalf("Run() unexpected error: %v", err)
+	}
+	if len(findings) != 1 {
+		t.Fatalf("Run() got %d findings, want 1", len(findings))
+	}
+	test.AssertSecureWorkflowRemediation(t, findings[0].Remediation, workflow)
+}


### PR DESCRIPTION
Fixes ossf/scorecard-action#1386.

## Summary
- Update Token-Permissions probe remediation markdown to use descriptive StepSecurity link labels.
- Preserve the generated workflow-specific Secure Workflow URL targets.
- Add regression coverage for top-level, job-level, and unknown workflow permission remediation links.

## Testing
- git diff --check
- Not run: go test ./probes/... (Go is not installed in this local environment)