### PR TITLE
:bug: Detect dependency update configs omitted from archives

### DIFF
--- a/checks/dependency_update_tool_test.go
+++ b/checks/dependency_update_tool_test.go
@@ -15,6 +15,9 @@
 package checks
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -144,6 +147,17 @@ func TestDependencyUpdateTool(t *testing.T) {
 				Score:        10,
 			},
 		},
+		{
+			name:              "renovate config found by file lookup",
+			wantErr:           false,
+			files:             []string{},
+			CallSearchCommits: 0,
+			expected: scut.TestReturn{
+				NumberOfInfo: 1,
+				NumberOfWarn: 0,
+				Score:        10,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -151,6 +165,16 @@ func TestDependencyUpdateTool(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockRepo := mockrepo.NewMockRepoClient(ctrl)
 			mockRepo.EXPECT().ListFiles(gomock.Any()).Return(tt.files, nil)
+			if tt.name == "renovate config found by file lookup" {
+				mockRepo.EXPECT().GetFileReader(gomock.Any()).DoAndReturn(func(path string) (io.ReadCloser, error) {
+					if path == "renovate.json" {
+						return io.NopCloser(strings.NewReader("{}")), nil
+					}
+					return nil, os.ErrNotExist
+				}).AnyTimes()
+			} else if tt.CallSearchCommits > 0 {
+				mockRepo.EXPECT().GetFileReader(gomock.Any()).Return(nil, clients.ErrUnsupportedFeature)
+			}
 			mockRepo.EXPECT().SearchCommits(gomock.Any()).Return(tt.SearchCommits, nil).Times(tt.CallSearchCommits)
 			dl := scut.TestDetailLogger{}
 			c := &checker.CheckRequest{
@@ -170,6 +194,7 @@ func TestDependencyUpdateTool_noSearchCommits(t *testing.T) {
 	mockRepo := mockrepo.NewMockRepoClient(ctrl)
 	files := []string{"README.md"}
 	mockRepo.EXPECT().ListFiles(gomock.Any()).Return(files, nil)
+	mockRepo.EXPECT().GetFileReader(gomock.Any()).Return(nil, clients.ErrUnsupportedFeature)
 	mockRepo.EXPECT().SearchCommits(gomock.Any()).Return(nil, clients.ErrUnsupportedFeature)
 	dl := scut.TestDetailLogger{}
 	c := &checker.CheckRequest{

--- a/checks/raw/dependency_update_tool.go
+++ b/checks/raw/dependency_update_tool.go
@@ -17,6 +17,7 @@ package raw
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/ossf/scorecard/v5/checker"
@@ -29,6 +30,54 @@ const (
 	dependabotID = 49699333
 )
 
+type dependencyToolConfig struct {
+	Name        string
+	URL         string
+	Description string
+	Paths       []string
+}
+
+var dependencyToolConfigs = []dependencyToolConfig{
+	{
+		Name:        "Dependabot",
+		URL:         "https://github.com/dependabot",
+		Description: "Automated dependency updates built into GitHub",
+		Paths: []string{
+			".github/dependabot.yml",
+			".github/dependabot.yaml",
+		},
+	},
+	{
+		Name:        "RenovateBot",
+		URL:         "https://github.com/renovatebot/renovate",
+		Description: "Automated dependency updates. Multi-platform and multi-language.",
+		Paths: []string{
+			"renovate.json",
+			"renovate.json5",
+			".github/renovate.json",
+			".github/renovate.json5",
+			".gitlab/renovate.json",
+			".gitlab/renovate.json5",
+			".renovaterc",
+			".renovaterc.json",
+			".renovaterc.json5",
+		},
+	},
+	{
+		Name:        "scala-steward",
+		URL:         "https://github.com/scala-steward-org/scala-steward",
+		Description: "Works with Maven, Mill, sbt, and Scala CLI.",
+		Paths: []string{
+			".scala-steward.conf",
+			"scala-steward.conf",
+			".github/.scala-steward.conf",
+			".github/scala-steward.conf",
+			".config/.scala-steward.conf",
+			".config/scala-steward.conf",
+		},
+	},
+}
+
 // DependencyUpdateTool is the exported name for Dependency-Update-Tool.
 func DependencyUpdateTool(c clients.RepoClient) (checker.DependencyUpdateToolData, error) {
 	var tools []checker.Tool
@@ -37,6 +86,16 @@ func DependencyUpdateTool(c clients.RepoClient) (checker.DependencyUpdateToolDat
 		return checker.DependencyUpdateToolData{}, fmt.Errorf("%w", err)
 	}
 
+	if len(tools) != 0 {
+		return checker.DependencyUpdateToolData{Tools: tools}, nil
+	}
+
+	tools, err = findDependencyFiles(c)
+	if err != nil {
+		if !errors.Is(err, clients.ErrUnsupportedFeature) {
+			return checker.DependencyUpdateToolData{}, fmt.Errorf("dependency update tool config lookup: %w", err)
+		}
+	}
 	if len(tools) != 0 {
 		return checker.DependencyUpdateToolData{Tools: tools}, nil
 	}
@@ -67,6 +126,30 @@ func DependencyUpdateTool(c clients.RepoClient) (checker.DependencyUpdateToolDat
 	return checker.DependencyUpdateToolData{Tools: tools}, nil
 }
 
+func findDependencyFiles(c clients.RepoClient) ([]checker.Tool, error) {
+	var tools []checker.Tool
+	for _, config := range dependencyToolConfigs {
+		for _, path := range config.Paths {
+			reader, err := c.GetFileReader(path)
+			if err != nil {
+				if errors.Is(err, clients.ErrUnsupportedFeature) {
+					return nil, err
+				}
+				if !errors.Is(err, os.ErrNotExist) {
+					return nil, err
+				}
+				continue
+			}
+			if reader != nil {
+				reader.Close()
+			}
+			tools = append(tools, dependencyTool(config, path))
+			break
+		}
+	}
+	return tools, nil
+}
+
 var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name string, args ...interface{}) (bool, error) {
 	if len(args) != 1 {
 		return false, fmt.Errorf("checkDependencyFileExists requires exactly one argument: %w", errInvalidArgLength)
@@ -79,65 +162,34 @@ var checkDependencyFileExists fileparser.DoWhileTrueOnFilename = func(name strin
 
 	switch strings.ToLower(name) {
 	case ".github/dependabot.yml", ".github/dependabot.yaml":
-		*ptools = append(*ptools, checker.Tool{
-			Name: "Dependabot",
-			URL:  asPointer("https://github.com/dependabot"),
-			Desc: asPointer("Automated dependency updates built into GitHub"),
-			Files: []checker.File{
-				{
-					Path:   name,
-					Type:   finding.FileTypeSource,
-					Offset: checker.OffsetDefault,
-				},
-			},
-		})
-
-	// https://docs.renovatebot.com/configuration-options/
-	case "renovate.json",
-		"renovate.json5",
-		".github/renovate.json",
-		".github/renovate.json5",
-		".gitlab/renovate.json",
-		".gitlab/renovate.json5",
-		".renovaterc",
-		".renovaterc.json",
+		*ptools = append(*ptools, dependencyTool(dependencyToolConfigs[0], name))
+	case "renovate.json", "renovate.json5", ".github/renovate.json", ".github/renovate.json5",
+		".gitlab/renovate.json", ".gitlab/renovate.json5", ".renovaterc", ".renovaterc.json",
 		".renovaterc.json5":
-		*ptools = append(*ptools, checker.Tool{
-			Name: "RenovateBot",
-			URL:  asPointer("https://github.com/renovatebot/renovate"),
-			Desc: asPointer("Automated dependency updates. Multi-platform and multi-language."),
-			Files: []checker.File{
-				{
-					Path:   name,
-					Type:   finding.FileTypeSource,
-					Offset: checker.OffsetDefault,
-				},
-			},
-		})
-	// https://github.com/scala-steward-org/scala-steward/blob/main/docs/repo-specific-configuration.md
-	case ".scala-steward.conf",
-		"scala-steward.conf",
-		".github/.scala-steward.conf",
-		".github/scala-steward.conf",
-		".config/.scala-steward.conf",
-		".config/scala-steward.conf":
-		*ptools = append(*ptools, checker.Tool{
-			Name: "scala-steward",
-			URL:  asPointer("https://github.com/scala-steward-org/scala-steward"),
-			Desc: asPointer("Works with Maven, Mill, sbt, and Scala CLI."),
-			Files: []checker.File{
-				{
-					Path:   name,
-					Type:   finding.FileTypeSource,
-					Offset: checker.OffsetDefault,
-				},
-			},
-		})
+		*ptools = append(*ptools, dependencyTool(dependencyToolConfigs[1], name))
+	case ".scala-steward.conf", "scala-steward.conf", ".github/.scala-steward.conf",
+		".github/scala-steward.conf", ".config/.scala-steward.conf", ".config/scala-steward.conf":
+		*ptools = append(*ptools, dependencyTool(dependencyToolConfigs[2], name))
 	}
 
 	// Continue iterating, even if we have found a tool.
 	// It's needed for all probes results to be populated.
 	return true, nil
+}
+
+func dependencyTool(config dependencyToolConfig, path string) checker.Tool {
+	return checker.Tool{
+		Name: config.Name,
+		URL:  asPointer(config.URL),
+		Desc: asPointer(config.Description),
+		Files: []checker.File{
+			{
+				Path:   path,
+				Type:   finding.FileTypeSource,
+				Offset: checker.OffsetDefault,
+			},
+		},
+	}
 }
 
 func asPointer(s string) *string {

--- a/checks/raw/dependency_update_tool_test.go
+++ b/checks/raw/dependency_update_tool_test.go
@@ -15,6 +15,9 @@
 package raw
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 
 	"go.uber.org/mock/gomock"
@@ -226,6 +229,13 @@ func TestDependencyUpdateTool(t *testing.T) {
 				{Committer: clients.User{ID: dependabotID}},
 			},
 		},
+		{
+			name:              "dependency update tool config found by file lookup",
+			wantErr:           false,
+			want:              1,
+			CallSearchCommits: 0,
+			files:             []string{},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -234,6 +244,16 @@ func TestDependencyUpdateTool(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			mockRepo := mockrepo.NewMockRepoClient(ctrl)
 			mockRepo.EXPECT().ListFiles(gomock.Any()).Return(tt.files, nil)
+			if tt.name == "dependency update tool config found by file lookup" {
+				mockRepo.EXPECT().GetFileReader(gomock.Any()).DoAndReturn(func(path string) (io.ReadCloser, error) {
+					if path == "renovate.json" {
+						return io.NopCloser(strings.NewReader("{}")), nil
+					}
+					return nil, os.ErrNotExist
+				}).AnyTimes()
+			} else if tt.CallSearchCommits > 0 {
+				mockRepo.EXPECT().GetFileReader(gomock.Any()).Return(nil, clients.ErrUnsupportedFeature)
+			}
 			mockRepo.EXPECT().SearchCommits(gomock.Any()).Return(tt.SearchCommits, nil).Times(tt.CallSearchCommits)
 
 			got, err := DependencyUpdateTool(mockRepo)

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -202,7 +202,32 @@ func (client *Client) GetFileReader(filename string) (io.ReadCloser, error) {
 		}
 		return f, nil
 	}
-	return client.tarball.getFile(filename)
+	f, err := client.tarball.getFile(filename)
+	if err == nil {
+		return f, nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return nil, err
+	}
+	ref := client.repourl.commitSHA
+	if strings.EqualFold(ref, clients.HeadSHA) {
+		ref = client.repo.GetDefaultBranch()
+	}
+	reader, _, err := client.repoClient.Repositories.DownloadContents(
+		client.ctx,
+		client.repourl.owner,
+		client.repourl.repo,
+		filename,
+		&github.RepositoryContentGetOptions{Ref: ref},
+	)
+	if err != nil {
+		var errResp *github.ErrorResponse
+		if errors.As(err, &errResp) && errResp.Response.StatusCode == http.StatusNotFound {
+			return nil, fmt.Errorf("github contents getfile: %w", os.ErrNotExist)
+		}
+		return nil, fmt.Errorf("github contents getfile: %w", err)
+	}
+	return reader, nil
 }
 
 // ListCommits implements RepoClient.ListCommits.

--- a/clients/githubrepo/tarball_test.go
+++ b/clients/githubrepo/tarball_test.go
@@ -16,12 +16,14 @@ package githubrepo
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -44,6 +46,60 @@ type getcontentTest struct {
 	err      error
 	filename string
 	output   []byte
+}
+
+func TestClientGetFileReaderFallsBackToContents(t *testing.T) {
+	t.Parallel()
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/o/r/contents/renovate.json" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("ref"); got != "abc123" {
+			t.Errorf("unexpected ref: %s", got)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"type":"file","encoding":"base64","content":"e30="}`))
+	}))
+	t.Cleanup(ts.Close)
+
+	ghClient := github.NewClient(ts.Client())
+	baseURL, err := url.Parse(ts.URL + "/")
+	if err != nil {
+		t.Fatalf("url.Parse: %v", err)
+	}
+	ghClient.BaseURL = baseURL
+
+	once := new(sync.Once)
+	once.Do(func() {})
+	client := &Client{
+		ctx:        context.Background(),
+		repo:       &github.Repository{DefaultBranch: github.String("main")},
+		repoClient: ghClient,
+		repourl: &Repo{
+			owner:     "o",
+			repo:      "r",
+			commitSHA: "abc123",
+		},
+		tarball: tarballHandler{
+			once:    once,
+			tempDir: t.TempDir(),
+		},
+	}
+
+	reader, err := client.GetFileReader("renovate.json")
+	if err != nil {
+		t.Fatalf("GetFileReader: %v", err)
+	}
+	defer reader.Close()
+
+	content, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("io.ReadAll: %v", err)
+	}
+	if got := string(content); got != "{}" {
+		t.Errorf("content = %q, want %q", got, "{}")
+	}
 }
 
 func isSortedString(x, y string) bool {


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

Bug fix.

#### What is the current behavior?

Fixes #5069.

The `Dependency-Update-Tool` check can miss dependency-update config files that are present in a GitHub repository but omitted from the downloaded tarball by `.gitattributes export-ignore`. For example, an export-ignored root `renovate.json` is not visible through the tarball-backed `ListFiles` path, so the check reports no update tool.

#### What is the new behavior (if this is a feature change)?

- [x] Tests for the changes have been added (for bug fixes/features)

After the normal file-list scan finds no dependency-update config, the raw check probes the known config filenames with `GetFileReader`.

For GitHub tarball-backed scans, `GetFileReader` now falls back to the GitHub Contents API when a file is absent from the export-filtered archive. The fallback uses the initialized commit SHA as the contents API ref, so commit-pinned scans can still find files that exist in the tree but not in the tarball.

#### Which issue(s) this PR fixes

Fixes #5069

#### Special notes for your reviewer

Validation run locally:

- `go test ./clients/githubrepo -run TestClientGetFileReaderFallsBackToContents -count=1`
- `go test ./checks/raw -run TestDependencyUpdateTool -count=1`
- `go test ./checks -run TestDependencyUpdateTool -count=1`
- `git diff --check`

#### Does this PR introduce a user-facing change?

```release-note
Fixed Dependency-Update-Tool detection for GitHub repositories whose dependency-update config files are omitted from generated archives by `.gitattributes export-ignore`.
```
