### PR TITLE
:bug: Use GitLab diff head SHA for CI-Tests statuses

### DIFF
--- a/clients/gitlabrepo/commits.go
+++ b/clients/gitlabrepo/commits.go
@@ -109,7 +109,9 @@ func (handler *commitsHandler) zip(commitsRaw []*gitlab.Commit, data graphqlData
 		for _, commit := range mr.Commits.Nodes {
 			commitToMRIID[commit.SHA] = mr.IID
 		}
-		commitToMRIID[mr.MergeCommitSHA] = mr.IID
+		if mr.MergeCommitSHA != "" {
+			commitToMRIID[mr.MergeCommitSHA] = mr.IID
+		}
 	}
 
 	iidToMr := make(map[string]clients.PullRequest)
@@ -161,10 +163,15 @@ func (handler *commitsHandler) zip(commitsRaw []*gitlab.Commit, data graphqlData
 			mrno = mr.ID.ID
 		}
 
+		headSHA := mr.DiffHeadSHA
+		if headSHA == "" {
+			headSHA = mr.MergeCommitSHA
+		}
+
 		iidToMr[mr.IID] = clients.PullRequest{
 			Number:   mrno,
 			MergedAt: mr.MergedAt,
-			HeadSHA:  mr.MergeCommitSHA,
+			HeadSHA:  headSHA,
 			Author:   clients.User{Login: mr.Author.Username, ID: int64(mr.Author.ID.ID)},
 			Reviews:  vals,
 			MergedBy: clients.User{Login: mr.MergedBy.Username, ID: int64(mr.MergedBy.ID.ID)},

--- a/clients/gitlabrepo/commits_test.go
+++ b/clients/gitlabrepo/commits_test.go
@@ -17,6 +17,7 @@ package gitlabrepo
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -58,6 +59,50 @@ func TestParsingEmail(t *testing.T) {
 				t.Errorf("Parser didn't work as expected: %s != %s", tt.expected, result)
 			}
 		})
+	}
+}
+
+func TestZipUsesDiffHeadSHAForMergeRequestHead(t *testing.T) {
+	t.Parallel()
+
+	committedDate := time.Date(2026, 5, 29, 0, 0, 0, 0, time.UTC)
+	commitSHA := "commit-from-merge-request"
+	diffHeadSHA := "diff-head-sha"
+	data := graphqlData{}
+	data.Project.MergeRequests.Nodes = []graphqlMergeRequestNode{
+		{
+			IID:         "7",
+			MergedAt:    committedDate,
+			DiffHeadSHA: diffHeadSHA,
+			Commits: struct {
+				Nodes []struct {
+					SHA string `graphql:"sha"`
+				} `graphql:"nodes"`
+			}{
+				Nodes: []struct {
+					SHA string `graphql:"sha"`
+				}{
+					{SHA: commitSHA},
+				},
+			},
+		},
+	}
+	commitsRaw := []*gitlab.Commit{
+		{
+			ID:            commitSHA,
+			Message:       "fix: example",
+			CommittedDate: &committedDate,
+		},
+	}
+
+	handler := &commitsHandler{}
+	commits := handler.zip(commitsRaw, data)
+
+	if len(commits) != 1 {
+		t.Fatalf("zip() returned %d commits, want 1", len(commits))
+	}
+	if got := commits[0].AssociatedMergeRequest.HeadSHA; got != diffHeadSHA {
+		t.Fatalf("AssociatedMergeRequest.HeadSHA = %q, want %q", got, diffHeadSHA)
 	}
 }
 

--- a/clients/gitlabrepo/graphql.go
+++ b/clients/gitlabrepo/graphql.go
@@ -93,6 +93,7 @@ type graphqlMergeRequestNode struct {
 			ID       GitlabGID `graphql:"id"`
 		} `graphql:"nodes"`
 	} `graphql:"approvedBy"`
+	DiffHeadSHA    string `graphql:"diffHeadSha"`
 	MergeCommitSHA string `graphql:"mergeCommitSha"`
 	// Labels         struct {
 	// 	Nodes []struct {


### PR DESCRIPTION
Fixes #3701.

#### What
- query GitLab merge requests for `diffHeadSha`
- use `diffHeadSha` as the associated merge request `HeadSHA`, falling back to `mergeCommitSha` if needed
- avoid mapping an empty merge commit SHA back to a merge request
- add a regression test for fast-forward-style merge requests where `mergeCommitSha` is empty

#### Testing
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./clients/gitlabrepo`
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./checks/raw -run TestCITests -count=1`
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./clients/gitlabrepo ./checks/raw`
- `git diff --check`