### PR TITLE
:sparkles: Add support for Winget package manager integration

### DIFF
--- a/cmd/package_managers.go
+++ b/cmd/package_managers.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strings"
 
@@ -71,7 +72,7 @@ type packageMangerResponse struct {
 	exists         bool
 }
 
-func fetchGitRepositoryFromPackageManagers(npm, pypi, rubygems, nuget string,
+func fetchGitRepositoryFromPackageManagers(npm, pypi, rubygems, nuget, winget string,
 	manager pmc.Client,
 ) (packageMangerResponse, error) {
 	if npm != "" {
@@ -98,6 +99,13 @@ func fetchGitRepositoryFromPackageManagers(npm, pypi, rubygems, nuget string,
 	if nuget != "" {
 		nugetClient := ngt.NugetClient{Manager: manager}
 		gitRepo, err := fetchGitRepositoryFromNuget(nuget, &nugetClient)
+		return packageMangerResponse{
+			exists:         true,
+			associatedRepo: gitRepo,
+		}, err
+	}
+	if winget != "" {
+		gitRepo, err := fetchGitRepositoryFromWinget(winget, manager)
 		return packageMangerResponse{
 			exists:         true,
 			associatedRepo: gitRepo,
@@ -218,4 +226,89 @@ func fetchGitRepositoryFromNuget(packageName string, nugetClient ngt.Client) (st
 			fmt.Sprintf("could not find source repo for nuget package: %v", err))
 	}
 	return repositoryURI, nil
+}
+
+type wingetContentsEntry struct {
+	Name string `json:"name"`
+	Type string `json:"type"`
+}
+
+var wingetGitHubURLRegexp = regexp.MustCompile(`https?://github\.com/[^\s"']+`)
+
+// Gets the GitHub repository URL for the winget package.
+// Reads manifests directly from the microsoft/winget-pkgs GitHub repository.
+// Note: https://api.winget.run/v2 was considered but appears unmaintained
+func fetchGitRepositoryFromWinget(packageID string, manager pmc.Client) (string, error) {
+	dotIdx := strings.Index(packageID, ".")
+	if dotIdx < 0 {
+		return "", sce.WithMessage(sce.ErrScorecardInternal,
+			fmt.Sprintf("invalid winget package ID format (expected Publisher.Name): %s", packageID))
+	}
+	publisher := packageID[:dotIdx]
+	appName := packageID[dotIdx+1:]
+	firstChar := strings.ToLower(string([]rune(publisher)[0]))
+
+	// List version directories from microsoft/winget-pkgs
+	versionsURL := fmt.Sprintf(
+		"https://api.github.com/repos/microsoft/winget-pkgs/contents/manifests/%s/%s/%s",
+		firstChar, url.PathEscape(publisher), url.PathEscape(appName),
+	)
+	resp, err := manager.GetURI(versionsURL)
+	if err != nil {
+		return "", sce.WithMessage(sce.ErrScorecardInternal,
+			fmt.Sprintf("failed to fetch winget versions for %s: %v", packageID, err))
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return "", sce.WithMessage(sce.ErrScorecardInternal,
+			fmt.Sprintf("could not find winget package: %s", packageID))
+	}
+
+	var entries []wingetContentsEntry
+	if err := json.NewDecoder(resp.Body).Decode(&entries); err != nil {
+		return "", sce.WithMessage(sce.ErrScorecardInternal,
+			fmt.Sprintf("failed to parse winget versions response: %v", err))
+	}
+	if len(entries) == 0 {
+		return "", sce.WithMessage(sce.ErrScorecardInternal,
+			fmt.Sprintf("no versions found for winget package: %s", packageID))
+	}
+
+	// Take the last listed version (most recently added to the repo)
+	latestVersion := entries[len(entries)-1].Name
+
+	// Fetch the locale YAML from raw.githubusercontent.com (no auth required for public repos)
+	localeFile := fmt.Sprintf("%s.%s.locale.en-US.yaml", publisher, appName)
+	rawURL := fmt.Sprintf(
+		"https://raw.githubusercontent.com/microsoft/winget-pkgs/master/manifests/%s/%s/%s/%s/%s",
+		firstChar,
+		url.PathEscape(publisher),
+		url.PathEscape(appName),
+		url.PathEscape(latestVersion),
+		url.PathEscape(localeFile),
+	)
+	yamlResp, err := manager.GetURI(rawURL)
+	if err != nil {
+		return "", sce.WithMessage(sce.ErrScorecardInternal,
+			fmt.Sprintf("failed to fetch winget locale manifest for %s: %v", packageID, err))
+	}
+	defer yamlResp.Body.Close()
+
+	body, err := io.ReadAll(yamlResp.Body)
+	if err != nil {
+		return "", sce.WithMessage(sce.ErrScorecardInternal,
+			fmt.Sprintf("failed to read winget locale manifest for %s: %v", packageID, err))
+	}
+
+	// Scan the YAML for any GitHub URL and extract the repo root
+	for _, rawMatch := range wingetGitHubURLRegexp.FindAll(body, -1) {
+		for _, matcher := range pypiMatchers {
+			if repo := matcher(string(rawMatch)); repo != "" {
+				return repo, nil
+			}
+		}
+	}
+
+	return "", sce.WithMessage(sce.ErrScorecardInternal,
+		fmt.Sprintf("could not find source repo for winget package: %s", packageID))
 }

--- a/cmd/package_managers_test.go
+++ b/cmd/package_managers_test.go
@@ -725,6 +725,98 @@ func Test_fetchGitRepositoryFromRubyGems(t *testing.T) {
 	}
 }
 
+func Test_fetchGitRepositoryFromWinget(t *testing.T) {
+	t.Parallel()
+	type args struct {
+		packageName    string
+		versionsResult string
+		localeResult   string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "fetchGitRepositoryFromWinget_notepadplusplus",
+			args: args{
+				packageName:    "Notepad++.Notepad++",
+				versionsResult: `[{"name":"8.9.6.2","type":"dir"},{"name":"8.9.6.4","type":"dir"}]`,
+				localeResult: `# yaml-language-server: $schema=https://aka.ms/winget-manifest.defaultLocale.1.12.0.schema.json
+PackageIdentifier: Notepad++.Notepad++
+PackageVersion: 8.9.6.4
+PackageLocale: en-US
+Publisher: Notepad++ Team
+PackageName: Notepad++
+PackageUrl: https://notepad-plus-plus.org/
+License: GPL-3.0-or-later
+LicenseUrl: https://github.com/notepad-plus-plus/notepad-plus-plus/blob/HEAD/LICENSE
+ShortDescription: Notepad++ is a free source code editor that supports several languages.
+ManifestType: defaultLocale
+ManifestVersion: 1.12.0
+`,
+			},
+			want:    "https://github.com/notepad-plus-plus/notepad-plus-plus",
+			wantErr: false,
+		},
+		{
+			name: "fetchGitRepositoryFromWinget_no_github_url",
+			args: args{
+				packageName:    "Notepad++.Notepad++",
+				versionsResult: `[{"name":"8.9.6.4","type":"dir"}]`,
+				localeResult: `PackageIdentifier: Notepad++.Notepad++
+PackageVersion: 8.9.6.4
+PackageUrl: https://notepad-plus-plus.org/
+`,
+			},
+			want:    "",
+			wantErr: true,
+		},
+		{
+			name: "fetchGitRepositoryFromWinget_versions_error",
+			args: args{
+				packageName:    "Notepad++.Notepad++",
+				versionsResult: "",
+			},
+			want:    "",
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			p := pmc.NewMockClient(ctrl)
+			p.EXPECT().GetURI(gomock.Any()).
+				DoAndReturn(func(uri string) (*http.Response, error) {
+					if strings.Contains(uri, "api.github.com") {
+						if tt.wantErr && tt.args.versionsResult == "" {
+							return nil, errors.New("error")
+						}
+						return &http.Response{
+							StatusCode: http.StatusOK,
+							Body:       io.NopCloser(bytes.NewBufferString(tt.args.versionsResult)),
+						}, nil
+					}
+					// raw.githubusercontent.com call
+					return &http.Response{
+						StatusCode: http.StatusOK,
+						Body:       io.NopCloser(bytes.NewBufferString(tt.args.localeResult)),
+					}, nil
+				}).AnyTimes()
+			got, err := fetchGitRepositoryFromWinget(tt.args.packageName, p)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("fetchGitRepositoryFromWinget() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("fetchGitRepositoryFromWinget() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func Test_fetchGitRepositoryFromNuget(t *testing.T) {
 	t.Parallel()
 	type args struct {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,7 +50,7 @@ var errChecksFailed = errors.New("one or more checks failed during execution")
 const (
 	scorecardLong = "A program that shows the OpenSSF scorecard for an open source software."
 	scorecardUse  = `./scorecard (--repo=<repo> | --local=<folder> | --org=<organization> | ` +
-		`--{npm,pypi,rubygems,nuget}=<package_name>) [--checks=check1,...] [--show-details] [--show-annotations]`
+		`--{npm,pypi,rubygems,nuget,winget}=<package_name>) [--checks=check1,...] [--show-details] [--show-annotations]`
 	scorecardShort = "OpenSSF Scorecard"
 )
 
@@ -114,7 +114,7 @@ func buildRepoURLs(ctx context.Context, o *options.Options) ([]string, error) {
 	// Package managers may override --repo
 	p := &pmc.PackageManagerClient{}
 	// Set `repo` from package managers.
-	pkgResp, err := fetchGitRepositoryFromPackageManagers(o.NPM, o.PyPI, o.RubyGems, o.Nuget, p)
+	pkgResp, err := fetchGitRepositoryFromPackageManagers(o.NPM, o.PyPI, o.RubyGems, o.Nuget, o.Winget, p)
 	if err != nil {
 		return nil, fmt.Errorf("fetchGitRepositoryFromPackageManagers: %w", err)
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -50,6 +50,7 @@ type scorecardRequest struct {
 	PyPI            string   `json:"pypi,omitempty"`
 	RubyGems        string   `json:"rubygems,omitempty"`
 	Nuget           string   `json:"nuget,omitempty"`
+	Winget          string   `json:"winget,omitempty"`
 	Commit          string   `json:"commit,omitempty"`
 	FileMode        string   `json:"file_mode,omitempty"`
 	Checks          []string `json:"checks,omitempty"`
@@ -78,6 +79,7 @@ func (s *server) handleScorecard(w http.ResponseWriter, r *http.Request) {
 		req.PyPI = r.URL.Query().Get("pypi")
 		req.RubyGems = r.URL.Query().Get("rubygems")
 		req.Nuget = r.URL.Query().Get("nuget")
+		req.Winget = r.URL.Query().Get("winget")
 		req.Checks = strings.Split(r.URL.Query().Get("checks"), ",")
 		req.Commit = r.URL.Query().Get("commit")
 		req.ShowDetails = r.URL.Query().Get("show_details") == "true"
@@ -95,6 +97,7 @@ func (s *server) handleScorecard(w http.ResponseWriter, r *http.Request) {
 	opts.PyPI = req.PyPI
 	opts.RubyGems = req.RubyGems
 	opts.Nuget = req.Nuget
+	opts.Winget = req.Winget
 	opts.Commit = req.Commit
 	if opts.Commit == "" {
 		opts.Commit = clients.HeadSHA
@@ -121,7 +124,7 @@ func (s *server) handleScorecard(w http.ResponseWriter, r *http.Request) {
 
 	p := &pmc.PackageManagerClient{}
 	// Set repo from package managers
-	pkgResp, err := fetchGitRepositoryFromPackageManagers(opts.NPM, opts.PyPI, opts.RubyGems, opts.Nuget, p)
+	pkgResp, err := fetchGitRepositoryFromPackageManagers(opts.NPM, opts.PyPI, opts.RubyGems, opts.Nuget, opts.Winget, p)
 	if err != nil {
 		http.Error(w, fmt.Sprintf("fetchGitRepositoryFromPackageManagers: %v", err), http.StatusInternalServerError)
 		return

--- a/options/flags.go
+++ b/options/flags.go
@@ -50,6 +50,9 @@ const (
 	// FlagNuget is the flag name for specifying a Nuget repository.
 	FlagNuget = "nuget"
 
+	// FlagWinget is the flag name for specifying a Winget package.
+	FlagWinget = "winget"
+
 	// FlagMetadata is the flag name for specifying metadata for the project.
 	FlagMetadata = "metadata"
 
@@ -160,6 +163,13 @@ func (o *Options) AddFlags(cmd *cobra.Command) {
 		FlagNuget,
 		o.Nuget,
 		"nuget package to check, given that the nuget package has a GitHub repository",
+	)
+
+	cmd.Flags().StringVar(
+		&o.Winget,
+		FlagWinget,
+		o.Winget,
+		"winget package identifier to check (e.g. Publisher.AppName), given that the package has a GitHub repository",
 	)
 
 	cmd.Flags().StringSliceVar(

--- a/options/options.go
+++ b/options/options.go
@@ -41,6 +41,7 @@ type Options struct {
 	PyPI            string
 	RubyGems        string
 	Nuget           string
+	Winget          string
 	PolicyFile      string
 	ResultsFile     string
 	FileMode        string
@@ -128,7 +129,7 @@ func (o *Options) Validate() error {
 	var errs []error
 
 	// Validate exactly one of `--repo`, `--repos`, `--org`, `--npm`, `--pypi`, `--rubygems`,
-	// `--nuget`, `--local` is enabled.
+	// `--nuget`, `--winget`, `--local` is enabled.
 	if boolSum(o.Repo != "",
 		len(o.Repos) > 0,
 		o.Org != "",
@@ -136,6 +137,7 @@ func (o *Options) Validate() error {
 		o.PyPI != "",
 		o.RubyGems != "",
 		o.Nuget != "",
+		o.Winget != "",
 		o.Local != "") != 1 {
 		errs = append(
 			errs,


### PR DESCRIPTION
#### What kind of change does this PR introduce?
New feature — adds support for the Windows Package Manager (winget) as an input source.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
Users who want to assess a winget package must manually look up the source repository and pass it via --repo. There is no --winget flag equivalent to the existing --npm, --pypi, --rubygems, and --nuget flags.

What is the new behavior (if this is a feature change)?
A new --winget flag accepts a winget package identifier and resolves the source repository automatically by reading the package manifest from [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs), then runs Scorecard against it.

`scorecard --winget="Notepad++.Notepad++"`

#### What is the new behavior (if this is a feature change)?

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes [#5100 ](https://github.com/ossf/scorecard/issues/5100)

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

Add `--winget` flag to resolve and score a package by its winget package identifier (e.g. `scorecard --winget="Notepad++.Notepad++"`).


```release-note
Add `--winget` flag to run Scorecard against a package by its winget identifier (e.g. `--winget=Notepad++.Notepad++`).
```
