### PR TITLE
:bug: Normalize path separators for --local mode on Windows

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -306,7 +306,7 @@ func IsWorkflowFile(pathfn string) bool {
 	// "Workflow files use YAML syntax, and must have either a .yml or .yaml file extension."
 	switch path.Ext(pathfn) {
 	case ".yml", ".yaml":
-		return filepath.Dir(strings.ToLower(pathfn)) == ".github/workflows"
+		return filepath.ToSlash(filepath.Dir(strings.ToLower(pathfn))) == ".github/workflows"
 	default:
 		return false
 	}

--- a/clients/localdir/client.go
+++ b/clients/localdir/client.go
@@ -23,7 +23,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -85,8 +84,8 @@ func isDir(p string) (bool, error) {
 }
 
 func trimPrefix(pathfn, clientPath string) string {
-	cleanPath := path.Clean(pathfn)
-	prefix := fmt.Sprintf("%s%s", clientPath, string(os.PathSeparator))
+	cleanPath := filepath.ToSlash(filepath.Clean(pathfn))
+	prefix := filepath.ToSlash(clientPath) + "/"
 	return strings.TrimPrefix(cleanPath, prefix)
 }
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

When running `scorecard --local <dir>` on Windows, several checks always return `N/A` or `0` regardless of repository contents:

- `Dangerous-Workflow` = `-1` ("no workflows found")
- `Token-Permissions` = `-1` ("no tokens found")
- `Pinned-Dependencies` = `-1` ("no dependencies found")
- `Security-Policy` = `0` for policies in subdirectories (e.g. `.github/SECURITY.md`)

The root cause is two places that compare OS-native paths against hardcoded forward-slash literals:

1. `clients/localdir/client.go` `trimPrefix` uses `path.Clean` (package `path`), which does not normalize backslashes. On Windows `filepath.Walk` yields backslash-separated paths, so the file listing contains `\`-separated entries and the prefix is not trimmed. Downstream, `checks/fileparser/listing.go` `isMatchingPath` calls `path.Match(".github/workflows/*", ...)`, which requires `/` and therefore never matches.
2. `checks/fileparser/github_workflow.go` `IsWorkflowFile` compares `filepath.Dir(...)` (backslash on Windows) against the literal `".github/workflows"`, which is always false on Windows.

#### What is the new behavior (if this is a feature change)?

Both locations normalize paths to forward slashes via `filepath.ToSlash`. On Linux/macOS this is a no-op (the separator is already `/`), so behavior on supported platforms is unchanged. On Windows the affected checks now produce real results instead of `N/A`, and `Security-Policy` detects policies in subdirectories.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #5088

#### Special notes for your reviewer

- The change is intentionally minimal: two `filepath.ToSlash` calls. It is a no-op on Unix, so it cannot regress Linux/macOS.
- This is verified by the existing test suite on Windows: with the fix, `TestIsWorkflowFile`, `TestDangerousWorkflow`, `TestGithubTokenPermissions`, `Test_SAST`, and the path assertion in `clients/localdir.TestClient_GetFileListAndContent` go from failing to passing. The existing `TestClient_GetFileListAndContent` already encodes the forward-slash contract this fix satisfies.
- No new unit test is added: the failure is reproducible only on Windows (on Unix, `\` is a valid filename character, not a separator, so a backslash input is genuinely not a nested path), and there is currently no Windows CI. Happy to add a `filepath.FromSlash`-based case if you'd prefer.
- This changes score results only on Windows, where the affected checks were previously non-functional; it aligns Windows behavior with the documented and Linux behavior. Discussed in #5088.
- Out of scope (same class of bug, separate function): `fileIsInVendorDir` in `checks/raw/pinned_dependencies.go` also mishandles separators on Windows. Can be addressed as a follow-up.

#### Does this PR introduce a user-facing change?

Yes. Windows users running `--local` now get correct results for workflow- and policy-based checks.

```release-note
Fix `--local` mode on Windows: normalize path separators so Dangerous-Workflow, Token-Permissions, Pinned-Dependencies, and subdirectory Security-Policy checks work correctly.
```
