### PR TITLE
✨ Detect more untrusted context patterns in Dangerous-Workflow check

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -49,6 +49,15 @@ func containsUntrustedContextPattern(variable string) bool {
 			`commits.*\.author\.name|` +
 			`blocked_user\.name|` +
 			`blocked_user\.email|` +
+			`fork\.forkee\.name|` +
+			`fork\.forkee\.full_name|` +
+			`fork\.forkee\.description|` +
+			`fork\.forkee\.homepage|` +
+			`fork\.forkee\.default_branch|` +
+			`workflow_run\.head_branch|` +
+			`workflow_run\.display_title|` +
+			`workflow_run\.head_repository\.description|` +
+			`workflow_run\.pull_requests.*\.head\.ref|` +
 			`pull_request\.head\.ref|` +
 			`pull_request\.head\.label|` +
 			`pull_request\.head\.repo\.default_branch).*`)

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -106,6 +106,71 @@ func TestUntrustedContextVariables(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "issue_comment body",
+			variable: "github.event.issue_comment.comment.body",
+			expected: true,
+		},
+		{
+			name:     "commit_comment body",
+			variable: "github.event.commit_comment.comment.body",
+			expected: true,
+		},
+		{
+			name:     "fork forkee name",
+			variable: "github.event.fork.forkee.name",
+			expected: true,
+		},
+		{
+			name:     "fork forkee full_name",
+			variable: "github.event.fork.forkee.full_name",
+			expected: true,
+		},
+		{
+			name:     "fork forkee description",
+			variable: "github.event.fork.forkee.description",
+			expected: true,
+		},
+		{
+			name:     "fork forkee homepage",
+			variable: "github.event.fork.forkee.homepage",
+			expected: true,
+		},
+		{
+			name:     "fork forkee default_branch",
+			variable: "github.event.fork.forkee.default_branch",
+			expected: true,
+		},
+		{
+			name:     "trusted fork forkee id",
+			variable: "github.event.fork.forkee.id",
+			expected: false,
+		},
+		{
+			name:     "workflow_run head_branch",
+			variable: "github.event.workflow_run.head_branch",
+			expected: true,
+		},
+		{
+			name:     "workflow_run display_title",
+			variable: "github.event.workflow_run.display_title",
+			expected: true,
+		},
+		{
+			name:     "workflow_run head_repository description",
+			variable: "github.event.workflow_run.head_repository.description",
+			expected: true,
+		},
+		{
+			name:     "workflow_run pull_requests head ref",
+			variable: "github.event.workflow_run.pull_requests[0].head.ref",
+			expected: true,
+		},
+		{
+			name:     "trusted workflow_run id",
+			variable: "github.event.workflow_run.id",
+			expected: false,
+		},
+		{
 			name:     "toJSON github.event",
 			variable: "toJSON(github.event)",
 			expected: true,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Improvement to the Dangerous-Workflow check (script injection detection).

Fixes #3915

#### What is the current behavior?

`containsUntrustedContextPattern` in `checks/raw/dangerous_workflow.go` misses
several attacker-controlled GitHub event context fields, so workflows
interpolating them into `run:` scripts are not flagged as script-injection
risks. Examples not detected:

- `github.event.fork.forkee.name` (and other forkee fields)
- `github.event.workflow_run.head_branch`

#### What is the new behavior?

The untrusted-input pattern now also detects the following fields, which are
attacker-controlled per GitHub's [webhook events and payloads docs](https://docs.github.com/en/webhooks/webhook-events-and-payloads)
and the [GitHub Security Lab untrusted-input research](https://securitylab.github.com/research/github-actions-untrusted-input/):

**`fork` event** — anyone can fork a repo and controls the fork's metadata:
- `fork.forkee.name`
- `fork.forkee.full_name`
- `fork.forkee.description`
- `fork.forkee.homepage`
- `fork.forkee.default_branch`

**`workflow_run` event** — attacker controls these via the triggering PR/branch:
- `workflow_run.head_branch`
- `workflow_run.display_title`
- `workflow_run.head_repository.description`
- `workflow_run.pull_requests[*].head.ref`

Note: `issue_comment.comment.body` and `commit_comment.comment.body` mentioned
in #3915 were already detected by the existing `comment\.body` pattern — this PR
adds regression tests to cover them explicitly.

Unit tests added for all new patterns, including negative cases
(`fork.forkee.id`, `workflow_run.id`) to guard against over-matching.

#### Which issue(s) this PR fixes

Fixes #3915

#### Special notes for your reviewer

The field list was derived from GitHub's webhook payload documentation; happy
to add further fields (e.g. other free-text fields from less common events) if
reviewers think the coverage should be broader.

#### Does this PR introduce a user-facing change?

```release-note
Dangerous-Workflow: detect additional untrusted context patterns (fork.forkee.*, workflow_run.head_branch/display_title/pull_requests head refs) in script injection detection
