### PR TITLE
:bug: report repository creation from oldest commit

### DIFF
--- a/clients/git/client.go
+++ b/clients/git/client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
-	"github.com/go-git/go-git/v5/plumbing/storer"
 	cp "github.com/otiai10/copy"
 
 	"github.com/ossf/scorecard/v5/clients"
@@ -288,29 +287,29 @@ func (c *Client) GetBranch(branch string) (*clients.BranchRef, error) {
 }
 
 func (c *Client) GetCreatedAt() (time.Time, error) {
-	// Retrieve the first commit of the repository
+	// Retrieve the oldest commit of the repository.
 	commitIter, err := c.gitRepo.Log(&git.LogOptions{Order: git.LogOrderCommitterTime})
 	if err != nil {
 		return time.Time{}, fmt.Errorf("git.Log: %w", err)
 	}
 	defer commitIter.Close()
 
-	// Iterate through the commits to find the first one
-	var firstCommit *object.Commit
+	var oldestCommit *object.Commit
 	err = commitIter.ForEach(func(c *object.Commit) error {
-		firstCommit = c
-		return storer.ErrStop
+		if oldestCommit == nil || c.Committer.When.Before(oldestCommit.Committer.When) {
+			oldestCommit = c
+		}
+		return nil
 	})
-	if err != nil && !errors.Is(err, storer.ErrStop) {
+	if err != nil {
 		return time.Time{}, fmt.Errorf("commitIter.ForEach: %w", err)
 	}
 
-	if firstCommit == nil {
+	if oldestCommit == nil {
 		return time.Time{}, errNilCommitFound
 	}
 
-	// Return the commit time of the first commit
-	return firstCommit.Committer.When, nil
+	return oldestCommit.Committer.When, nil
 }
 
 func (c *Client) GetDefaultBranchName() (string, error) {

--- a/clients/git/client_test.go
+++ b/clients/git/client_test.go
@@ -140,6 +140,28 @@ func TestListCommits(t *testing.T) {
 	}
 }
 
+func TestGetCreatedAtReturnsOldestCommit(t *testing.T) {
+	t.Parallel()
+
+	repoPath, wantCreatedAt := createTimedTestRepo(t)
+	client := &Client{}
+	repo, err := localdir.MakeLocalDirRepo(repoPath)
+	if err != nil {
+		t.Fatalf("MakeLocalDirRepo(%s) failed: %v", repoPath, err)
+	}
+	if err := client.InitRepo(repo, clients.HeadSHA, 10); err != nil {
+		t.Fatalf("InitRepo(%s) failed: %v", repoPath, err)
+	}
+
+	createdAt, err := client.GetCreatedAt()
+	if err != nil {
+		t.Fatalf("GetCreatedAt() failed: %v", err)
+	}
+	if !createdAt.Equal(wantCreatedAt) {
+		t.Fatalf("GetCreatedAt() = %v, want %v", createdAt, wantCreatedAt)
+	}
+}
+
 func TestSearch(t *testing.T) {
 	t.Parallel()
 	testCases := []struct {
@@ -230,4 +252,63 @@ func TestSearch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func createTimedTestRepo(t *testing.T) (string, time.Time) {
+	t.Helper()
+	dir := t.TempDir()
+
+	r, err := gitV5.PlainInit(dir, false)
+	if err != nil {
+		t.Fatalf("PlainInit() failed: %v", err)
+	}
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("Worktree() failed: %v", err)
+	}
+
+	createdAt := time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)
+	if err := os.WriteFile(filepath.Join(dir, "first.txt"), []byte("first"), 0o600); err != nil {
+		t.Fatalf("WriteFile() failed: %v", err)
+	}
+	if _, err := w.Add("first.txt"); err != nil {
+		t.Fatalf("Add() failed: %v", err)
+	}
+	if _, err := w.Commit("First commit", &gitV5.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test Author",
+			Email: "author@example.com",
+			When:  createdAt,
+		},
+		Committer: &object.Signature{
+			Name:  "Test Committer",
+			Email: "committer@example.com",
+			When:  createdAt,
+		},
+	}); err != nil {
+		t.Fatalf("Commit() failed: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(dir, "second.txt"), []byte("second"), 0o600); err != nil {
+		t.Fatalf("WriteFile() failed: %v", err)
+	}
+	if _, err := w.Add("second.txt"); err != nil {
+		t.Fatalf("Add() failed: %v", err)
+	}
+	if _, err := w.Commit("Second commit", &gitV5.CommitOptions{
+		Author: &object.Signature{
+			Name:  "Test Author",
+			Email: "author@example.com",
+			When:  createdAt.Add(24 * time.Hour),
+		},
+		Committer: &object.Signature{
+			Name:  "Test Committer",
+			Email: "committer@example.com",
+			When:  createdAt.Add(24 * time.Hour),
+		},
+	}); err != nil {
+		t.Fatalf("Commit() failed: %v", err)
+	}
+
+	return dir, createdAt
 }


### PR DESCRIPTION


#### What kind of change does this PR introduce?

Bug fix/improvement

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

GetCreatedAt used the first entry returned by git.Log(Order: git.LogOrderCommitterTime), which is the newest commit. That can make old git-backed repositories look newly created and affect Created-Recently.

#### What is the new behavior (if this is a feature change)?

Return the oldest visible committer timestamp instead. For shallow histories, this is the oldest commit present locally, not necessarily the repository root commit.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note

```
