### PR TITLE
🌱 Support Makefiles in pinned dependencies

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -69,6 +69,11 @@ func PinningDependencies(c *checker.CheckRequest) (checker.PinningDependenciesDa
 		return checker.PinningDependenciesData{}, err
 	}
 
+	// Makefile downloads.
+	if err := collectMakefileInsecureDownloads(c, &results); err != nil {
+		return checker.PinningDependenciesData{}, err
+	}
+
 	// Action script downloads.
 	if err := collectGitHubWorkflowScriptInsecureDownloads(c, &results); err != nil {
 		return checker.PinningDependenciesData{}, err
@@ -313,6 +318,58 @@ var validateShellScriptIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFileCon
 	}
 
 	return true, nil
+}
+
+func collectMakefileInsecureDownloads(c *checker.CheckRequest, r *checker.PinningDependenciesData) error {
+	return fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
+		Pattern:       "Makefile*",
+		CaseSensitive: false,
+	}, validateMakefileIsFreeOfInsecureDownloads, r)
+}
+
+var validateMakefileIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFileContent = func(
+	pathfn string,
+	content []byte,
+	args ...interface{},
+) (bool, error) {
+	if len(args) != 1 {
+		return false, fmt.Errorf(
+			"validateMakefileIsFreeOfInsecureDownloads requires exactly 1 arguments: got %v: %w",
+			len(args), errInvalidArgLength)
+	}
+
+	if !isMakefile(pathfn) {
+		return true, nil
+	}
+
+	pdata := dataAsPinnedDependenciesPointer(args[0])
+	script := makefileRecipesAsShellScript(content)
+	if !fileparser.CheckFileContainsCommands(script, "#") {
+		return true, nil
+	}
+
+	if err := validateShellFile(pathfn, 0, 0, script, map[string]bool{}, pdata); err != nil {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func isMakefile(pathfn string) bool {
+	name := filepath.Base(pathfn)
+	return strings.EqualFold(name, "Makefile") || strings.HasPrefix(strings.ToLower(name), "makefile.")
+}
+
+func makefileRecipesAsShellScript(content []byte) []byte {
+	lines := bytes.Split(content, []byte("\n"))
+	for i, line := range lines {
+		if len(line) > 0 && line[0] == '\t' {
+			lines[i] = line[1:]
+		} else {
+			lines[i] = nil
+		}
+	}
+	return bytes.Join(lines, []byte("\n"))
 }
 
 func collectDockerfileInsecureDownloads(c *checker.CheckRequest, r *checker.PinningDependenciesData) error {

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -1655,6 +1655,26 @@ func TestShellScriptDownloadPinned(t *testing.T) {
 	}
 }
 
+func TestMakefileDownload(t *testing.T) {
+	t.Parallel()
+
+	content, err := os.ReadFile("./testdata/Makefile-pkg-managers")
+	if err != nil {
+		t.Errorf("cannot read file: %v", err)
+	}
+
+	var r checker.PinningDependenciesData
+	_, err = validateMakefileIsFreeOfInsecureDownloads("./testdata/Makefile-pkg-managers", content, &r)
+	if !errCmp(err, nil) {
+		t.Error(cmp.Diff(err, nil, cmpopts.EquateErrors()))
+	}
+
+	unpinned := countUnpinned(r.Dependencies)
+	if unpinned != 1 {
+		t.Errorf("expected 1 unpinned. Got %v", unpinned)
+	}
+}
+
 func TestGitHubWorkflowRunDownload(t *testing.T) {
 	t.Parallel()
 	//nolint:govet

--- a/checks/raw/testdata/Makefile-pkg-managers
+++ b/checks/raw/testdata/Makefile-pkg-managers
@@ -1,0 +1,5 @@
+install:
+	curl -sSL https://example.com/install.sh | bash
+	pip install requests==2.31.0
+
+.PHONY: install


### PR DESCRIPTION
#### What kind of change does this PR introduce?\n\nAdds Makefile recipe scanning to the Pinned-Dependencies check.\n\n#### What is the current behavior?\n\nThe check scans GitHub Actions workflows, Dockerfiles, shell scripts, and workflow run scripts for unpinned downloads, but Makefile recipes are skipped.\n\n#### What is the new behavior?\n\nMakefile recipe lines are extracted into shell-like input and passed through the existing shell download validator, so commands such as `curl ... | bash` in Makefiles are reported by Pinned-Dependencies.\n\nFixes #884.\n\n#### Does this PR introduce a breaking change?\n\nNo.\n\n#### Other information\n\nTest plan:\n- `git diff --check`\n\nI could not run `gofmt` or Go tests locally because this environment does not have `go` / `gofmt` installed.