### PR TITLE
:bug: Support legacy Azure DevOps repository URLs

### DIFF
--- a/checker/client.go
+++ b/checker/client.go
@@ -61,15 +61,26 @@ func GetClients(ctx context.Context, repoURI, localURI string, logger *log.Logge
 	_, experimental := os.LookupEnv("SCORECARD_EXPERIMENTAL")
 	var repoClient clients.RepoClient
 
-	repo, makeRepoError = glrepo.MakeGitlabRepo(repoURI)
-	if repo != nil && makeRepoError == nil {
-		repoClient, makeRepoError = glrepo.CreateGitlabClient(ctx, repo.Host())
-	}
-
-	if experimental && (makeRepoError != nil || repo == nil) {
+	if experimental {
 		repo, makeRepoError = azdorepo.MakeAzureDevOpsRepo(repoURI)
 		if repo != nil && makeRepoError == nil {
 			repoClient, makeRepoError = azdorepo.CreateAzureDevOpsClient(ctx, repo)
+		}
+		if azdorepo.HasAzureDevOpsHost(repoURI) && (makeRepoError != nil || repo == nil) {
+			return repo,
+				nil,
+				nil,
+				nil,
+				nil,
+				packageclient.CreateDepsDevClient(),
+				fmt.Errorf("error making azure devops repo: %w", makeRepoError)
+		}
+	}
+
+	if makeRepoError != nil || repo == nil {
+		repo, makeRepoError = glrepo.MakeGitlabRepo(repoURI)
+		if repo != nil && makeRepoError == nil {
+			repoClient, makeRepoError = glrepo.CreateGitlabClient(ctx, repo.Host())
 		}
 	}
 

--- a/checker/client_test.go
+++ b/checker/client_test.go
@@ -95,6 +95,18 @@ func TestGetClients(t *testing.T) {
 			wantErr:               false,
 			isGhHost:              true,
 		},
+		{
+			name: "malformed Azure DevOps URL does not fall through to GitLab",
+			args: args{
+				ctx:      t.Context(),
+				repoURI:  "http://teamgitlab.visualstudio.com/project/_git/repo",
+				localURI: "",
+			},
+			shouldRepoClientBeNil: true,
+			shouldRepoBeNil:       true,
+			wantErr:               true,
+			experimental:          true,
+		},
 	}
 
 	for _, tt := range tests {

--- a/clients/azuredevopsrepo/repo.go
+++ b/clients/azuredevopsrepo/repo.go
@@ -15,6 +15,7 @@
 package azuredevopsrepo
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
@@ -36,11 +37,49 @@ type Repo struct {
 	metadata      []string
 }
 
+const (
+	azureDevOpsHost        = "dev.azure.com"
+	visualStudioHostSuffix = ".visualstudio.com"
+	defaultCollection      = "DefaultCollection"
+	gitPathSegment         = "_git"
+)
+
+var errInvalidAzureDevOpsPathSegment = errors.New("invalid Azure DevOps path segment")
+
+func hasAzureDevOpsHost(input string) bool {
+	u, err := url.Parse(withDefaultScheme(input))
+	if err != nil {
+		return false
+	}
+
+	host := strings.ToLower(u.Hostname())
+	return host == azureDevOpsHost || strings.HasSuffix(host, visualStudioHostSuffix)
+}
+
+// HasAzureDevOpsHost reports whether input uses an Azure DevOps cloud hostname.
+func HasAzureDevOpsHost(input string) bool {
+	return hasAzureDevOpsHost(input)
+}
+
+func pathSegments(u *url.URL) ([]string, error) {
+	escapedSegments := strings.Split(strings.Trim(u.EscapedPath(), "/"), "/")
+	segments := make([]string, len(escapedSegments))
+	for i, escapedSegment := range escapedSegments {
+		segment, err := url.PathUnescape(escapedSegment)
+		if err != nil || strings.Contains(segment, "/") {
+			return nil, errInvalidAzureDevOpsPathSegment
+		}
+		segments[i] = segment
+	}
+	return segments, nil
+}
+
 // Parses input string into repoURL struct
 /*
- Accepted input string formats are as follows:
+ Accepted input string formats, with or without an https scheme, are as follows:
 	- "dev.azure.com/<organization:string>/<project:string>/_git/<repository:string>"
-	- "https://dev.azure.com/<organization:string>/<project:string>/_git/<repository:string>"
+	- "<organization:string>.visualstudio.com/<project:string>/_git/<repository:string>"
+	- "<organization:string>.visualstudio.com/DefaultCollection/<project:string>/_git/<repository:string>"
 */
 func (r *Repo) parse(input string) error {
 	u, err := url.Parse(withDefaultScheme(input))
@@ -48,13 +87,62 @@ func (r *Repo) parse(input string) error {
 		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("url.Parse: %v", err))
 	}
 
-	const splitLen = 4
-	split := strings.SplitN(strings.Trim(u.Path, "/"), "/", splitLen)
-	if len(split) != splitLen {
+	if !strings.EqualFold(u.Scheme, "https") || u.Port() != "" {
 		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("Azure DevOps repo format is invalid: %s", input))
 	}
 
-	r.scheme, r.host, r.organization, r.project, r.name = u.Scheme, u.Host, split[0], split[1], split[3]
+	host := strings.ToLower(u.Hostname())
+	segments, err := pathSegments(u)
+	if err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("Azure DevOps repo format is invalid: %s", input))
+	}
+
+	var organization, project, gitSegment, name string
+	switch {
+	case host == azureDevOpsHost:
+		if len(segments) != 4 {
+			return sce.WithMessage(
+				sce.ErrScorecardInternal,
+				fmt.Sprintf("Azure DevOps repo format is invalid: %s", input),
+			)
+		}
+		organization, project, gitSegment, name = segments[0], segments[1], segments[2], segments[3]
+	case strings.HasSuffix(host, visualStudioHostSuffix):
+		organization = strings.TrimSuffix(host, visualStudioHostSuffix)
+		if organization == "" || strings.Contains(organization, ".") {
+			return sce.WithMessage(
+				sce.ErrScorecardInternal,
+				fmt.Sprintf("Azure DevOps repo format is invalid: %s", input),
+			)
+		}
+
+		switch {
+		case len(segments) == 3:
+			project, gitSegment, name = segments[0], segments[1], segments[2]
+		case len(segments) == 4 && strings.EqualFold(segments[0], defaultCollection):
+			project, gitSegment, name = segments[1], segments[2], segments[3]
+		default:
+			return sce.WithMessage(
+				sce.ErrScorecardInternal,
+				fmt.Sprintf("Azure DevOps repo format is invalid: %s", input),
+			)
+		}
+	default:
+		return sce.WithMessage(
+			sce.ErrScorecardInternal,
+			fmt.Sprintf("Azure DevOps repo format is invalid: %s", input),
+		)
+	}
+
+	if organization == "" || project == "" || !strings.EqualFold(gitSegment, gitPathSegment) || name == "" {
+		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("Azure DevOps repo format is invalid: %s", input))
+	}
+
+	r.scheme = "https"
+	r.host = azureDevOpsHost
+	r.organization = organization
+	r.project = project
+	r.name = name
 	return nil
 }
 

