### PR TITLE
:bug: Dangerous-Workflow: detect fork repo metadata and workflow_run branch as untrusted

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -51,7 +51,10 @@ func containsUntrustedContextPattern(variable string) bool {
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +
 			`pull_request\.head\.label|` +
-			`pull_request\.head\.repo\.default_branch).*`)
+			`pull_request\.head\.repo\.default_branch|` +
+			`pull_request\.head\.repo\.description|` +
+			`pull_request\.head\.repo\.homepage|` +
+			`workflow_run\.head_branch).*`)
 
 	if strings.Contains(variable, "github.head_ref") {
 		return true

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -101,6 +101,26 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "fork repo description",
+			variable: "github.event.pull_request.head.repo.description",
+			expected: true,
+		},
+		{
+			name:     "fork repo homepage",
+			variable: "github.event.pull_request.head.repo.homepage",
+			expected: true,
+		},
+		{
+			name:     "trusted fork repo id",
+			variable: "github.event.pull_request.head.repo.id",
+			expected: false,
+		},
+		{
+			name:     "workflow_run head branch",
+			variable: "github.event.workflow_run.head_branch",
+			expected: true,
+		},
+		{
 			name:     "discussion title",
 			variable: "github.event.discussion.title",
 			expected: true,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix for the Dangerous-Workflow check (catches script-injection vectors it currently misses).

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`containsUntrustedContextPattern` does not flag three attacker-controllable context fields, so script injection through them is not detected:

- `github.event.pull_request.head.repo.description`
- `github.event.pull_request.head.repo.homepage`
- `github.event.workflow_run.head_branch`

For a `pull_request` / `pull_request_target` from a fork, `head.repo` is the contributor's fork, so its `description` and `homepage` are arbitrary attacker-set strings. `head_branch` on a `workflow_run` triggered by a fork is attacker-controlled in the same way `github.head_ref` already is (which the check already treats as untrusted).

#### What is the new behavior (if this is a feature change)?

These three fields are added to the untrusted-context pattern, so a `run:` step interpolating them is reported by Dangerous-Workflow. A `head.repo.id` case is included in the tests to confirm trusted sibling fields are not over-matched.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Towards #3915. This is scoped to the fork-repository-metadata and `workflow_run` fields and is complementary to (does not overlap) the other open PRs against that issue: #4968 (committer name/email) and #5055 (fork event names).

#### Special notes for your reviewer

I checked the field paths against the GitHub webhook payloads and the [GitHub Security Lab untrusted-input research](https://securitylab.github.com/research/github-actions-untrusted-input/) already cited in the file. Note `workflow_run.head_commit.message` is intentionally left out because the existing `head_commit\.message` pattern already covers it.

#### Does this PR introduce a user-facing change?

Repositories using these fields inside a `run:` step will now be flagged by the Dangerous-Workflow check.

```release-note
Dangerous-Workflow: detect `pull_request.head.repo.description`, `pull_request.head.repo.homepage`, and `workflow_run.head_branch` as untrusted input.
```
