### PR TITLE
:bug: Fall back when Azure language metrics are unavailable

### DIFF
--- a/clients/azuredevopsrepo/languages.go
+++ b/clients/azuredevopsrepo/languages.go
@@ -16,13 +16,18 @@ package azuredevopsrepo
 
 import (
 	"context"
-	"log"
+	"errors"
+	"fmt"
+	"strings"
 	"sync"
 
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/projectanalysis"
 
 	"github.com/ossf/scorecard/v5/clients"
 )
+
+var errLanguageAnalyticsMalformed = errors.New("azure DevOps language analytics response is malformed")
 
 type languagesHandler struct {
 	ctx                   context.Context
@@ -50,6 +55,82 @@ type (
 	) (*projectanalysis.ProjectLanguageAnalytics, error)
 )
 
+func isLanguageAnalyticsUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	var wrappedError azuredevops.WrappedError
+	if errors.As(err, &wrappedError) && wrappedError.StatusCode != nil {
+		switch *wrappedError.StatusCode {
+		case 401, 403, 404:
+			return true
+		}
+	}
+	var wrappedErrorPointer *azuredevops.WrappedError
+	if errors.As(err, &wrappedErrorPointer) && wrappedErrorPointer.StatusCode != nil {
+		switch *wrappedErrorPointer.StatusCode {
+		case 401, 403, 404:
+			return true
+		}
+	}
+
+	message := strings.ToLower(err.Error())
+	for _, fragment := range []string{
+		"access denied",
+		"not authorized",
+		"permission",
+		"not available",
+		"not enabled",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *languagesHandler) useAllLanguagesFallback() {
+	l.languages = []clients.Language{{Name: clients.All, NumLines: 1}}
+	l.errSetup = nil
+}
+
+func (l *languagesHandler) useProjectAnalytics(res *projectanalysis.ProjectLanguageAnalytics) error {
+	if res.RepositoryLanguageAnalytics == nil {
+		return fmt.Errorf("%w: missing repositories", errLanguageAnalyticsMalformed)
+	}
+
+	for _, repo := range *res.RepositoryLanguageAnalytics {
+		if repo.Id == nil {
+			return fmt.Errorf("%w: missing repository ID", errLanguageAnalyticsMalformed)
+		}
+		if repo.Id.String() != l.repourl.id {
+			continue
+		}
+		if repo.LanguageBreakdown == nil {
+			return fmt.Errorf("%w: missing language breakdown", errLanguageAnalyticsMalformed)
+		}
+
+		// TODO: Find the number of lines in the repo and multiply the value of each language by that number.
+		for _, language := range *repo.LanguageBreakdown {
+			if language.Name == nil {
+				return fmt.Errorf("%w: missing language name", errLanguageAnalyticsMalformed)
+			}
+			percentage := 0
+			if language.LanguagePercentage != nil {
+				percentage = int(*language.LanguagePercentage)
+			}
+			l.languages = append(l.languages,
+				clients.Language{
+					Name:     clients.LanguageName(*language.Name),
+					NumLines: percentage,
+				},
+			)
+		}
+	}
+	return nil
+}
+
 func (l *languagesHandler) setup() error {
 	l.once.Do(func() {
 		args := projectanalysis.GetProjectLanguageAnalyticsArgs{
@@ -57,33 +138,23 @@ func (l *languagesHandler) setup() error {
 		}
 		res, err := l.projectAnalysis(l.ctx, args)
 		if err != nil {
+			if isLanguageAnalyticsUnavailable(err) {
+				l.useAllLanguagesFallback()
+				return
+			}
 			l.errSetup = err
 			return
 		}
 
-		if res.ResultPhase != &projectanalysis.ResultPhaseValues.Full {
-			log.Println("Project language analytics not ready yet. Results may be incomplete.")
+		if res == nil {
+			l.errSetup = fmt.Errorf("%w: missing response", errLanguageAnalyticsMalformed)
+			return
 		}
-
-		for _, repo := range *res.RepositoryLanguageAnalytics {
-			if repo.Id.String() != l.repourl.id {
-				continue
-			}
-
-			// TODO: Find the number of lines in the repo and multiply the value of each language by that number.
-			for _, language := range *repo.LanguageBreakdown {
-				percentage := 0
-				if language.LanguagePercentage != nil {
-					percentage = int(*language.LanguagePercentage)
-				}
-				l.languages = append(l.languages,
-					clients.Language{
-						Name:     clients.LanguageName(*language.Name),
-						NumLines: percentage,
-					},
-				)
-			}
+		if res.ResultPhase == nil || *res.ResultPhase != projectanalysis.ResultPhaseValues.Full {
+			l.useAllLanguagesFallback()
+			return
 		}
+		l.errSetup = l.useProjectAnalytics(res)
 	})
 	return l.errSetup
 }

--- a/clients/azuredevopsrepo/languages.go
+++ b/clients/azuredevopsrepo/languages.go
@@ -16,13 +16,19 @@ package azuredevopsrepo
 
 import (
 	"context"
-	"log"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
 	"sync"
 
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/projectanalysis"
 
 	"github.com/ossf/scorecard/v5/clients"
 )
+
+var errLanguageAnalyticsMalformed = errors.New("azure DevOps language analytics response is malformed")
 
 type languagesHandler struct {
 	ctx                   context.Context
@@ -50,6 +56,89 @@ type (
 	) (*projectanalysis.ProjectLanguageAnalytics, error)
 )
 
+func azureDevOpsErrorStatusCode(err error) (int, bool) {
+	var wrappedError azuredevops.WrappedError
+	if errors.As(err, &wrappedError) && wrappedError.StatusCode != nil {
+		return *wrappedError.StatusCode, true
+	}
+
+	var wrappedErrorPointer *azuredevops.WrappedError
+	if errors.As(err, &wrappedErrorPointer) &&
+		wrappedErrorPointer != nil &&
+		wrappedErrorPointer.StatusCode != nil {
+		return *wrappedErrorPointer.StatusCode, true
+	}
+
+	return 0, false
+}
+
+func isLanguageAnalyticsUnavailable(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	if statusCode, ok := azureDevOpsErrorStatusCode(err); ok {
+		switch statusCode {
+		case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+			return true
+		}
+	}
+
+	message := strings.ToLower(err.Error())
+	for _, fragment := range []string{
+		"access denied",
+		"not authorized",
+		"permission",
+		"not available",
+		"not enabled",
+	} {
+		if strings.Contains(message, fragment) {
+			return true
+		}
+	}
+	return false
+}
+
+func (l *languagesHandler) useAllLanguagesFallback() {
+	l.languages = []clients.Language{{Name: clients.All, NumLines: 1}}
+}
+
+func (l *languagesHandler) useProjectAnalytics(res *projectanalysis.ProjectLanguageAnalytics) error {
+	if res.RepositoryLanguageAnalytics == nil {
+		return fmt.Errorf("%w: missing repositories", errLanguageAnalyticsMalformed)
+	}
+
+	for _, repo := range *res.RepositoryLanguageAnalytics {
+		if repo.Id == nil {
+			return fmt.Errorf("%w: missing repository ID", errLanguageAnalyticsMalformed)
+		}
+		if repo.Id.String() != l.repourl.id {
+			continue
+		}
+		if repo.LanguageBreakdown == nil {
+			return fmt.Errorf("%w: missing language breakdown", errLanguageAnalyticsMalformed)
+		}
+
+		// TODO: Find the number of lines in the repo and multiply the value of each language by that number.
+		for _, language := range *repo.LanguageBreakdown {
+			if language.Name == nil {
+				return fmt.Errorf("%w: missing language name", errLanguageAnalyticsMalformed)
+			}
+			percentage := 0
+			if language.LanguagePercentage != nil {
+				percentage = int(*language.LanguagePercentage)
+			}
+			l.languages = append(l.languages,
+				clients.Language{
+					Name:     clients.LanguageName(*language.Name),
+					NumLines: percentage,
+				},
+			)
+		}
+	}
+	return nil
+}
+
 func (l *languagesHandler) setup() error {
 	l.once.Do(func() {
 		args := projectanalysis.GetProjectLanguageAnalyticsArgs{
@@ -57,33 +146,23 @@ func (l *languagesHandler) setup() error {
 		}
 		res, err := l.projectAnalysis(l.ctx, args)
 		if err != nil {
+			if isLanguageAnalyticsUnavailable(err) {
+				l.useAllLanguagesFallback()
+				return
+			}
 			l.errSetup = err
 			return
 		}
 
-		if res.ResultPhase != &projectanalysis.ResultPhaseValues.Full {
-			log.Println("Project language analytics not ready yet. Results may be incomplete.")
+		if res == nil {
+			l.errSetup = fmt.Errorf("%w: missing response", errLanguageAnalyticsMalformed)
+			return
 		}
-
-		for _, repo := range *res.RepositoryLanguageAnalytics {
-			if repo.Id.String() != l.repourl.id {
-				continue
-			}
-
-			// TODO: Find the number of lines in the repo and multiply the value of each language by that number.
-			for _, language := range *repo.LanguageBreakdown {
-				percentage := 0
-				if language.LanguagePercentage != nil {
-					percentage = int(*language.LanguagePercentage)
-				}
-				l.languages = append(l.languages,
-					clients.Language{
-						Name:     clients.LanguageName(*language.Name),
-						NumLines: percentage,
-					},
-				)
-			}
+		if res.ResultPhase == nil || *res.ResultPhase != projectanalysis.ResultPhaseValues.Full {
+			l.useAllLanguagesFallback()
+			return
 		}
+		l.errSetup = l.useProjectAnalytics(res)
 	})
 	return l.errSetup
 }

--- a/clients/azuredevopsrepo/languages_test.go
+++ b/clients/azuredevopsrepo/languages_test.go
@@ -16,11 +16,13 @@ package azuredevopsrepo
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/projectanalysis"
 
 	"github.com/ossf/scorecard/v5/clients"
@@ -30,7 +32,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name            string
-		projectAnalysis func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error)
+		projectAnalysis fnGetProjectLanguageAnalytics
 		want            []clients.Language
 		wantErr         bool
 	}{
@@ -39,6 +41,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
 				return &projectanalysis.ProjectLanguageAnalytics{
 					RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{},
+					ResultPhase:                 toPtr(projectanalysis.ResultPhaseValues.Full),
 				}, nil
 			},
 			want:    []clients.Language(nil),
@@ -48,6 +51,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			name: "single response",
 			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
 				return &projectanalysis.ProjectLanguageAnalytics{
+					ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
 					RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
 						{
 							Id: toPtr(uuid.Nil),
@@ -73,6 +77,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			name: "multiple response",
 			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
 				return &projectanalysis.ProjectLanguageAnalytics{
+					ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
 					RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
 						{
 							Id: toPtr(uuid.Nil),
@@ -102,6 +107,14 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "API error",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return nil, errors.New("network error")
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -120,8 +133,218 @@ func Test_listProgrammingLanguages(t *testing.T) {
 				t.Errorf("listProgrammingLanguages() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !cmp.Equal(got, tt.want) {
-				t.Errorf("listProgrammingLanguages() got = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("languages mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isLanguageAnalyticsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct { //nolint:govet
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "forbidden status",
+			err: azuredevops.WrappedError{
+				Message:    toPtr("forbidden"),
+				StatusCode: toPtr(403),
+			},
+			want: true,
+		},
+		{
+			name: "not found status",
+			err: azuredevops.WrappedError{
+				Message:    toPtr("not found"),
+				StatusCode: toPtr(404),
+			},
+			want: true,
+		},
+		{
+			name: "unauthorized pointer status",
+			err: &azuredevops.WrappedError{
+				Message:    toPtr("unauthorized"),
+				StatusCode: toPtr(401),
+			},
+			want: true,
+		},
+		{
+			name: "access denied message",
+			err:  errors.New("Access Denied: missing permission"),
+			want: true,
+		},
+		{
+			name: "server error",
+			err: azuredevops.WrappedError{
+				Message:    toPtr("server error"),
+				StatusCode: toPtr(500),
+			},
+			want: false,
+		},
+		{
+			name: "network error",
+			err:  errors.New("network error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isLanguageAnalyticsUnavailable(tt.err); got != tt.want {
+				t.Errorf("isLanguageAnalyticsUnavailable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_listProgrammingLanguagesFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct { //nolint:govet
+		name            string
+		projectAnalysis fnGetProjectLanguageAnalytics
+	}{
+		{
+			name: "permission denied",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return nil, azuredevops.WrappedError{
+					Message:    toPtr("Access Denied"),
+					StatusCode: toPtr(403),
+				}
+			},
+		},
+		{
+			name: "nil phase",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return &projectanalysis.ProjectLanguageAnalytics{}, nil
+			},
+		},
+		{
+			name: "preliminary phase",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return &projectanalysis.ProjectLanguageAnalytics{
+					ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Preliminary),
+				}, nil
+			},
+		},
+	}
+	want := []clients.Language{{Name: clients.All, NumLines: 1}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projectCalls := 0
+			l := &languagesHandler{
+				once: new(sync.Once),
+				ctx:  t.Context(),
+				repourl: &Repo{
+					id:      uuid.Nil.String(),
+					project: "project",
+				},
+				projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+					projectCalls++
+					return tt.projectAnalysis(ctx, args)
+				},
+			}
+
+			got, err := l.listProgrammingLanguages()
+			if err != nil {
+				t.Fatalf("listProgrammingLanguages() error = %v", err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("languages mismatch (-want +got):\n%s", diff)
+			}
+
+			got, err = l.listProgrammingLanguages()
+			if err != nil {
+				t.Fatalf("second listProgrammingLanguages() error = %v", err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("second languages mismatch (-want +got):\n%s", diff)
+			}
+			if projectCalls != 1 {
+				t.Errorf("project analysis calls = %d, want 1", projectCalls)
+			}
+		})
+	}
+}
+
+func Test_listProgrammingLanguagesMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct { //nolint:govet
+		name     string
+		response *projectanalysis.ProjectLanguageAnalytics
+	}{
+		{
+			name:     "nil response",
+			response: nil,
+		},
+		{
+			name: "missing repositories",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+			},
+		},
+		{
+			name: "missing repository ID",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+				RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
+					{},
+				},
+			},
+		},
+		{
+			name: "missing language breakdown",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+				RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
+					{Id: toPtr(uuid.Nil)},
+				},
+			},
+		},
+		{
+			name: "missing language name",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+				RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
+					{
+						Id: toPtr(uuid.Nil),
+						LanguageBreakdown: &[]projectanalysis.LanguageStatistics{
+							{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := &languagesHandler{
+				once: new(sync.Once),
+				ctx:  t.Context(),
+				repourl: &Repo{
+					id:      uuid.Nil.String(),
+					project: "project",
+				},
+				projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+					return tt.response, nil
+				},
+			}
+
+			_, err := l.listProgrammingLanguages()
+			if !errors.Is(err, errLanguageAnalyticsMalformed) {
+				t.Errorf("listProgrammingLanguages() error = %v, want malformed analytics error", err)
 			}
 		})
 	}

--- a/clients/azuredevopsrepo/languages_test.go
+++ b/clients/azuredevopsrepo/languages_test.go
@@ -16,21 +16,37 @@ package azuredevopsrepo
 
 import (
 	"context"
+	"errors"
 	"sync"
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/uuid"
+	"github.com/microsoft/azure-devops-go-api/azuredevops/v7"
 	"github.com/microsoft/azure-devops-go-api/azuredevops/v7/projectanalysis"
 
 	"github.com/ossf/scorecard/v5/clients"
 )
 
+func newTestLanguagesHandler(t *testing.T, projectAnalysis fnGetProjectLanguageAnalytics) *languagesHandler {
+	t.Helper()
+
+	return &languagesHandler{
+		once: new(sync.Once),
+		ctx:  t.Context(),
+		repourl: &Repo{
+			id:      uuid.Nil.String(),
+			project: "project",
+		},
+		projectAnalysis: projectAnalysis,
+	}
+}
+
 func Test_listProgrammingLanguages(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name            string
-		projectAnalysis func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error)
+		projectAnalysis fnGetProjectLanguageAnalytics
 		want            []clients.Language
 		wantErr         bool
 	}{
@@ -39,6 +55,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
 				return &projectanalysis.ProjectLanguageAnalytics{
 					RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{},
+					ResultPhase:                 toPtr(projectanalysis.ResultPhaseValues.Full),
 				}, nil
 			},
 			want:    []clients.Language(nil),
@@ -48,6 +65,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			name: "single response",
 			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
 				return &projectanalysis.ProjectLanguageAnalytics{
+					ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
 					RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
 						{
 							Id: toPtr(uuid.Nil),
@@ -73,6 +91,7 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			name: "multiple response",
 			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
 				return &projectanalysis.ProjectLanguageAnalytics{
+					ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
 					RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
 						{
 							Id: toPtr(uuid.Nil),
@@ -102,26 +121,222 @@ func Test_listProgrammingLanguages(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "API error",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return nil, errors.New("network error")
+			},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-			l := &languagesHandler{
-				once: new(sync.Once),
-				ctx:  t.Context(),
-				repourl: &Repo{
-					id:      uuid.Nil.String(),
-					project: "project",
-				},
-				projectAnalysis: tt.projectAnalysis,
-			}
+			l := newTestLanguagesHandler(t, tt.projectAnalysis)
 			got, err := l.listProgrammingLanguages()
 			if (err != nil) != tt.wantErr {
 				t.Errorf("listProgrammingLanguages() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if !cmp.Equal(got, tt.want) {
-				t.Errorf("listProgrammingLanguages() got = %v, want %v", got, tt.want)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("languages mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func Test_isLanguageAnalyticsUnavailable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct { //nolint:govet
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "forbidden status",
+			err: azuredevops.WrappedError{
+				Message:    toPtr("forbidden"),
+				StatusCode: toPtr(403),
+			},
+			want: true,
+		},
+		{
+			name: "not found status",
+			err: azuredevops.WrappedError{
+				Message:    toPtr("not found"),
+				StatusCode: toPtr(404),
+			},
+			want: true,
+		},
+		{
+			name: "unauthorized pointer status",
+			err: &azuredevops.WrappedError{
+				Message:    toPtr("unauthorized"),
+				StatusCode: toPtr(401),
+			},
+			want: true,
+		},
+		{
+			name: "access denied message",
+			err:  errors.New("Access Denied: missing permission"),
+			want: true,
+		},
+		{
+			name: "server error",
+			err: azuredevops.WrappedError{
+				Message:    toPtr("server error"),
+				StatusCode: toPtr(500),
+			},
+			want: false,
+		},
+		{
+			name: "network error",
+			err:  errors.New("network error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isLanguageAnalyticsUnavailable(tt.err); got != tt.want {
+				t.Errorf("isLanguageAnalyticsUnavailable() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_listProgrammingLanguagesFallback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct { //nolint:govet
+		name            string
+		projectAnalysis fnGetProjectLanguageAnalytics
+	}{
+		{
+			name: "permission denied",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return nil, azuredevops.WrappedError{
+					Message:    toPtr("Access Denied"),
+					StatusCode: toPtr(403),
+				}
+			},
+		},
+		{
+			name: "nil phase",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return &projectanalysis.ProjectLanguageAnalytics{}, nil
+			},
+		},
+		{
+			name: "preliminary phase",
+			projectAnalysis: func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+				return &projectanalysis.ProjectLanguageAnalytics{
+					ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Preliminary),
+				}, nil
+			},
+		},
+	}
+	want := []clients.Language{{Name: clients.All, NumLines: 1}}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			projectCalls := 0
+			l := newTestLanguagesHandler(t,
+				func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+					projectCalls++
+					return tt.projectAnalysis(ctx, args)
+				})
+
+			got, err := l.listProgrammingLanguages()
+			if err != nil {
+				t.Fatalf("listProgrammingLanguages() error = %v", err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("languages mismatch (-want +got):\n%s", diff)
+			}
+
+			got, err = l.listProgrammingLanguages()
+			if err != nil {
+				t.Fatalf("second listProgrammingLanguages() error = %v", err)
+			}
+			if diff := cmp.Diff(want, got); diff != "" {
+				t.Errorf("second languages mismatch (-want +got):\n%s", diff)
+			}
+			if projectCalls != 1 {
+				t.Errorf("project analysis calls = %d, want 1", projectCalls)
+			}
+		})
+	}
+}
+
+func Test_listProgrammingLanguagesMalformedResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct { //nolint:govet
+		name     string
+		response *projectanalysis.ProjectLanguageAnalytics
+	}{
+		{
+			name:     "nil response",
+			response: nil,
+		},
+		{
+			name: "missing repositories",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+			},
+		},
+		{
+			name: "missing repository ID",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+				RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
+					{},
+				},
+			},
+		},
+		{
+			name: "missing language breakdown",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+				RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
+					{Id: toPtr(uuid.Nil)},
+				},
+			},
+		},
+		{
+			name: "missing language name",
+			response: &projectanalysis.ProjectLanguageAnalytics{
+				ResultPhase: toPtr(projectanalysis.ResultPhaseValues.Full),
+				RepositoryLanguageAnalytics: &[]projectanalysis.RepositoryLanguageAnalytics{
+					{
+						Id: toPtr(uuid.Nil),
+						LanguageBreakdown: &[]projectanalysis.LanguageStatistics{
+							{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			l := newTestLanguagesHandler(t,
+				func(ctx context.Context, args projectanalysis.GetProjectLanguageAnalyticsArgs) (*projectanalysis.ProjectLanguageAnalytics, error) {
+					return tt.response, nil
+				})
+
+			_, err := l.listProgrammingLanguages()
+			if !errors.Is(err, errLanguageAnalyticsMalformed) {
+				t.Errorf("listProgrammingLanguages() error = %v, want malformed analytics error", err)
 			}
 		})
 	}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Azure checks fail when Project Analysis language metrics are unavailable, incomplete, or blocked by the pipeline token's permissions.

#### What is the new behavior (if this is a feature change)?

The Azure client returns the existing `clients.All` sentinel in those cases, so language-aware checks conservatively test every supported language. Full analytics results remain unchanged, and unrelated errors still propagate.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

This uses the same fallback contract as local-directory scans and does not add a separate language detector.

#### Does this PR introduce a user-facing change?

Yes.

```release-note
Fall back to all supported language checks when Azure language analytics are unavailable.
```
