### PR TITLE
:book: Clarify Scorecard webviewer references

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,14 +125,14 @@ metrics. Prominent projects that use Scorecard include:
 
 ### View a Project's Score
 
-To see scores for projects regularly scanned by Scorecard, navigate to the [webviewer](https://scorecard.dev/viewer/?uri=). You can also replace the placeholder text (platform, user/org, and repository name) in the following template link to generate a custom Scorecard link for a repo:
+To see scores for projects regularly scanned by Scorecard, use the [Scorecard webviewer](https://scorecard.dev/viewer/), a browser-based result viewer for Scorecard scan results. You can also replace the placeholder text (platform, user/org, and repository name) in the following URL template to open a specific repo:
 `https://scorecard.dev/viewer/?uri=<github_or_gitlab>.com/<user_name_or_org>/<repository_name>`
 
 For example:
  - [https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard](https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard)
  - [https://scorecard.dev/viewer/?uri=gitlab.com/fdroid/fdroidclient](https://scorecard.dev/viewer/?uri=gitlab.com/fdroid/fdroidclient)
 
-To view scores for projects not included in the webviewer, use the [Scorecard CLI](#scorecard-command-line-interface).
+To view scores for projects without pre-calculated results in the webviewer, use the [Scorecard CLI](#scorecard-command-line-interface).
 
 ### Public Data
 

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -25,7 +25,7 @@ This page answers frequently asked questions about Scorecard, including its purp
 
 Yes.
 
-Over a million projects are automatically tracked by the Scorecard project. Use the webviewer to see these scores, replacing the placeholder text with the platform, user/org, and repository name: https://scorecard.dev/viewer/?uri=<github_or_gitlab>.com/<user_name_or_org>/<repository_name>.
+Over a million projects are automatically tracked by the Scorecard project. Use the [Scorecard webviewer](https://scorecard.dev/viewer/), a browser-based result viewer for Scorecard scan results, to see these scores. To open a specific repository, replace the placeholder text in this URL template with the platform, user/org, and repository name: https://scorecard.dev/viewer/?uri=<github_or_gitlab>.com/<user_name_or_org>/<repository_name>.
 
 For example: 
  - [https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard](https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard)


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Docs update.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The README and FAQ refer to the webviewer without first defining what it is. The README also describes the viewer pattern as a "template link".

#### What is the new behavior (if this is a feature change)?

The README and FAQ now define the Scorecard webviewer as a browser-based result viewer for Scorecard scan results, and the README calls the viewer pattern a URL template.

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #3986

#### Special notes for your reviewer

Validation:
- `git diff --check`
- `curl.exe -L -I https://scorecard.dev/viewer/`
- `curl.exe -L -I "https://scorecard.dev/viewer/?uri=github.com/ossf/scorecard"`

`make validate-docs` was attempted locally, but this environment does not have Go installed (`make` under WSL found no `go` binary), and this change only touches README/FAQ prose.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```