### PR TITLE
:sparkles: Detect Brakeman SAST workflows

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -288,6 +288,8 @@ const (
 	QodanaWorkflow SASTWorkflowType = "Qodana"
 	// HadolintWorkflow represents a workflow that runs Hadolint.
 	HadolintWorkflow SASTWorkflowType = "Hadolint"
+	// BrakemanWorkflow represents a workflow that runs Brakeman.
+	BrakemanWorkflow SASTWorkflowType = "Brakeman"
 )
 
 // SASTWorkflow represents a SAST workflow.

--- a/checks/evaluation/sast_test.go
+++ b/checks/evaluation/sast_test.go
@@ -179,6 +179,25 @@ func TestSAST(t *testing.T) {
 				NumberOfInfo: 2,
 			},
 		},
+		{
+			name: "Brakeman is installed, no other SAST tools are installed",
+			findings: []finding.Finding{
+				tool(checker.BrakemanWorkflow),
+				{
+					Probe:   sastToolRunsOnAllCommits.Probe,
+					Outcome: finding.OutcomeTrue,
+					Values: map[string]string{
+						sastToolRunsOnAllCommits.AnalyzedPRsKey: "1",
+						sastToolRunsOnAllCommits.TotalPRsKey:    "3",
+					},
+				},
+			},
+			result: scut.TestReturn{
+				Score:        10,
+				NumberOfWarn: 0,
+				NumberOfInfo: 2,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/raw/sast.go
+++ b/checks/raw/sast.go
@@ -93,6 +93,12 @@ func SAST(c *checker.CheckRequest) (checker.SASTData, error) {
 	}
 	data.Workflows = append(data.Workflows, hadolintWorkflows...)
 
+	brakemanWorkflows, err := getSastUsesWorkflows(c, "^devmasx/brakeman-linter-action$", checker.BrakemanWorkflow)
+	if err != nil {
+		return data, err
+	}
+	data.Workflows = append(data.Workflows, brakemanWorkflows...)
+
 	return data, nil
 }
 

--- a/checks/raw/sast_test.go
+++ b/checks/raw/sast_test.go
@@ -271,6 +271,29 @@ func TestSAST(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "Has Brakeman",
+			files: []string{".github/workflows/github-brakeman-workflow.yaml"},
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number: 1,
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Workflows: []checker.SASTWorkflow{
+					{
+						Type: checker.BrakemanWorkflow,
+						File: checker.File{
+							Path:   ".github/workflows/github-brakeman-workflow.yaml",
+							Offset: checker.OffsetDefault,
+							Type:   finding.FileTypeSource,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/raw/testdata/.github/workflows/github-brakeman-workflow.yaml
+++ b/checks/raw/testdata/.github/workflows/github-brakeman-workflow.yaml
@@ -1,0 +1,16 @@
+name: Brakeman
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions: read-all
+
+jobs:
+  brakeman:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: devmasx/brakeman-linter-action@0dc80fcccf87915ccb1761669014015214f36287

--- a/docs/checks/sast/README.md
+++ b/docs/checks/sast/README.md
@@ -7,6 +7,8 @@
   * Detection based on GitHub workflows using one of the actions from the set at https://github.com/snyk/actions
 * [Sonar](https://docs.sonarsource.com/sonarqube/latest/setup-and-upgrade/overview/)
   * Detection based on the presence of a `pom.xml` file specifying a `sonar.host.url`, or GitHub Action checks run against PRs.
+* [Brakeman](https://brakemanscanner.org/)
+  * Detection based on GitHub workflows using `devmasx/brakeman-linter-action`.
 
 # Add Support
 

--- a/probes/sastToolConfigured/impl_test.go
+++ b/probes/sastToolConfigured/impl_test.go
@@ -69,10 +69,14 @@ func Test_Run(t *testing.T) {
 						{
 							Type: checker.HadolintWorkflow,
 						},
+						{
+							Type: checker.BrakemanWorkflow,
+						},
 					},
 				},
 			},
 			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
 				finding.OutcomeTrue,
 				finding.OutcomeTrue,
 				finding.OutcomeTrue,
@@ -146,10 +150,13 @@ func Test_Run_tools(t *testing.T) {
 						{
 							Type: checker.PysaWorkflow,
 						},
+						{
+							Type: checker.BrakemanWorkflow,
+						},
 					},
 				},
 			},
-			tools: []string{"Sonar", "Pysa"},
+			tools: []string{"Sonar", "Pysa", "Brakeman"},
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- detect `devmasx/brakeman-linter-action` as a Brakeman SAST workflow
- add raw, probe, and evaluation coverage for the new workflow type
- document Brakeman in the SAST supported tools list

This addresses the concrete Brakeman GitHub Actions detection case from #1031 without changing the broader SAST scoring model.

## Testing

- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./checks/raw -run TestSAST -count=1`
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./probes/sastToolConfigured ./checks/evaluation -run 'TestSAST|Test_Run' -count=1`
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./checks/raw ./probes/sastToolConfigured ./checks/evaluation -count=1`
- `PATH=/tmp/scorecard-go-toolchain/go/bin:$PATH GOTOOLCHAIN=local make validate-docs`
- `git diff --check`
