### PR TITLE
:bug: Include workflow path in parse errors

### DIFF
--- a/checks/fileparser/listing.go
+++ b/checks/fileparser/listing.go
@@ -140,7 +140,7 @@ func onMatchingFileDo(repoClient clients.RepoClient, matchPathTo PathMatcher,
 			return sce.WithMessage(sce.ErrScorecardInternal, msg)
 		}
 		if err != nil {
-			return err
+			return fmt.Errorf("%s: %w", file, err)
 		}
 
 		if !continueIter {

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -537,6 +537,33 @@ func TestOnMatchingFileContent(t *testing.T) {
 	}
 }
 
+func TestOnMatchingFileContentIncludesFilePathOnCallbackError(t *testing.T) {
+	t.Parallel()
+
+	const workflowPath = ".github/workflows/bad.yaml"
+	ctrl := gomock.NewController(t)
+	mockRepo := mockrepo.NewMockRepoClient(ctrl)
+	mockRepo.EXPECT().ListFiles(gomock.Any()).Return([]string{workflowPath}, nil)
+	mockRepo.EXPECT().GetFileReader(workflowPath).Return(io.NopCloser(strings.NewReader("")), nil)
+
+	err := OnMatchingFileContentDo(mockRepo, PathMatcher{
+		Pattern:       ".github/workflows/*",
+		CaseSensitive: false,
+	}, func(string, []byte, ...interface{}) (bool, error) {
+		return false, errTest
+	})
+
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), workflowPath) {
+		t.Fatalf("expected error to include %q, got %q", workflowPath, err)
+	}
+	if !errors.Is(err, errTest) {
+		t.Fatalf("expected error to wrap errTest, got %q", err)
+	}
+}
+
 // TestOnAllFilesDo tests the OnAllFilesDo function.
 func TestOnAllFilesDo(t *testing.T) {
 	t.Parallel()

--- a/checks/raw/github/packaging.go
+++ b/checks/raw/github/packaging.go
@@ -33,9 +33,6 @@ func Packaging(c *checker.CheckRequest) (checker.PackagingData, error) {
 	var data checker.PackagingData
 	matchedFiles, err := c.RepoClient.ListFiles(fileparser.IsGithubWorkflowFileCb)
 	if err != nil {
-		return data, fmt.Errorf("%w", err)
-	}
-	if err != nil {
 		return data, fmt.Errorf("RepoClient.ListFiles: %w", err)
 	}
 
@@ -53,7 +50,7 @@ func Packaging(c *checker.CheckRequest) (checker.PackagingData, error) {
 		workflow, errs := actionlint.Parse(fc)
 		if len(errs) > 0 && workflow == nil {
 			e := fileparser.FormatActionlintError(errs)
-			return data, e
+			return data, fmt.Errorf("%s: %w", fp, e)
 		}
 
 		// Check if it's a packaging workflow.

--- a/checks/raw/github/packaging_test.go
+++ b/checks/raw/github/packaging_test.go
@@ -1,0 +1,47 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package github
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"go.uber.org/mock/gomock"
+
+	"github.com/ossf/scorecard/v5/checker"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
+)
+
+func TestPackagingIncludesWorkflowPathOnParseError(t *testing.T) {
+	t.Parallel()
+
+	const workflowPath = ".github/workflows/bad.yaml"
+	ctrl := gomock.NewController(t)
+	mockRepo := mockrepo.NewMockRepoClient(ctrl)
+	mockRepo.EXPECT().ListFiles(gomock.Any()).Return([]string{workflowPath}, nil)
+	mockRepo.EXPECT().GetFileReader(workflowPath).Return(
+		io.NopCloser(strings.NewReader("name: bad\non: [push\n")),
+		nil,
+	)
+
+	_, err := Packaging(&checker.CheckRequest{RepoClient: mockRepo})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), workflowPath) {
+		t.Fatalf("expected error to include %q, got %q", workflowPath, err)
+	}
+}


### PR DESCRIPTION
## Summary

- include the matched workflow path when file parser callbacks return errors
- include the workflow path for GitHub Packaging parse errors, which uses its own workflow loop
- add regression coverage for both shared file parser and Packaging paths

This helps malformed workflow YAML errors point at the offending file, addressing #5072.

For the repro repo in #5072, the malformed workflow is `.github/workflows/benchmark.yml`.

## Testing

- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./checks/fileparser -run 'TestOnMatchingFileContentIncludesFilePathOnCallbackError|TestOnMatchingFileContent' -count=1`
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./checks/raw/github -run TestPackagingIncludesWorkflowPathOnParseError -count=1`
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./checks/fileparser ./checks/raw/github ./checks/raw -count=1`
- `GOTOOLCHAIN=local /tmp/scorecard-go-toolchain/go/bin/go test ./checks/... -count=1`
- `git diff --check`
