### PR TITLE
Expand Dangerous Workflow untrusted context detection

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -42,16 +42,33 @@ func containsUntrustedContextPattern(variable string) bool {
 			`review_comment\.body|` +
 			`pages.*\.page_name|` +
 			`commits.*\.message|` +
+			`commits.*\.author\.email|` +
+			`commits.*\.author\.name|` +
+			`commits.*\.committer\.name|` +
+			`commits.*\.committer\.email|` +
 			`head_commit\.message|` +
 			`head_commit\.author\.email|` +
 			`head_commit\.author\.name|` +
-			`commits.*\.author\.email|` +
-			`commits.*\.author\.name|` +
+			`head_commit\.committer\.name|` +
+			`head_commit\.committer\.email|` +
 			`blocked_user\.name|` +
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +
 			`pull_request\.head\.label|` +
-			`pull_request\.head\.repo\.default_branch).*`)
+			`pull_request\.head\.repo\.default_branch|` +
+			`workflow_run\.head_branch|` +
+			`workflow_run\.head_commit\.message|` +
+			`workflow_run\.head_commit\.author\.name|` +
+			`workflow_run\.head_commit\.author\.email|` +
+			`workflow_run\.head_commit\.committer\.name|` +
+			`workflow_run\.head_commit\.committer\.email|` +
+			`workflow_run\.pull_requests.*\.head\.ref|` +
+			`fork\.forkee\.description|` +
+			`release\.name|` +
+			`release\.body|` +
+			`release\.tag_name|` +
+			`deployment\.payload|` +
+			`deployment\.description).*`)
 
 	if strings.Contains(variable, "github.head_ref") {
 		return true

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -135,6 +135,96 @@ func TestUntrustedContextVariables(t *testing.T) {
 			variable: "toJSON(github.repository)",
 			expected: false,
 		},
+		{
+			name:     "commits committer name",
+			variable: "github.event.commits[0].committer.name",
+			expected: true,
+		},
+		{
+			name:     "commits committer email",
+			variable: "github.event.commits[0].committer.email",
+			expected: true,
+		},
+		{
+			name:     "head_commit committer name",
+			variable: "github.event.head_commit.committer.name",
+			expected: true,
+		},
+		{
+			name:     "head_commit committer email",
+			variable: "github.event.head_commit.committer.email",
+			expected: true,
+		},
+		{
+			name:     "workflow_run head_branch",
+			variable: "github.event.workflow_run.head_branch",
+			expected: true,
+		},
+		{
+			name:     "workflow_run head_commit message",
+			variable: "github.event.workflow_run.head_commit.message",
+			expected: true,
+		},
+		{
+			name:     "workflow_run head_commit author name",
+			variable: "github.event.workflow_run.head_commit.author.name",
+			expected: true,
+		},
+		{
+			name:     "workflow_run head_commit author email",
+			variable: "github.event.workflow_run.head_commit.author.email",
+			expected: true,
+		},
+		{
+			name:     "workflow_run head_commit committer name",
+			variable: "github.event.workflow_run.head_commit.committer.name",
+			expected: true,
+		},
+		{
+			name:     "workflow_run head_commit committer email",
+			variable: "github.event.workflow_run.head_commit.committer.email",
+			expected: true,
+		},
+		{
+			name:     "workflow_run pull_requests head ref",
+			variable: "github.event.workflow_run.pull_requests[0].head.ref",
+			expected: true,
+		},
+		{
+			name:     "fork forkee description",
+			variable: "github.event.fork.forkee.description",
+			expected: true,
+		},
+		{
+			name:     "release name",
+			variable: "github.event.release.name",
+			expected: true,
+		},
+		{
+			name:     "release body",
+			variable: "github.event.release.body",
+			expected: true,
+		},
+		{
+			name:     "release tag_name",
+			variable: "github.event.release.tag_name",
+			expected: true,
+		},
+		{
+			name:     "deployment payload",
+			variable: "github.event.deployment.payload",
+			expected: true,
+		},
+		{
+			name:     "deployment description",
+			variable: "github.event.deployment.description",
+			expected: true,
+		},
+		{
+			name:     "trusted workflow_run id",
+			variable: "github.event.workflow_run.id",
+			expected: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
#### What

Expands the Dangerous Workflow script-injection detector to cover additional attacker-controlled GitHub event context fields from #3915 and follow-up discussion.

This adds coverage for:
- commit committer name/email fields alongside the existing author fields
- workflow_run head branch, head commit author/committer/message fields, and PR head ref
- fork description
- release name/body/tag_name
- deployment payload/description

I intentionally left out lower-confidence fields such as fork name/full_name and label/milestone values. I also left out review.state because it is an enum-like field rather than free-text user content like review.body.

#### Tests

- go test ./checks/raw -run TestUntrustedContextVariables
- go test ./checks/raw

Fixes #3915