### PR TITLE
Fix tag-only release checks

### DIFF
--- a/checks/signed_releases_test.go
+++ b/checks/signed_releases_test.go
@@ -54,7 +54,26 @@ func TestSignedRelease(t *testing.T) {
 				},
 			},
 			expected: checker.CheckResult{
-				Score: -1,
+				Score: 0,
+			},
+		},
+		{
+			name: "Release with verified signed tag",
+			releases: []clients.Release{
+				{
+					TagName:         "v1.0.0",
+					URL:             "http://foo.com/v1.0.0",
+					TargetCommitish: "master",
+					Tag: &clients.ReleaseTag{
+						Name:              "v1.0.0",
+						URL:               "http://foo.com/v1.0.0",
+						TargetCommitish:   "master",
+						SignatureVerified: true,
+					},
+				},
+			},
+			expected: checker.CheckResult{
+				Score: 8,
 			},
 		},
 		{

--- a/clients/githubrepo/releases.go
+++ b/clients/githubrepo/releases.go
@@ -55,6 +55,12 @@ func (handler *releasesHandler) setup() error {
 			handler.errSetup = sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("githubv4.Query: %v", err))
 		}
 		handler.releases = releasesFrom(releases)
+		tags, err := handler.listTagReleases()
+		if err != nil {
+			handler.errSetup = sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("githubv4.Query: %v", err))
+			return
+		}
+		handler.releases = mergeTagReleases(handler.releases, tags)
 	})
 	return handler.errSetup
 }
@@ -81,6 +87,91 @@ func releasesFrom(data []*github.RepositoryRelease) []clients.Release {
 			})
 		}
 		releases = append(releases, release)
+	}
+	return releases
+}
+
+func (handler *releasesHandler) listTagReleases() ([]clients.Release, error) {
+	refs, _, err := handler.client.Git.ListMatchingRefs(
+		handler.ctx, handler.repourl.owner, handler.repourl.repo, "tags/",
+	)
+	if err != nil {
+		return nil, fmt.Errorf("Git.ListMatchingRefs: %w", err)
+	}
+
+	releases := make([]clients.Release, 0, len(refs))
+	for _, ref := range refs {
+		tag := handler.releaseTagFromRef(ref)
+		if tag == nil {
+			continue
+		}
+
+		releases = append(releases, clients.Release{
+			TagName:         tag.Name,
+			URL:             tag.URL,
+			TargetCommitish: tag.TargetCommitish,
+			Tag:             tag,
+		})
+	}
+	return releases, nil
+}
+
+func (handler *releasesHandler) releaseTagFromRef(ref *github.Reference) *clients.ReleaseTag {
+	if ref == nil || ref.Object == nil {
+		return nil
+	}
+
+	name := strings.TrimPrefix(ref.GetRef(), "refs/tags/")
+	if name == "" {
+		return nil
+	}
+
+	tag := &clients.ReleaseTag{
+		Name:            name,
+		URL:             ref.GetURL(),
+		TargetCommitish: ref.Object.GetSHA(),
+	}
+
+	if ref.Object.GetType() != "tag" {
+		return tag
+	}
+
+	gitTag, _, err := handler.client.Git.GetTag(
+		handler.ctx, handler.repourl.owner, handler.repourl.repo, ref.Object.GetSHA(),
+	)
+	if err != nil {
+		return tag
+	}
+
+	if gitTag.Object != nil {
+		tag.TargetCommitish = gitTag.Object.GetSHA()
+	}
+	if gitTag.Verification != nil {
+		tag.SignatureVerified = gitTag.Verification.GetVerified()
+	}
+	return tag
+}
+
+func mergeTagReleases(releases, tags []clients.Release) []clients.Release {
+	if len(tags) == 0 {
+		return releases
+	}
+
+	releaseByTag := make(map[string]int, len(releases))
+	for i := range releases {
+		releaseByTag[releases[i].TagName] = i
+	}
+
+	for i := range tags {
+		tagRelease := tags[i]
+		if releaseIndex, ok := releaseByTag[tagRelease.TagName]; ok {
+			releases[releaseIndex].Tag = tagRelease.Tag
+			if releases[releaseIndex].TargetCommitish == "" {
+				releases[releaseIndex].TargetCommitish = tagRelease.TargetCommitish
+			}
+			continue
+		}
+		releases = append(releases, tagRelease)
 	}
 	return releases
 }

