### PR TITLE
:bug: Avoid OSV scans when no target is available

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -224,7 +224,8 @@ type ContributorsData struct {
 // VulnerabilitiesData contains the raw results
 // for the Vulnerabilities check.
 type VulnerabilitiesData struct {
-	Vulnerabilities []clients.Vulnerability
+	Vulnerabilities   []clients.Vulnerability
+	ScanTargetMissing bool
 }
 
 type SecurityPolicyInformationType string

--- a/checks/evaluation/vulnerabilities.go
+++ b/checks/evaluation/vulnerabilities.go
@@ -40,6 +40,9 @@ func Vulnerabilities(name string,
 	var numVulnsFound int
 	for i := range findings {
 		f := &findings[i]
+		if f.Outcome == finding.OutcomeNotApplicable {
+			return checker.CreateInconclusiveResult(name, f.Message)
+		}
 		if f.Outcome == finding.OutcomeTrue {
 			numVulnsFound++
 			checker.LogFinding(dl, f, checker.DetailWarn)

--- a/checks/evaluation/vulnerabilities_test.go
+++ b/checks/evaluation/vulnerabilities_test.go
@@ -64,6 +64,19 @@ func TestVulnerabilities(t *testing.T) {
 			},
 		},
 		{
+			name: "scan target missing",
+			findings: []finding.Finding{
+				{
+					Probe:   hasOSVVulnerabilities.Probe,
+					Message: "Project could not be scanned for OSV vulnerabilities",
+					Outcome: finding.OutcomeNotApplicable,
+				},
+			},
+			result: scut.TestReturn{
+				Score: -1,
+			},
+		},
+		{
 			name:     "invalid findings",
 			findings: []finding.Finding{},
 			result: scut.TestReturn{

--- a/checks/raw/vulnerabilities.go
+++ b/checks/raw/vulnerabilities.go
@@ -38,7 +38,8 @@ func Vulnerabilities(c *checker.CheckRequest) (checker.VulnerabilitiesData, erro
 		return checker.VulnerabilitiesData{}, fmt.Errorf("vulnerabilitiesClient.ListUnfixedVulnerabilities: %w", err)
 	}
 	return checker.VulnerabilitiesData{
-		Vulnerabilities: resp.Vulnerabilities,
+		Vulnerabilities:   resp.Vulnerabilities,
+		ScanTargetMissing: resp.ScanTargetMissing,
 	}, nil
 }
 

--- a/checks/raw/vulnerabilities_test.go
+++ b/checks/raw/vulnerabilities_test.go
@@ -59,6 +59,13 @@ func TestVulnerabilities(t *testing.T) {
 			vulnsResponse:   clients.VulnerabilitiesResponse{},
 		},
 		{
+			name:            "scan target missing",
+			wantErr:         false,
+			numberofCommits: 0,
+			vulnsResponse:   clients.VulnerabilitiesResponse{ScanTargetMissing: true},
+			want:            checker.VulnerabilitiesData{ScanTargetMissing: true},
+		},
+		{
 			name:            "vulns err response",
 			wantErr:         true,
 			vulnsError:      true,
@@ -110,6 +117,9 @@ func TestVulnerabilities(t *testing.T) {
 			if !tt.wantErr {
 				if len(got.Vulnerabilities) != len(tt.want.Vulnerabilities) {
 					t.Errorf("Vulnerabilities() got = %v, want %v", len(got.Vulnerabilities), len(tt.want.Vulnerabilities))
+				}
+				if got.ScanTargetMissing != tt.want.ScanTargetMissing {
+					t.Errorf("Vulnerabilities() ScanTargetMissing got = %v, want %v", got.ScanTargetMissing, tt.want.ScanTargetMissing)
 				}
 			}
 

--- a/checks/vulnerabilities_test.go
+++ b/checks/vulnerabilities_test.go
@@ -32,11 +32,19 @@ func TestVulnerabilities(t *testing.T) {
 		name     string
 		expected clients.VulnerabilitiesResponse
 		isError  bool
+		score    int
 	}{
 		{
 			name:     "Valid response",
 			isError:  false,
 			expected: clients.VulnerabilitiesResponse{},
+			score:    checker.MaxResultScore,
+		},
+		{
+			name:     "scan target missing",
+			isError:  false,
+			expected: clients.VulnerabilitiesResponse{ScanTargetMissing: true},
+			score:    checker.InconclusiveResultScore,
 		},
 	}
 
@@ -74,6 +82,9 @@ func TestVulnerabilities(t *testing.T) {
 				t.Fail()
 			} else if tt.isError && res.Error == nil {
 				t.Fail()
+			}
+			if res.Score != tt.score {
+				t.Errorf("Vulnerabilities() score = %v, want %v", res.Score, tt.score)
 			}
 			ctrl.Finish()
 		})

--- a/clients/osv.go
+++ b/clients/osv.go
@@ -69,6 +69,9 @@ func (v osvClient) ListUnfixedVulnerabilities(
 	if commit != "" {
 		gitCommits = append(gitCommits, commit)
 	}
+	if len(directoryPaths) == 0 && len(gitCommits) == 0 {
+		return VulnerabilitiesResponse{ScanTargetMissing: true}, nil
+	}
 
 	exp := osvscanner.ExperimentalScannerActions{
 		PluginsEnabled:   []string{"python/requirements"},

--- a/clients/osv_test.go
+++ b/clients/osv_test.go
@@ -56,3 +56,18 @@ func TestEmptyProject(t *testing.T) {
 		t.Fatalf("empty directory shouldn't throw an error: %v", err)
 	}
 }
+
+func TestEmptyScanTarget(t *testing.T) {
+	t.Parallel()
+	var client osvClient
+	resp, err := client.ListUnfixedVulnerabilities(t.Context(), "", "")
+	if err != nil {
+		t.Fatalf("empty scan target shouldn't throw an error: %v", err)
+	}
+	if len(resp.Vulnerabilities) != 0 {
+		t.Fatalf("empty scan target returned vulnerabilities: %v", resp.Vulnerabilities)
+	}
+	if !resp.ScanTargetMissing {
+		t.Fatal("empty scan target should be marked missing")
+	}
+}

--- a/clients/vulnerabilities.go
+++ b/clients/vulnerabilities.go
@@ -44,7 +44,8 @@ func ExperimentalLocalOSVClient() VulnerabilitiesClient {
 
 // VulnerabilitiesResponse is the response from the vuln DB.
 type VulnerabilitiesResponse struct {
-	Vulnerabilities []Vulnerability
+	Vulnerabilities   []Vulnerability
+	ScanTargetMissing bool
 }
 
 // Vulnerability uniquely identifies a reported security vuln.

--- a/probes/hasOSVVulnerabilities/impl.go
+++ b/probes/hasOSVVulnerabilities/impl.go
@@ -45,6 +45,16 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 
 	var findings []finding.Finding
 
+	if raw.VulnerabilitiesResults.ScanTargetMissing {
+		f, err := finding.NewNotApplicable(fs, Probe,
+			"Project could not be scanned for OSV vulnerabilities", nil)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		findings = append(findings, *f)
+		return findings, Probe, nil
+	}
+
 	// if no vulns were found
 	if len(raw.VulnerabilitiesResults.Vulnerabilities) == 0 {
 		f, err := finding.NewWith(fs, Probe,

--- a/probes/hasOSVVulnerabilities/impl_test.go
+++ b/probes/hasOSVVulnerabilities/impl_test.go
@@ -60,6 +60,17 @@ func Test_Run(t *testing.T) {
 				finding.OutcomeFalse,
 			},
 		},
+		{
+			name: "scan target missing",
+			raw: &checker.RawResults{
+				VulnerabilitiesResults: checker.VulnerabilitiesData{
+					ScanTargetMissing: true,
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeNotApplicable,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## Summary
- avoid invoking osv-scanner when Scorecard has neither a commit nor a local path to scan
- carry the missing-target state through the Vulnerabilities check as NotApplicable/Inconclusive instead of scoring it as zero vulnerabilities
- add regression coverage for the OSV client, raw data propagation, probe outcome, evaluation, and top-level check

Fixes #5056

## Testing
- `go test ./clients ./checks/raw ./probes/hasOSVVulnerabilities ./checks/evaluation ./checks ./pkg/scorecard`