### PR TITLE
Detect more untrusted workflow inputs

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -38,12 +38,12 @@ func containsUntrustedContextPattern(variable string) bool {
 			`discussion\.title|` +
 			`discussion\.body|` +
 			`comment\.body|` +
-				`issue_comment\.comment\.body|` +
-				`commit_comment\.comment\.body|` +
+			`issue_comment\.comment\.body|` +
+			`commit_comment\.comment\.body|` +
 			`review\.body|` +
 			`review_comment\.body|` +
 			`pages.*\.page_name|` +
-				`fork\.forkee\.name|` +
+			`fork\.forkee\.name|` +
 			`commits.*\.message|` +
 			`head_commit\.message|` +
 			`head_commit\.author\.email|` +

--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -38,9 +38,12 @@ func containsUntrustedContextPattern(variable string) bool {
 			`discussion\.title|` +
 			`discussion\.body|` +
 			`comment\.body|` +
+				`issue_comment\.comment\.body|` +
+				`commit_comment\.comment\.body|` +
 			`review\.body|` +
 			`review_comment\.body|` +
 			`pages.*\.page_name|` +
+				`fork\.forkee\.name|` +
 			`commits.*\.message|` +
 			`head_commit\.message|` +
 			`head_commit\.author\.email|` +

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -106,19 +106,19 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
-    		name:     "issue comment body",
-    		variable: "github.event.issue_comment.comment.body",
-    		expected: true,
+			name:     "issue comment body",
+			variable: "github.event.issue_comment.comment.body",
+			expected: true,
 		},
 		{
-		    name:     "commit comment body",
-		    variable: "github.event.commit_comment.comment.body",
-		    expected: true,
+			name:     "commit comment body",
+			variable: "github.event.commit_comment.comment.body",
+			expected: true,
 		},
 		{
-		    name:     "fork forkee name",
-		    variable: "github.event.fork.forkee.name",
-		    expected: true,
+			name:     "fork forkee name",
+			variable: "github.event.fork.forkee.name",
+			expected: true,
 		},
 		{
 			name:     "toJSON github.event",

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -106,6 +106,21 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+    		name:     "issue comment body",
+    		variable: "github.event.issue_comment.comment.body",
+    		expected: true,
+		},
+		{
+		    name:     "commit comment body",
+		    variable: "github.event.commit_comment.comment.body",
+		    expected: true,
+		},
+		{
+		    name:     "fork forkee name",
+		    variable: "github.event.fork.forkee.name",
+		    expected: true,
+		},
+		{
 			name:     "toJSON github.event",
 			variable: "toJSON(github.event)",
 			expected: true,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix / security detection improvement.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The Dangerous-Workflow check detects several attacker-controlled GitHub event fields in inline workflow scripts, but misses some fields such as `github.event.issue_comment.comment.body`, `github.event.commit_comment.comment.body`, and `github.event.fork.forkee.name`.

#### What is the new behavior (if this is a feature change)?

The check now treats those additional GitHub event payload fields as untrusted input and flags them when they are used directly in inline scripts.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #3915

#### Special notes for your reviewer

Added regression coverage for the newly detected untrusted context variables.

#### Does this PR introduce a user-facing change?

```release-note
The Dangerous-Workflow check now detects additional untrusted GitHub event payload fields in inline workflow scripts.