### PR TITLE
checks/sast: detect Semgrep, Bandit, and gosec SAST workflows

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -288,6 +288,12 @@ const (
 	QodanaWorkflow SASTWorkflowType = "Qodana"
 	// HadolintWorkflow represents a workflow that runs Hadolint.
 	HadolintWorkflow SASTWorkflowType = "Hadolint"
+	// SemgrepWorkflow represents a workflow that runs Semgrep.
+	SemgrepWorkflow SASTWorkflowType = "Semgrep"
+	// BanditWorkflow represents a workflow that runs Bandit.
+	BanditWorkflow SASTWorkflowType = "Bandit"
+	// GosecWorkflow represents a workflow that runs gosec.
+	GosecWorkflow SASTWorkflowType = "Gosec"
 )
 
 // SASTWorkflow represents a SAST workflow.

--- a/checks/raw/sast.go
+++ b/checks/raw/sast.go
@@ -93,6 +93,24 @@ func SAST(c *checker.CheckRequest) (checker.SASTData, error) {
 	}
 	data.Workflows = append(data.Workflows, hadolintWorkflows...)
 
+	semgrepWorkflows, err := getSastUsesWorkflows(c, "^returntocorp/semgrep-action$|^semgrep/semgrep$", checker.SemgrepWorkflow)
+	if err != nil {
+		return data, err
+	}
+	data.Workflows = append(data.Workflows, semgrepWorkflows...)
+
+	banditWorkflows, err := getSastUsesWorkflows(c, "^PyCQA/bandit-action$", checker.BanditWorkflow)
+	if err != nil {
+		return data, err
+	}
+	data.Workflows = append(data.Workflows, banditWorkflows...)
+
+	gosecWorkflows, err := getSastUsesWorkflows(c, "^securego/gosec$|^securecodewarrior/github-action-gosec$", checker.GosecWorkflow)
+	if err != nil {
+		return data, err
+	}
+	data.Workflows = append(data.Workflows, gosecWorkflows...)
+
 	return data, nil
 }
 

--- a/checks/raw/sast_test.go
+++ b/checks/raw/sast_test.go
@@ -271,6 +271,75 @@ func TestSAST(t *testing.T) {
 				},
 			},
 		},
