### PR TITLE
:bug: Avoid querying all Azure builds for a missing workflow

### DIFF
--- a/clients/azuredevopsrepo/builds.go
+++ b/clients/azuredevopsrepo/builds.go
@@ -77,6 +77,10 @@ func (b *buildsHandler) listSuccessfulBuilds(filename string) ([]clients.Workflo
 		continuationToken = response.ContinuationToken
 	}
 
+	if len(buildDefinitions) == 0 {
+		return []clients.WorkflowRun{}, nil
+	}
+
 	buildIds := make([]int, 0, len(buildDefinitions))
 	for i := range buildDefinitions {
 		buildIds = append(buildIds, *buildDefinitions[i].Id)

--- a/clients/azuredevopsrepo/builds_e2e_test.go
+++ b/clients/azuredevopsrepo/builds_e2e_test.go
@@ -40,5 +40,24 @@ var _ = Describe("E2E TEST: azuredevopsrepo.buildsHandler", func() {
 			// Builds may be empty if hosted parallelism hasn't been granted yet.
 			Expect(builds).ShouldNot(BeNil())
 		})
+		It("Should return no builds when the YAML file does not exist", func() {
+			repo, err := MakeAzureDevOpsRepo(
+				"https://dev.azure.com/openssf-scorecard/scorecard-testing/_git/scorecard-testing",
+			)
+			Expect(err).Should(BeNil())
+
+			repoClient, err := CreateAzureDevOpsClient(context.Background(), repo)
+			Expect(err).Should(BeNil())
+
+			err = repoClient.InitRepo(repo, clients.HeadSHA, 0)
+			Expect(err).Should(BeNil())
+
+			builds, err := repoClient.ListSuccessfulWorkflowRuns("does-not-exist.yml")
+			Expect(err).Should(BeNil())
+			Expect(builds).ShouldNot(BeNil())
+			Expect(builds).Should(BeEmpty())
+
+			Expect(repoClient.Close()).Should(BeNil())
+		})
 	})
 })

--- a/clients/azuredevopsrepo/builds_test.go
+++ b/clients/azuredevopsrepo/builds_test.go
@@ -42,7 +42,7 @@ func Test_listSuccessfulBuilds(t *testing.T) {
 				}, nil
 			},
 			getBuilds: func(ctx context.Context, args build.GetBuildsArgs) (*build.GetBuildsResponseValue, error) {
-				return &build.GetBuildsResponseValue{}, nil
+				return nil, errors.New("getBuilds should not be called")
 			},
 			want:    []clients.WorkflowRun{},
 			wantErr: false,


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

When no Azure YAML definition matches a workflow filename, Scorecard queries builds with an empty definition filter. Azure DevOps treats that as all builds.

#### What is the new behavior (if this is a feature change)?

Scorecard returns an empty workflow run list without querying builds when no definition matches.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

This does not change branch, recency, or result filtering.

#### Does this PR introduce a user-facing change?

Yes.

```release-note
Return no Azure workflow runs when the requested YAML pipeline does not exist.
```