--- a/clients/azuredevopsrepo/repo_test.go
+++ b/clients/azuredevopsrepo/repo_test.go
@@ -18,21 +18,20 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 )
 
 func TestRepo_parse(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		name         string
-		inputURL     string
-		expected     Repo
-		wantErr      bool
-		flagRequired bool
+		name     string
+		inputURL string
+		expected Repo
+		wantErr  bool
 	}{
 		{
 			name: "valid azuredevops project with scheme",
 			expected: Repo{
+				scheme:       "https",
 				host:         "dev.azure.com",
 				organization: "dnceng-public",
 				project:      "public",
@@ -44,6 +43,7 @@ func TestRepo_parse(t *testing.T) {
 		{
 			name: "valid azuredevops project without scheme",
 			expected: Repo{
+				scheme:       "https",
 				host:         "dev.azure.com",
 				organization: "dnceng-public",
 				project:      "public",
@@ -53,9 +53,129 @@ func TestRepo_parse(t *testing.T) {
 			wantErr:  false,
 		},
 		{
+			name: "valid azuredevops project with user information",
+			expected: Repo{
+				scheme:       "https",
+				host:         "dev.azure.com",
+				organization: "dnceng-public",
+				project:      "public",
+				name:         "public",
+			},
+			inputURL: "https://dnceng-public@dev.azure.com/dnceng-public/public/_git/public?version=1#readme",
+			wantErr:  false,
+		},
+		{
+			name: "valid legacy project with scheme",
+			expected: Repo{
+				scheme:       "https",
+				host:         "dev.azure.com",
+				organization: "dnceng-public",
+				project:      "public",
+				name:         "public",
+			},
+			inputURL: "https://dnceng-public.visualstudio.com/public/_git/public",
+			wantErr:  false,
+		},
+		{
+			name: "valid legacy project without scheme",
+			expected: Repo{
+				scheme:       "https",
+				host:         "dev.azure.com",
+				organization: "dnceng-public",
+				project:      "public",
+				name:         "public",
+			},
+			inputURL: "dnceng-public.visualstudio.com/public/_git/public",
+			wantErr:  false,
+		},
+		{
+			name: "valid legacy DefaultCollection project with scheme",
+			expected: Repo{
+				scheme:       "https",
+				host:         "dev.azure.com",
+				organization: "dnceng-public",
+				project:      "public",
+				name:         "public",
+			},
+			inputURL: "https://dnceng-public.visualstudio.com/DefaultCollection/public/_git/public",
+			wantErr:  false,
+		},
+		{
+			name: "valid legacy DefaultCollection project without scheme",
+			expected: Repo{
+				scheme:       "https",
+				host:         "dev.azure.com",
+				organization: "dnceng-public",
+				project:      "public",
+				name:         "public",
+			},
+			inputURL: "dnceng-public.visualstudio.com/DefaultCollection/public/_git/public",
+			wantErr:  false,
+		},
+		{
+			name: "valid legacy project with case-insensitive markers",
+			expected: Repo{
+				scheme:       "https",
+				host:         "dev.azure.com",
+				organization: "dnceng-public",
+				project:      "public",
+				name:         "public",
+			},
+			inputURL: "https://DNCENG-PUBLIC.visualstudio.com/defaultcollection/public/_GIT/public",
+			wantErr:  false,
+		},
+		{
 			name:     "invalid azuredevops project missing repo",
 			expected: Repo{},
 			inputURL: "https://dev.azure.com/dnceng-public/public",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid host",
+			expected: Repo{},
+			inputURL: "https://example.com/dnceng-public/public/_git/public",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid nested legacy host",
+			expected: Repo{},
+			inputURL: "https://nested.dnceng-public.visualstudio.com/public/_git/public",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid HTTP URL",
+			expected: Repo{},
+			inputURL: "http://dev.azure.com/dnceng-public/public/_git/public",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid URL with port",
+			expected: Repo{},
+			inputURL: "https://dev.azure.com:8443/dnceng-public/public/_git/public",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid git path segment",
+			expected: Repo{},
+			inputURL: "https://dev.azure.com/dnceng-public/public/git/public",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid legacy project with extra path segment",
+			expected: Repo{},
+			inputURL: "https://dnceng-public.visualstudio.com/public/_git/public/extra",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid DefaultCollection path",
+			expected: Repo{},
+			inputURL: "https://dnceng-public.visualstudio.com/DefaultCollection/public/public",
+			wantErr:  true,
+		},
+		{
+			name:     "invalid encoded path separator",
+			expected: Repo{},
+			inputURL: "https://dev.azure.com/dnceng-public%2Fpublic/_git/public",
 			wantErr:  true,
 		},
 	}
@@ -70,16 +190,59 @@ func TestRepo_parse(t *testing.T) {
 			if tt.wantErr {
 				return
 			}
-			t.Log(r.URI())
-			if !tt.wantErr && !cmp.Equal(tt.expected, r, cmpopts.IgnoreUnexported(Repo{})) {
-				t.Logf("expected: %s GOT: %s", tt.expected.host, r.host)
-				t.Logf("expected: %s GOT: %s", tt.expected.organization, r.organization)
-				t.Logf("expected: %s GOT: %s", tt.expected.project, r.project)
-				t.Logf("expected: %s GOT: %s", tt.expected.name, r.name)
-				t.Errorf("Got diff: %s", cmp.Diff(tt.expected, r))
+			if diff := cmp.Diff(tt.expected, r, cmp.AllowUnexported(Repo{})); diff != "" {
+				t.Errorf("Repo mismatch (-want +got):\n%s", diff)
 			}
-			if !cmp.Equal(r.Host(), tt.expected.host) {
-				t.Errorf("%s expected host: %s got host %s", tt.inputURL, tt.expected.host, r.Host())
+			if got, want := r.Host(), tt.expected.Host(); got != want {
+				t.Errorf("Host() = %q, want %q", got, want)
+			}
+			if got, want := r.Path(), tt.expected.Path(); got != want {
+				t.Errorf("Path() = %q, want %q", got, want)
+			}
+			if got, want := r.URI(), tt.expected.URI(); got != want {
+				t.Errorf("URI() = %q, want %q", got, want)
+			}
+			if got, want := r.String(), tt.expected.String(); got != want {
+				t.Errorf("String() = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestHasAzureDevOpsHost(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name  string
+		input string
+		want  bool
+	}{
+		{
+			name:  "canonical host",
+			input: "https://dev.azure.com/dnceng-public/public/_git/public",
+			want:  true,
+		},
+		{
+			name:  "legacy host",
+			input: "dnceng-public.visualstudio.com/public/_git/public",
+			want:  true,
+		},
+		{
+			name:  "nested legacy host remains Azure-associated",
+			input: "https://nested.dnceng-public.visualstudio.com/public/_git/public",
+			want:  true,
+		},
+		{
+			name:  "unsupported host",
+			input: "https://gitlab.com/ossf/scorecard",
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := HasAzureDevOpsHost(tt.input); got != tt.want {
+				t.Errorf("HasAzureDevOpsHost() = %t, want %t", got, tt.want)
 			}
 		})
 	}
@@ -132,9 +295,8 @@ func TestRepo_IsValid(t *testing.T) {
 func TestRepo_MakeAzureDevOpsRepo(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
-		repouri      string
-		expected     bool
-		flagRequired bool
+		repouri  string
+		expected bool
 	}{
 		{
 			repouri:  "github.com/ossf/scorecard",
@@ -155,6 +317,18 @@ func TestRepo_MakeAzureDevOpsRepo(t *testing.T) {
 		{
 			repouri:  "dev.azure.com/dnceng-public/public/_git/public",
 			expected: true,
+		},
+		{
+			repouri:  "https://dnceng-public.visualstudio.com/public/_git/public",
+			expected: true,
+		},
+		{
+			repouri:  "dnceng-public.visualstudio.com/DefaultCollection/public/_git/public",
+			expected: true,
+		},
+		{
+			repouri:  "https://example.com/dnceng-public/public/_git/public",
+			expected: false,
 		},
 	}
 

--- a/clients/azuredevopsrepo/zip_e2e_test.go
+++ b/clients/azuredevopsrepo/zip_e2e_test.go
@@ -26,7 +26,9 @@ import (
 var _ = Describe("E2E TEST: azuredevopsrepo.zipHandler", func() {
 	Context("Zip - Azure DevOps", func() {
 		It("Should list files in repository", func() {
-			repo, err := MakeAzureDevOpsRepo("https://dev.azure.com/openssf-scorecard/scorecard-testing/_git/scorecard-testing")
+			repo, err := MakeAzureDevOpsRepo(
+				"https://openssf-scorecard.visualstudio.com/scorecard-testing/_git/scorecard-testing",
+			)
 			Expect(err).Should(BeNil())
 
 			repoClient, err := CreateAzureDevOpsClient(context.Background(), repo)
@@ -56,7 +58,9 @@ var _ = Describe("E2E TEST: azuredevopsrepo.zipHandler", func() {
 			Expect(repoClient.Close()).Should(BeNil())
 		})
 		It("Should get file reader for a file", func() {
-			repo, err := MakeAzureDevOpsRepo("https://dev.azure.com/openssf-scorecard/scorecard-testing/_git/scorecard-testing")
+			repo, err := MakeAzureDevOpsRepo(
+				"https://openssf-scorecard.visualstudio.com/DefaultCollection/scorecard-testing/_git/scorecard-testing",
+			)
 			Expect(err).Should(BeNil())
 
 			repoClient, err := CreateAzureDevOpsClient(context.Background(), repo)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -257,12 +257,6 @@ func makeRepo(uri string) (clients.Repo, error) {
 	}
 	compositeErr = errors.Join(compositeErr, errGitHub)
 
-	repo, errGitLab = gitlabrepo.MakeGitlabRepo(uri)
-	if errGitLab == nil {
-		return repo, nil
-	}
-	compositeErr = errors.Join(compositeErr, errGitLab)
-
 	_, experimental := os.LookupEnv("SCORECARD_EXPERIMENTAL")
 	if experimental {
 		repo, errAzureDevOps = azuredevopsrepo.MakeAzureDevOpsRepo(uri)
@@ -270,7 +264,16 @@ func makeRepo(uri string) (clients.Repo, error) {
 			return repo, nil
 		}
 		compositeErr = errors.Join(compositeErr, errAzureDevOps)
+		if azuredevopsrepo.HasAzureDevOpsHost(uri) {
+			return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", compositeErr)
+		}
 	}
+
+	repo, errGitLab = gitlabrepo.MakeGitlabRepo(uri)
+	if errGitLab == nil {
+		return repo, nil
+	}
+	compositeErr = errors.Join(compositeErr, errGitLab)
 
 	return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", compositeErr)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -265,7 +265,7 @@ func makeRepo(uri string) (clients.Repo, error) {
 		}
 		compositeErr = errors.Join(compositeErr, errAzureDevOps)
 		if azuredevopsrepo.HasAzureDevOpsHost(uri) {
-			return nil, fmt.Errorf("unable to parse as github, gitlab, or azuredevops: %w", compositeErr)
+			return nil, fmt.Errorf("unable to parse Azure DevOps repository URI: %w", errAzureDevOps)
 		}
 	}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -1,0 +1,52 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"testing"
+
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+func TestMakeRepoLegacyAzureDevOpsURL(t *testing.T) {
+	t.Setenv("SCORECARD_EXPERIMENTAL", "1")
+
+	repo, err := makeRepo(
+		"https://dnceng-public.visualstudio.com/DefaultCollection/public/_git/public",
+	)
+	if err != nil {
+		t.Fatalf("makeRepo() error = %v", err)
+	}
+	if got, want := repo.Type(), clients.RepoTypeAzureDevOps; got != want {
+		t.Errorf("Type() = %q, want %q", got, want)
+	}
+	if got, want := repo.URI(), "dev.azure.com/dnceng-public/public/_git/public"; got != want {
+		t.Errorf("URI() = %q, want %q", got, want)
+	}
+}
+
+func TestMakeRepoRejectsMalformedAzureDevOpsURL(t *testing.T) {
+	t.Setenv("SCORECARD_EXPERIMENTAL", "1")
+
+	tests := []string{
+		"http://teamgitlab.visualstudio.com/project/_git/repo",
+		"https://teamgitlab.visualstudio.com:8443/project/_git/repo",
+	}
+	for _, repoURI := range tests {
+		if repo, err := makeRepo(repoURI); err == nil || repo != nil {
+			t.Errorf("makeRepo(%q) = %v, %v; want nil repo and error", repoURI, repo, err)
+		}
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Scorecard rejects valid Azure DevOps cloud repository URLs that use `*.visualstudio.com`, including `DefaultCollection` URLs.

#### What is the new behavior (if this is a feature change)?

Scorecard accepts canonical and legacy Azure DevOps cloud URLs and normalizes them to `dev.azure.com` before creating repository clients.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

Azure DevOps Server URLs remain out of scope.

#### Does this PR introduce a user-facing change?

Yes.

```release-note
Support legacy Azure DevOps repository URLs.
```
