### PR TITLE
:sparkles: Add remediation tip for unpinned pip installs

### DIFF
--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -1655,6 +1655,56 @@ func TestShellScriptDownloadPinned(t *testing.T) {
 	}
 }
 
+func TestPipInstallRemediation(t *testing.T) {
+	t.Parallel()
+	//nolint:govet
+	tests := []struct {
+		name           string
+		script         string
+		pinned         bool
+		hasRemediation bool
+	}{
+		{
+			name:           "unpinned pip install",
+			script:         "pip install some-package",
+			pinned:         false,
+			hasRemediation: true,
+		},
+		{
+			name:           "unpinned python -m pip install",
+			script:         "python -m pip install some-package",
+			pinned:         false,
+			hasRemediation: true,
+		},
+		{
+			name:           "pip install with --require-hashes",
+			script:         "pip install --require-hashes -r requirements.txt",
+			pinned:         true,
+			hasRemediation: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var r checker.PinningDependenciesData
+			_, err := validateShellScriptIsFreeOfInsecureDownloads("script.sh", []byte(tt.script), &r)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if len(r.Dependencies) != 1 {
+				t.Fatalf("expected 1 dependency. Got %v", len(r.Dependencies))
+			}
+			dep := r.Dependencies[0]
+			if *dep.Pinned != tt.pinned {
+				t.Errorf("expected pinned to be %v. Got %v", tt.pinned, *dep.Pinned)
+			}
+			if (dep.Remediation != nil) != tt.hasRemediation {
+				t.Errorf("expected remediation presence to be %v. Got %+v", tt.hasRemediation, dep.Remediation)
+			}
+		})
+	}
+}
+
 func TestGitHubWorkflowRunDownload(t *testing.T) {
 	t.Parallel()
 	//nolint:govet

--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -963,6 +963,15 @@ func collectUnpinnedPackageManagerDownload(startLine, endLine uint, node syntax.
 
 	// Pip install.
 	if isPipDownload(c) {
+		pinned := !isPipUnpinnedDownload(c)
+		var remediation *finding.Remediation
+		if !pinned {
+			remediation = &finding.Remediation{
+				Text: "pin your pip installs by using a requirements file with hashes and " +
+					"passing the --require-hashes option " +
+					"(https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode)",
+			}
+		}
 		r.Dependencies = append(r.Dependencies,
 			checker.Dependency{
 				Location: &checker.File{
@@ -972,8 +981,9 @@ func collectUnpinnedPackageManagerDownload(startLine, endLine uint, node syntax.
 					EndOffset: endLine,
 					Snippet:   cmd,
 				},
-				Pinned: asBoolPointer(!isPipUnpinnedDownload(c)),
-				Type:   checker.DependencyUseTypePipCommand,
+				Pinned:      &pinned,
+				Type:        checker.DependencyUseTypePipCommand,
+				Remediation: remediation,
 			},
 		)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Enhancement to check output (Pinned-Dependencies).

## What is the current behavior?

Unpinned `pip install` commands are reported only as `pipCommand not pinned by hash`, with no hint about what the user should do to fix it (see #2444).

## What is the new behavior?

Unpinned pip dependencies now carry a remediation tip, following the same pattern already used for nuget commands and the suggestion in https://github.com/ossf/scorecard/issues/2444#issuecomment-1521866907:

> pin your pip installs by using a requirements file with hashes and passing the --require-hashes option (https://pip.pypa.io/en/stable/topics/secure-installs/#hash-checking-mode)

Covers both `pip install` and `python -m pip install`. Added unit tests verifying the remediation is attached for unpinned installs and absent for pinned ones.

## Which issue(s) this PR fixes

Contributes to #2444 (pip ecosystem; npm/choco/go from the follow-up comment can be done separately).

## Special notes for your reviewer

The remediation text is intentionally static (like the nuget one). If you'd prefer cause-specific messages (e.g. a different tip for unpinned editable installs), happy to extend.

## Does this PR introduce a user-facing change?

```release-note
The Pinned-Dependencies check now includes a remediation tip for unpinned pip installs.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)