+		{
+			name:  "Has Semgrep",
+			files: []string{".github/workflows/github-semgrep-workflow.yaml"},
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number: 1,
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Workflows: []checker.SASTWorkflow{
+					{
+						Type: checker.SemgrepWorkflow,
+						File: checker.File{
+							Path:   ".github/workflows/github-semgrep-workflow.yaml",
+							Offset: checker.OffsetDefault,
+							Type:   finding.FileTypeSource,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "Has Bandit",
+			files: []string{".github/workflows/github-bandit-workflow.yaml"},
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number: 1,
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Workflows: []checker.SASTWorkflow{
+					{
+						Type: checker.BanditWorkflow,
+						File: checker.File{
+							Path:   ".github/workflows/github-bandit-workflow.yaml",
+							Offset: checker.OffsetDefault,
+							Type:   finding.FileTypeSource,
+						},
+					},
+				},
+			},
+		},
+		{
+			name:  "Has gosec",
+			files: []string{".github/workflows/github-gosec-workflow.yaml"},
+			commits: []clients.Commit{
+				{
+					AssociatedMergeRequest: clients.PullRequest{
+						Number: 1,
+					},
+				},
+			},
+			expected: checker.SASTData{
+				Workflows: []checker.SASTWorkflow{
+					{
+						Type: checker.GosecWorkflow,
+						File: checker.File{
+							Path:   ".github/workflows/github-gosec-workflow.yaml",
+							Offset: checker.OffsetDefault,
+							Type:   finding.FileTypeSource,
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/raw/testdata/.github/workflows/github-bandit-workflow.yaml
+++ b/checks/raw/testdata/.github/workflows/github-bandit-workflow.yaml
@@ -1,0 +1,20 @@
+name: Bandit
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+
+jobs:
+  bandit:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Bandit Scan
+        uses: PyCQA/bandit-action@v1
+        with:
+          targets: .

--- a/checks/raw/testdata/.github/workflows/github-gosec-workflow.yaml
+++ b/checks/raw/testdata/.github/workflows/github-gosec-workflow.yaml
@@ -1,0 +1,20 @@
+name: gosec
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+permissions:
+  contents: read
+
+jobs:
+  gosec:
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run gosec security scanner
+        uses: securego/gosec@master
+        with:
+          args: '-no-fail -fmt sarif -out results.sarif ./...'

--- a/checks/raw/testdata/.github/workflows/github-semgrep-workflow.yaml
+++ b/checks/raw/testdata/.github/workflows/github-semgrep-workflow.yaml
@@ -1,0 +1,23 @@
+name: Semgrep
+on:
+  pull_request: {}
+  push:
+    branches:
+      - main
+      - 'releases/*'
+permissions:
+  contents: read
+
+jobs:
+  semgrep:
+    name: semgrep/ci
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: semgrep/semgrep@v1
+        with:
+          config: p/default
+        env:
+          SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}

--- a/docs/checks/sast/README.md
+++ b/docs/checks/sast/README.md
@@ -7,6 +7,12 @@
   * Detection based on GitHub workflows using one of the actions from the set at https://github.com/snyk/actions
 * [Sonar](https://docs.sonarsource.com/sonarqube/latest/setup-and-upgrade/overview/)
   * Detection based on the presence of a `pom.xml` file specifying a `sonar.host.url`, or GitHub Action checks run against PRs.
+* [Semgrep](https://github.com/semgrep/semgrep)
+  * Detection based on GitHub workflows using `semgrep/semgrep` or the legacy `returntocorp/semgrep-action`.
+* [Bandit](https://github.com/PyCQA/bandit-action)
+  * Detection based on GitHub workflows using `PyCQA/bandit-action`.
+* [gosec](https://github.com/securego/gosec)
+  * Detection based on GitHub workflows using `securego/gosec` or `securecodewarrior/github-action-gosec`.
 
 # Add Support
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Feature — expands SAST tool detection in the `SAST` check.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The `SAST` check detects CodeQL, Sonar, Snyk, Pysa, Qodana, and Hadolint. Three
widely deployed open-source SAST tools are not recognized:

- **Semgrep** (`semgrep/semgrep`, legacy `returntocorp/semgrep-action`)
- **Bandit** (`PyCQA/bandit-action`) — the de facto Python SAST
- **gosec** (`securego/gosec`, `securecodewarrior/github-action-gosec`) — the de facto Go SAST

Repositories that run these tools in CI are currently scored as if they have no
SAST configured. This is a false negative: a project with real static analysis
coverage receives a lower SAST score than its security posture warrants.

#### What is the new behavior (if this is a feature change)?

The `SAST` check now also detects Semgrep, Bandit, and gosec when invoked as a
GitHub Action. Detection follows the exact existing `getSastUsesWorkflows`
pattern used for CodeQL/Snyk/Qodana/Hadolint — each tool gets an anchored
`uses:` regex and a matching `SASTWorkflowType` constant. The
`sastToolConfigured` probe consumes the new workflow types automatically (it
maps `SASTWorkflow.Type` straight to a finding value, so no probe change is
required).

Changes:
- `checker/raw_result.go`: add `SemgrepWorkflow`, `BanditWorkflow`, `GosecWorkflow` constants after `HadolintWorkflow`.
- `checks/raw/sast.go`: add three `getSastUsesWorkflows` calls with anchored regexes.
- `checks/raw/sast_test.go`: add `Has Semgrep` / `Has Bandit` / `Has gosec` table cases.
- `checks/raw/testdata/.github/workflows/`: add three workflow fixtures using the real action references.
- `docs/checks/sast/README.md`: list the three newly supported tools.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Security rationale

SAST is a primary control against the introduction of injection, deserialization,
path-traversal, and hardcoded-secret defects (CWE-79, CWE-89, CWE-22, CWE-502,
CWE-798). Scorecard's SAST signal feeds downstream supply-chain risk decisions; a
false negative here understates the real assurance level of a dependency and can
nudge consumers toward unwarranted manual review or, worse, away from a project
that is in fact well-instrumented.

Semgrep, Bandit, and gosec are among the most commonly adopted open-source SAST
tools across the JavaScript/Python/Go ecosystems, so closing this gap materially
improves the accuracy of the SAST score for a large slice of the OSS population.

The detection regexes are fully anchored (`^...$`) on the action repository
reference, so they match the canonical tool actions and their documented legacy
aliases while rejecting look-alike forks and typosquats
(`semgrep/semgrep-app-action`, `securego/gosec-installer`, `PyCQA/bandit-action-fork`
do **not** match). This keeps false-positive risk minimal, consistent with the
existing CodeQL/Qodana matchers.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

- The matcher for Semgrep covers both the current `semgrep/semgrep` action and
  the legacy `returntocorp/semgrep-action`, since both are still in active use
  across repositories.
- gosec covers the maintained `securego/gosec` action and the older
  `securecodewarrior/github-action-gosec` wrapper.
- I deliberately scoped this to GitHub Action (`uses:`) detection to mirror the
  existing pattern exactly and keep false-positive risk low. Config-file
  detection (e.g. `.semgrep.yml`, `.bandit`) is a reasonable follow-up but is
  noisier (these files are frequently present without CI enforcement), so I left
  it out of this PR; happy to add it in a follow-up if maintainers want it.

#### Does this PR introduce a user-facing change?

Yes — repositories that run Semgrep, Bandit, or gosec via GitHub Actions will now
have those tools recognized by the SAST check.

```release-note
checks/sast: detect Semgrep, Bandit, and gosec SAST tools when configured as GitHub Actions
```