--- a/clients/release.go
+++ b/clients/release.go
@@ -20,10 +20,19 @@ type Release struct {
 	URL             string
 	TargetCommitish string
 	Assets          []ReleaseAsset
+	Tag             *ReleaseTag
 }
 
 // ReleaseAsset is part of the Release bundle.
 type ReleaseAsset struct {
 	Name string
 	URL  string
+}
+
+// ReleaseTag contains git tag metadata associated with a release.
+type ReleaseTag struct {
+	Name              string
+	URL               string
+	TargetCommitish   string
+	SignatureVerified bool
 }

--- a/probes/releasesAreSigned/impl.go
+++ b/probes/releasesAreSigned/impl.go
@@ -57,11 +57,26 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 			break
 		}
 
-		if len(release.Assets) == 0 {
+		totalReleases++
+		if release.Tag != nil && release.Tag.SignatureVerified {
+			loc := &finding.Location{
+				Type: finding.FileTypeURL,
+				Path: release.Tag.URL,
+			}
+			f, err := finding.NewWith(fs, Probe,
+				fmt.Sprintf("signed release tag: %s", release.Tag.Name),
+				loc,
+				finding.OutcomeTrue)
+			if err != nil {
+				return nil, Probe, fmt.Errorf("create finding: %w", err)
+			}
+			f.Values = map[string]string{
+				ReleaseNameKey: release.TagName,
+			}
+			findings = append(findings, *f)
 			continue
 		}
 
-		totalReleases++
 		signed := false
 		for j := range release.Assets {
 			asset := release.Assets[j]

--- a/probes/releasesAreSigned/impl_test.go
+++ b/probes/releasesAreSigned/impl_test.go
@@ -154,6 +154,47 @@ func Test_Run(t *testing.T) {
 			},
 		},
 		{
+			name: "Has verified signed tag.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						{
+							TagName: "v1.0",
+							Tag: &clients.ReleaseTag{
+								Name:              "v1.0",
+								URL:               "https://github.com/test/repo/releases/tag/v1.0",
+								TargetCommitish:   "abc123",
+								SignatureVerified: true,
+							},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeTrue,
+			},
+		},
+		{
+			name: "Has unsigned tag-only release.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						{
+							TagName: "v1.0",
+							Tag: &clients.ReleaseTag{
+								Name:            "v1.0",
+								URL:             "https://github.com/test/repo/releases/tag/v1.0",
+								TargetCommitish: "abc123",
+							},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeFalse,
+			},
+		},
+		{
 			name: "Many releases.",
 			raw: &checker.RawResults{
 				SignedReleasesResults: checker.SignedReleasesData{

--- a/probes/releasesHaveProvenance/impl.go
+++ b/probes/releasesHaveProvenance/impl.go
@@ -59,9 +59,7 @@ func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
 		if i >= releaseLookBack {
 			break
 		}
-		if len(release.Assets) == 0 {
-			continue
-		}
+
 		totalReleases++
 		hasProvenance := false
 		for j := range release.Assets {

--- a/probes/releasesHaveProvenance/impl_test.go
+++ b/probes/releasesHaveProvenance/impl_test.go
@@ -153,6 +153,26 @@ func Test_Run(t *testing.T) {
 			},
 		},
 		{
+			name: "Has tag-only release without provenance.",
+			raw: &checker.RawResults{
+				SignedReleasesResults: checker.SignedReleasesData{
+					Releases: []clients.Release{
+						{
+							TagName: "v1.0",
+							Tag: &clients.ReleaseTag{
+								Name:            "v1.0",
+								URL:             "https://github.com/test/repo/releases/tag/v1.0",
+								TargetCommitish: "abc123",
+							},
+						},
+					},
+				},
+			},
+			outcomes: []finding.Outcome{
+				finding.OutcomeFalse,
+			},
+		},
+		{
 			name: "enforce lookback limit of 5 releases",
 			raw: &checker.RawResults{
 				SignedReleasesResults: checker.SignedReleasesData{


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix / enhancement

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Release checks rely on GitHub releases with assets and do not account well for tag-only releases.

#### What is the new behavior (if this is a feature change)?

Signed git tags are included when evaluating tag-only releases.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Addresses part of #2166

#### Special notes for your reviewer

This focuses on the signed tag/tag-only release part of the issue.

#### Does this PR introduce a user-facing change?

```release-note
NONE