### PR TITLE
🌱 Normalize extracted file paths across repository handlers

### DIFF
--- a/clients/azuredevopsrepo/zip.go
+++ b/clients/azuredevopsrepo/zip.go
@@ -209,6 +209,9 @@ func (z *zipHandler) extractZip() error {
 		outFile.Close()
 
 		filename := strings.TrimPrefix(filenamepath, destinationPrefix)
+
+		filename = filepath.ToSlash(filename)
+
 		z.files = append(z.files, filename)
 	}
 	return nil

--- a/clients/githubrepo/tarball.go
+++ b/clients/githubrepo/tarball.go
@@ -220,8 +220,14 @@ func (handler *tarballHandler) extractTarball() error {
 				return fmt.Errorf("%w io.Copy: %w", errTarballCorrupted, err)
 			}
 			outFile.Close()
-			handler.files = append(handler.files,
-				strings.TrimPrefix(filenamepath, filepath.Clean(handler.tempDir)+string(os.PathSeparator)))
+			filename := strings.TrimPrefix(
+				filenamepath,
+				filepath.Clean(handler.tempDir)+string(os.PathSeparator),
+			)
+
+			filename = filepath.ToSlash(filename)
+
+			handler.files = append(handler.files, filename)
 		case tar.TypeXGlobalHeader, tar.TypeSymlink:
 			continue
 		default:

--- a/clients/gitlabrepo/tarball.go
+++ b/clients/gitlabrepo/tarball.go
@@ -175,8 +175,14 @@ func (handler *tarballHandler) getTarball() error {
 	handler.tempDir = tempDir
 	handler.tempTarFile = repoFile.Name()
 
-	handler.files = append(handler.files,
-		strings.TrimPrefix(ciYaml.Name(), filepath.Clean(handler.tempDir)+string(os.PathSeparator)))
+	filename := strings.TrimPrefix(
+		ciYaml.Name(),
+		filepath.Clean(handler.tempDir)+string(os.PathSeparator),
+	)
+
+	filename = filepath.ToSlash(filename)
+
+	handler.files = append(handler.files, filename)
 	return nil
 }
 
@@ -263,8 +269,14 @@ func (handler *tarballHandler) extractTarball() error {
 				return fmt.Errorf("%w io.Copy: %w", errTarballCorrupted, err)
 			}
 			outFile.Close()
-			handler.files = append(handler.files,
-				strings.TrimPrefix(filenamepath, filepath.Clean(handler.tempDir)+string(os.PathSeparator)))
+			filename := strings.TrimPrefix(
+				filenamepath,
+				filepath.Clean(handler.tempDir)+string(os.PathSeparator),
+			)
+
+			filename = filepath.ToSlash(filename)
+
+			handler.files = append(handler.files, filename)
 		case tar.TypeXGlobalHeader, tar.TypeSymlink:
 			continue
 		default:


### PR DESCRIPTION
## Summary

Normalize extracted repository file paths using `filepath.ToSlash()` before storing them in handler file lists.

## Motivation

On Windows, extracted paths were stored with `\` separators while repository paths and tests expected normalized `/` separators.

This behavior was reproducible across:

* GitHub tarball handler
* GitLab tarball handler
* Azure DevOps zip handler

## Changes

* Normalize extracted paths using `filepath.ToSlash()`
* Apply consistent behavior across repository handlers

## Release Note

👻 No release note



## Testing

Tested locally on Windows 11 using Go 1.26.4.

The original path separator assertion failures no longer reproduce after applying the change.

Related to #5094
