### PR TITLE
:seedling: Hoist regex compilation out of hot paths in pinned_dependencies

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -35,6 +35,19 @@ import (
 	"github.com/ossf/scorecard/v5/remediation"
 )
 
+// The dependency must be pinned by sha256 hash, e.g.,
+// FROM something@sha256:${ARG},
+// FROM something:@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
+var dockerfilePinnedRegex = regexp.MustCompile(`.*@sha256:([a-f\d]{64}|\${.*})`)
+
+var githubVarRegex = regexp.MustCompile(`{{[^{}]*}}`)
+
+var (
+	localActionRegex     = regexp.MustCompile(`^\..+[^/]`)
+	publicActionRegex    = regexp.MustCompile(`.*@[a-fA-F\d]{40,}`)
+	dockerhubActionRegex = regexp.MustCompile(`docker://.*@sha256:[a-fA-F\d]{64}`)
+)
+
 type dotnetCsprojLockedData struct {
 	Path          string
 	LockedModeSet bool
@@ -487,10 +500,7 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 	// We have what looks like a docker file.
 	// Let's interpret the content as utf8-encoded strings.
 	contentReader := bytes.NewReader(content)
-	// The dependency must be pinned by sha256 hash, e.g.,
-	// FROM something@sha256:${ARG},
-	// FROM something:@sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2
-	regex := regexp.MustCompile(`.*@sha256:([a-f\d]{64}|\${.*})`)
+	regex := dockerfilePinnedRegex
 
 	pinnedAsNames := make(map[string]bool)
 	res, err := parser.Parse(contentReader)
@@ -642,7 +652,6 @@ var validateGitHubWorkflowIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFile
 		return false, fileparser.FormatActionlintError(errs)
 	}
 
-	githubVarRegex := regexp.MustCompile(`{{[^{}]*}}`)
 	for jobName, job := range workflow.Jobs {
 		if len(fileparser.GetJobName(job)) > 0 {
 			jobName = fileparser.GetJobName(job)
@@ -831,16 +840,13 @@ func newGHActionDependency(uses, pathfn string, line int) checker.Dependency {
 }
 
 func isActionDependencyPinned(actionUses string) bool {
-	localActionRegex := regexp.MustCompile(`^\..+[^/]`)
 	if localActionRegex.MatchString(actionUses) {
 		return true
 	}
 
-	publicActionRegex := regexp.MustCompile(`.*@[a-fA-F\d]{40,}`)
 	if publicActionRegex.MatchString(actionUses) {
 		return true
 	}
 
-	dockerhubActionRegex := regexp.MustCompile(`docker://.*@sha256:[a-fA-F\d]{64}`)
 	return dockerhubActionRegex.MatchString(actionUses)
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Performance improvement (internal refactor, no behavior change). Compiles regexes once at package init instead of on every call in `checks/raw/pinned_dependencies.go`.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Three regexes in `pinned_dependencies.go` are compiled with `regexp.MustCompile` on every function call:

- `isActionDependencyPinned` compiles 3 regexes — invoked once per GitHub Action `uses:` step across every workflow.
- The Dockerfile `@sha256` pinning regex — compiled once per Dockerfile.
- The `{{...}}` GitHub-var regex — compiled once per workflow file.

Because these sit in per-step / per-file loops during a scan, the same patterns are recompiled repeatedly, wasting time and allocating on each call.

#### What is the new behavior (if this is a feature change)?

The regexes are moved to package-level `var`s so each pattern is compiled once. Variable names and comments are preserved; the Dockerfile call site keeps its local `regex` alias so its use sites are unchanged. Behavior is identical.

Benchmark of `isActionDependencyPinned` (Apple M4 Pro, `-count=6`, benchstat), old inline-compile vs. new package-level:

| Metric | Before | After | Δ |
|---|---|---|---|
| time/op | 25.76 µs | 3.59 µs | −86% |
| B/op | 85.3 KiB | 0 | −100% |
| allocs/op | 372 | 0 | −100% |

- [x] Tests for the changes have been added (for bug fixes/features)

Added `BenchmarkIsActionDependencyPinned` (compares both variants in one run); existing pinning/Dockerfile/action tests continue to pass.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

- Pure internal optimization — no user-visible behavior change, so it's tagged `:seedling:` per the release-note buckets in CONTRIBUTING.md (no `:zap:` category exists in this repo).
- Only the `pinned_dependencies.go` sites are addressed here. Hotter sites still exist inside AST-walk loops in `checks/raw/sast.go` and `checks/raw/shell_download_validate.go`; happy to do those in a follow-up if you'd like.
- The benchmark keeps an `isActionDependencyPinnedInline` copy of the pre-change implementation so before/after can be compared in a single run — noted with a "keep in sync" comment.

#### Does this PR introduce a user-facing change?

No.

​```release-note
NONE
​```
