### PR TITLE
Detect commit committer fields in dangerous workflows

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -45,8 +45,12 @@ func containsUntrustedContextPattern(variable string) bool {
 			`head_commit\.message|` +
 			`head_commit\.author\.email|` +
 			`head_commit\.author\.name|` +
+			`head_commit\.committer\.email|` +
+			`head_commit\.committer\.name|` +
 			`commits.*\.author\.email|` +
 			`commits.*\.author\.name|` +
+			`commits.*\.committer\.email|` +
+			`commits.*\.committer\.name|` +
 			`blocked_user\.name|` +
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -86,6 +86,26 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "head commit committer name",
+			variable: "github.event.head_commit.committer.name",
+			expected: true,
+		},
+		{
+			name:     "head commit committer email",
+			variable: "github.event.head_commit.committer.email",
+			expected: true,
+		},
+		{
+			name:     "commits committer name",
+			variable: "github.event.commits[2].committer.name",
+			expected: true,
+		},
+		{
+			name:     "commits committer email",
+			variable: "github.event.commits[2].committer.email",
+			expected: true,
+		},
+		{
 			name:     "blocked_user name",
 			variable: "github.event.pull_request.organization.blocked_user.name",
 			expected: true,


### PR DESCRIPTION
## Summary
- Treat GitHub Actions commit committer name/email fields as untrusted in the Dangerous-Workflow check
- Cover both `github.event.head_commit.committer.{name,email}` and `github.event.commits[*].committer.{name,email}`
- Add unit tests for the newly detected fields

## Rationale
Commit committer metadata can be attacker-controlled in GitHub event payloads in the same way as the existing author metadata fields. If these values are interpolated directly into a workflow `run:` script, they can contribute to script-injection risk.

Related to #3915.

## Testing
- `go test ./checks/raw`