### PR TITLE
fix: fallback to REST API for fine-grained PAT in CheckRuns

### DIFF
--- a/clients/githubrepo/checkruns.go
+++ b/clients/githubrepo/checkruns.go
@@ -113,7 +113,7 @@ func (handler *checkrunsHandler) setup() error {
 		if err := handler.graphClient.Query(handler.ctx, handler.checkData, vars); err != nil {
 			// quit early without setting crsErrSetup for "Resource not accessible by integration" error
 			// for whatever reason, this check doesn't work with a GITHUB_TOKEN, only a PAT
-			if strings.Contains(err.Error(), "Resource not accessible by integration") {
+			if strings.Contains(err.Error(), "Resource not accessible by integration") || strings.Contains(err.Error(), "Resource not accessible by personal access token") {
 				return
 			}
 			handler.errSetup = err


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)
Bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
When using a Fine-Grained Personal Access Token (PAT) on a private repository, running `scorecard --repo <repo> --checks CI-Tests` (or `SAST`) fails immediately with the error: `error during graphqlHandler.setupCheckRuns: Resource not accessible by personal access token`. It does not fall back to the REST API as intended.

#### What is the new behavior (if this is a feature change)?
The GraphQL API error string for Fine-Grained PATs (`"Resource not accessible by personal access token"`) is now correctly ignored in the GraphQL `setupCheckRuns` logic. This forces Scorecard to gracefully fall back to the REST API (`ListCheckRunsForRef`), allowing `CI-Tests` and `SAST` to succeed on private repositories using Fine-Grained PATs (mirroring the exact same fallback behavior that currently exists for classic `GITHUB_TOKEN` integrations).

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

Fixes #4307

#### Special notes for your reviewer
The GitHub GraphQL API has known limitations around CheckRuns. The previous code already implemented a fallback for classic integrations by silently swallowing `"Resource not accessible by integration"`. The only change here is treating `"Resource not accessible by personal access token"` identically so the REST API fallback correctly triggers for fine-grained PATs.

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
Fixed an issue where CI-Tests and SAST checks failed on private repositories when using fine-grained Personal Access Tokens.
