### PR TITLE
:sparkles: Add packaging workflow detection for changesets

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -593,6 +593,24 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 			LogText: "candidate publishing workflow using semantic-release",
 		},
 		{
+			// Changesets GitHub Action. https://github.com/changesets/action
+			Steps: []*JobMatcherStep{
+				{
+					Uses: "changesets/action",
+				},
+			},
+			LogText: "candidate publishing workflow using changesets",
+		},
+		{
+			// Changesets CLI invoked directly. https://github.com/changesets/changesets
+			Steps: []*JobMatcherStep{
+				{
+					Run: "changeset publish",
+				},
+			},
+			LogText: "candidate publishing workflow using changesets",
+		},
+		{
 			// Elixir packaging
 			Steps: []*JobMatcherStep{
 				{

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -995,6 +995,16 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "changesets action",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-changesets-action.yaml",
+			expected: true,
+		},
+		{
+			name:     "changeset publish",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-changesets-cli.yaml",
+			expected: true,
+		},
+		{
 			name:     "regression",
 			filename: "../testdata/.github/workflows/spicedb-release.yaml",
 			expected: true,

--- a/checks/testdata/.github/workflows/github-workflow-packaging-changesets-action.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-changesets-action.yaml
@@ -1,0 +1,29 @@
+# Copyright 2024 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Create Release Pull Request or Publish to npm
+        uses: changesets/action@v1
+        with:
+          publish: npm run release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/checks/testdata/.github/workflows/github-workflow-packaging-changesets-cli.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-changesets-cli.yaml
@@ -1,0 +1,26 @@
+# Copyright 2024 Security Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - name: Publish to npm
+        run: pnpm changeset publish
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Adds detection for [changesets](https://github.com/changesets/changesets) in a GitHub Actions packaging workflow.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

changesets is not detected as a packaging tool, so repositories that publish to npm via changesets report "packaging workflow not detected" even though they have a fully automated publishing workflow. This is the same class of problem as semantic-release, which was added in #2964.

The npm `JobMatcher` requires `actions/setup-node` with `registry-url: https://registry.npmjs.org` **and** a `run:` step matching `npm.*publish`. changesets workflows match neither: auth is via `NODE_AUTH_TOKEN`/`.npmrc` (no `registry-url` marker), and publishing is done by `changeset publish`, commonly invoked through `changesets/action`'s `publish:` input.

Real-world example: https://github.com/vercel/ai/blob/main/.github/workflows/release.yml

#### What is the new behavior (if this is a feature change)?

changesets is now detected in two common configurations:

* a job step using the `changesets/action` GitHub Action (the recommended setup)
* a `run:` step invoking `changeset publish` directly (e.g. `pnpm changeset publish`, `npx changeset publish`)

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #5096

#### Special notes for your reviewer

The `changesets/action` matcher keys on the action itself rather than its `publish:` input value, since that value varies per repository (e.g. `npm run release`, `pnpm release`) and `With` matching is exact. This mirrors how `semantic-release` is matched loosely on the `run` command in #2964.
