### PR TITLE
:sparkles: Factor private vulnerability reporting into the Security-Policy score

### DIFF
--- a/checker/raw_result.go
+++ b/checker/raw_result.go
@@ -299,8 +299,26 @@ type SASTWorkflow struct {
 // SecurityPolicyData contains the raw results
 // for the Security-Policy check.
 type SecurityPolicyData struct {
-	PolicyFiles []SecurityPolicyFile
+	PolicyFiles                   []SecurityPolicyFile
+	PrivateVulnerabilityReporting PrivateVulnerabilityReportingStatus
 }
+
+// PrivateVulnerabilityReportingStatus describes whether a repository provides
+// a private vulnerability reporting channel. NotSupported is the zero value so
+// file-only and non-GitHub checks retain their existing behavior.
+type PrivateVulnerabilityReportingStatus int
+
+const (
+	// PrivateVulnerabilityReportingNotSupported means the repository provider
+	// does not expose this setting.
+	PrivateVulnerabilityReportingNotSupported PrivateVulnerabilityReportingStatus = iota
+	// PrivateVulnerabilityReportingEnabled means private reporting is enabled.
+	PrivateVulnerabilityReportingEnabled
+	// PrivateVulnerabilityReportingDisabled means private reporting is disabled.
+	PrivateVulnerabilityReportingDisabled
+	// PrivateVulnerabilityReportingNotAvailable means the setting could not be retrieved.
+	PrivateVulnerabilityReportingNotAvailable
+)
 
 // BinaryArtifactData contains the raw results
 // for the Binary-Artifact check.

--- a/checks/evaluation/security_policy.go
+++ b/checks/evaluation/security_policy.go
@@ -22,16 +22,18 @@ import (
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsText"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsVulnerabilityDisclosure"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyPresent"
+	"github.com/ossf/scorecard/v5/probes/securityPolicyPrivateVulnerabilityReportingEnabled"
 )
 
 // SecurityPolicy applies the score policy for the Security-Policy check.
 func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLogger) checker.CheckResult {
-	// We have 4 unique probes, each should have a finding.
+	// Every Security-Policy probe must provide a finding.
 	expectedProbes := []string{
 		securityPolicyContainsVulnerabilityDisclosure.Probe,
 		securityPolicyContainsLinks.Probe,
 		securityPolicyContainsText.Probe,
 		securityPolicyPresent.Probe,
+		securityPolicyPrivateVulnerabilityReportingEnabled.Probe,
 	}
 	if !finding.UniqueProbesEqual(findings, expectedProbes) {
 		e := sce.WithMessage(sce.ErrScorecardInternal, "invalid probe results")
@@ -40,6 +42,7 @@ func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLo
 
 	score := 0
 	m := make(map[string]bool)
+	privateReportingEnabled := false
 	var logLevel checker.DetailType
 	for i := range findings {
 		f := &findings[i]
@@ -56,12 +59,19 @@ func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLo
 				score += scoreProbeOnce(f.Probe, m, 3)
 			case securityPolicyPresent.Probe:
 				m[f.Probe] = true
+			case securityPolicyPrivateVulnerabilityReportingEnabled.Probe:
+				privateReportingEnabled = true
 			default:
 				e := sce.WithMessage(sce.ErrScorecardInternal, "unknown probe results")
 				return checker.CreateRuntimeErrorResult(name, e)
 			}
 		case finding.OutcomeFalse:
 			logLevel = checker.DetailWarn
+		case finding.OutcomeNotSupported:
+			if f.Probe == securityPolicyPrivateVulnerabilityReportingEnabled.Probe {
+				continue
+			}
+			logLevel = checker.DetailDebug
 		default:
 			logLevel = checker.DetailDebug
 		}
@@ -73,7 +83,21 @@ func SecurityPolicy(name string, findings []finding.Finding, dl checker.DetailLo
 			e := sce.WithMessage(sce.ErrScorecardInternal, "score calculation problem")
 			return checker.CreateRuntimeErrorResult(name, e)
 		}
+		if privateReportingEnabled {
+			return checker.CreateResultWithScore(
+				name, "private vulnerability reporting enabled", 8)
+		}
 		return checker.CreateMinScoreResult(name, "security policy file not detected")
+	}
+
+	if privateReportingEnabled {
+		if m[securityPolicyContainsLinks.Probe] {
+			score = checker.MaxResultScore
+		} else if score < 8 {
+			score = 8
+		}
+		return checker.CreateResultWithScore(
+			name, "security policy file and private vulnerability reporting detected", score)
 	}
 	return checker.CreateResultWithScore(name, "security policy file detected", score)
 }

--- a/checks/evaluation/security_policy_test.go
+++ b/checks/evaluation/security_policy_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/ossf/scorecard/v5/checker"
 	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/securityPolicyPrivateVulnerabilityReportingEnabled"
 	scut "github.com/ossf/scorecard/v5/utests"
 )
 
@@ -184,14 +185,118 @@ func TestSecurityPolicy(t *testing.T) {
 				NumberOfInfo: 4,
 			},
 		},
+		{
+			name: "private reporting enabled without policy file",
+			findings: []finding.Finding{
+				{
+					Probe:   "securityPolicyContainsVulnerabilityDisclosure",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyContainsLinks",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyContainsText",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyPresent",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   securityPolicyPrivateVulnerabilityReportingEnabled.Probe,
+					Outcome: finding.OutcomeTrue,
+				},
+			},
+			result: scut.TestReturn{
+				Score:        8,
+				NumberOfInfo: 1,
+				NumberOfWarn: 4,
+			},
+		},
+		{
+			name: "private reporting enabled with empty policy file",
+			findings: []finding.Finding{
+				{
+					Probe:   "securityPolicyContainsVulnerabilityDisclosure",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyContainsLinks",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyContainsText",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyPresent",
+					Outcome: finding.OutcomeTrue,
+				},
+				{
+					Probe:   securityPolicyPrivateVulnerabilityReportingEnabled.Probe,
+					Outcome: finding.OutcomeTrue,
+				},
+			},
+			result: scut.TestReturn{
+				Score:        8,
+				NumberOfInfo: 2,
+				NumberOfWarn: 3,
+			},
+		},
+		{
+			name: "private reporting enabled with linked policy",
+			findings: []finding.Finding{
+				{
+					Probe:   "securityPolicyContainsVulnerabilityDisclosure",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyContainsLinks",
+					Outcome: finding.OutcomeTrue,
+				},
+				{
+					Probe:   "securityPolicyContainsText",
+					Outcome: finding.OutcomeFalse,
+				},
+				{
+					Probe:   "securityPolicyPresent",
+					Outcome: finding.OutcomeTrue,
+				},
+				{
+					Probe:   securityPolicyPrivateVulnerabilityReportingEnabled.Probe,
+					Outcome: finding.OutcomeTrue,
+				},
+			},
+			result: scut.TestReturn{
+				Score:        checker.MaxResultScore,
+				NumberOfInfo: 3,
+				NumberOfWarn: 2,
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			dl := scut.TestDetailLogger{}
-			got := SecurityPolicy(tt.name, tt.findings, &dl)
+			got := SecurityPolicy(tt.name, withPrivateReportingFinding(tt.findings), &dl)
 			scut.ValidateTestReturn(t, tt.name, &tt.result, &got, &dl)
 		})
 	}
+}
+
+func withPrivateReportingFinding(findings []finding.Finding) []finding.Finding {
+	for i := range findings {
+		if findings[i].Probe == securityPolicyPrivateVulnerabilityReportingEnabled.Probe {
+			return findings
+		}
+	}
+
+	ret := append([]finding.Finding(nil), findings...)
+	return append(ret, finding.Finding{
+		Probe:   securityPolicyPrivateVulnerabilityReportingEnabled.Probe,
+		Outcome: finding.OutcomeNotSupported,
+	})
 }

--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -37,6 +37,7 @@ type securityPolicyFilesWithURI struct {
 // SecurityPolicy checks for presence of security policy
 // and applicable content discovered by checkSecurityPolicyFileContent().
 func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error) {
+	privateReporting := privateVulnerabilityReportingStatus(c.RepoClient)
 	data := securityPolicyFilesWithURI{
 		uri: "", files: make([]checker.SecurityPolicyFile, 0),
 	}
@@ -55,7 +56,10 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 				return checker.SecurityPolicyData{}, err
 			}
 		}
-		return checker.SecurityPolicyData{PolicyFiles: data.files}, nil
+		return checker.SecurityPolicyData{
+			PolicyFiles:                   data.files,
+			PrivateVulnerabilityReporting: privateReporting,
+		}, nil
 	}
 
 	// Check if present in parent org.
@@ -95,7 +99,31 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 			}
 		}
 	}
-	return checker.SecurityPolicyData{PolicyFiles: data.files}, nil
+	return checker.SecurityPolicyData{
+		PolicyFiles:                   data.files,
+		PrivateVulnerabilityReporting: privateReporting,
+	}, nil
+}
+
+func privateVulnerabilityReportingStatus(
+	repoClient clients.RepoClient,
+) checker.PrivateVulnerabilityReportingStatus {
+	client, ok := repoClient.(clients.PrivateVulnerabilityReportingClient)
+	if !ok {
+		return checker.PrivateVulnerabilityReportingNotSupported
+	}
+
+	enabled, err := client.IsPrivateVulnerabilityReportingEnabled()
+	switch {
+	case errors.Is(err, clients.ErrUnsupportedFeature):
+		return checker.PrivateVulnerabilityReportingNotSupported
+	case err != nil:
+		return checker.PrivateVulnerabilityReportingNotAvailable
+	case enabled:
+		return checker.PrivateVulnerabilityReportingEnabled
+	default:
+		return checker.PrivateVulnerabilityReportingDisabled
+	}
 }
 
 // Check repository for repository-specific policy.

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -15,6 +15,7 @@
 package raw
 
 import (
+	"errors"
 	"io"
 	"os"
 	"strings"
@@ -23,9 +24,20 @@ import (
 	"go.uber.org/mock/gomock"
 
 	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/clients"
 	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
 	scut "github.com/ossf/scorecard/v5/utests"
 )
+
+type privateReportingRepoClient struct {
+	clients.RepoClient
+	enabled bool
+	err     error
+}
+
+func (c *privateReportingRepoClient) IsPrivateVulnerabilityReportingEnabled() (bool, error) {
+	return c.enabled, c.err
+}
 
 func Test_isSecurityPolicyFilename(t *testing.T) {
 	t.Parallel()
@@ -55,6 +67,66 @@ func Test_isSecurityPolicyFilename(t *testing.T) {
 			t.Parallel()
 			if got := isSecurityPolicyFilename(tt.filename); got != tt.expected {
 				t.Errorf("isSecurityPolicyFilename() = %v, want %v for %v", got, tt.expected, tt.name)
+			}
+		})
+	}
+}
+
+func TestPrivateVulnerabilityReportingStatus(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		enabled bool
+		err     error
+		capable bool
+		want    checker.PrivateVulnerabilityReportingStatus
+	}{
+		{
+			name:    "enabled",
+			enabled: true,
+			capable: true,
+			want:    checker.PrivateVulnerabilityReportingEnabled,
+		},
+		{
+			name:    "disabled",
+			capable: true,
+			want:    checker.PrivateVulnerabilityReportingDisabled,
+		},
+		{
+			name:    "unsupported",
+			err:     clients.ErrUnsupportedFeature,
+			capable: true,
+			want:    checker.PrivateVulnerabilityReportingNotSupported,
+		},
+		{
+			name:    "not available",
+			err:     errors.New("api unavailable"),
+			capable: true,
+			want:    checker.PrivateVulnerabilityReportingNotAvailable,
+		},
+		{
+			name: "client has no capability",
+			want: checker.PrivateVulnerabilityReportingNotSupported,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			baseClient := mockrepo.NewMockRepoClient(ctrl)
+			var repoClient clients.RepoClient = baseClient
+			if tt.capable {
+				repoClient = &privateReportingRepoClient{
+					RepoClient: baseClient,
+					enabled:    tt.enabled,
+					err:        tt.err,
+				}
+			}
+
+			got := privateVulnerabilityReportingStatus(repoClient)
+			if got != tt.want {
+				t.Errorf("privateVulnerabilityReportingStatus() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/clients/githubrepo/client.go
+++ b/clients/githubrepo/client.go
@@ -36,9 +36,10 @@ import (
 )
 
 var (
-	_                     clients.RepoClient = &Client{}
-	errInputRepoType                         = errors.New("input repo should be of type repoURL")
-	errDefaultBranchEmpty                    = errors.New("default branch name is empty")
+	_                     clients.RepoClient                          = &Client{}
+	_                     clients.PrivateVulnerabilityReportingClient = &Client{}
+	errInputRepoType                                                  = errors.New("input repo should be of type repoURL")
+	errDefaultBranchEmpty                                             = errors.New("default branch name is empty")
 )
 
 type Option func(*repoClientConfig) error

--- a/clients/githubrepo/private_vulnerability_reporting.go
+++ b/clients/githubrepo/private_vulnerability_reporting.go
@@ -1,0 +1,40 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubrepo
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+// IsPrivateVulnerabilityReportingEnabled reports whether GitHub private
+// vulnerability reporting is enabled for the repository.
+func (client *Client) IsPrivateVulnerabilityReportingEnabled() (bool, error) {
+	if !strings.EqualFold(client.repourl.commitSHA, clients.HeadSHA) {
+		return false, fmt.Errorf(
+			"%w: private vulnerability reporting is only supported for HEAD queries",
+			clients.ErrUnsupportedFeature,
+		)
+	}
+
+	enabled, _, err := client.repoClient.Repositories.IsPrivateReportingEnabled(
+		client.ctx, client.repourl.owner, client.repourl.repo)
+	if err != nil {
+		return false, fmt.Errorf("check private vulnerability reporting: %w", err)
+	}
+	return enabled, nil
+}

--- a/clients/githubrepo/private_vulnerability_reporting_test.go
+++ b/clients/githubrepo/private_vulnerability_reporting_test.go
@@ -1,0 +1,110 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package githubrepo
+
+import (
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/google/go-github/v82/github"
+
+	"github.com/ossf/scorecard/v5/clients"
+)
+
+func TestIsPrivateVulnerabilityReportingEnabled(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		statusCode  int
+		body        string
+		wantEnabled bool
+		wantErr     bool
+	}{
+		{
+			name:        "enabled",
+			statusCode:  http.StatusOK,
+			body:        `{"enabled":true}`,
+			wantEnabled: true,
+		},
+		{
+			name:       "disabled",
+			statusCode: http.StatusOK,
+			body:       `{"enabled":false}`,
+		},
+		{
+			name:       "API error",
+			statusCode: http.StatusUnprocessableEntity,
+			body:       `{"message":"unprocessable"}`,
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/repos/ossf/scorecard/private-vulnerability-reporting" {
+					t.Errorf("request path = %q", r.URL.Path)
+				}
+				w.WriteHeader(tt.statusCode)
+				if _, err := io.WriteString(w, tt.body); err != nil {
+					t.Errorf("write response: %v", err)
+				}
+			}))
+			defer server.Close()
+
+			githubClient := github.NewClient(server.Client())
+			baseURL, err := url.Parse(server.URL + "/")
+			if err != nil {
+				t.Fatalf("parse server URL: %v", err)
+			}
+			githubClient.BaseURL = baseURL
+
+			client := &Client{
+				ctx:        t.Context(),
+				repoClient: githubClient,
+				repourl: &Repo{
+					owner:     "ossf",
+					repo:      "scorecard",
+					commitSHA: clients.HeadSHA,
+				},
+			}
+
+			got, err := client.IsPrivateVulnerabilityReportingEnabled()
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("IsPrivateVulnerabilityReportingEnabled() error = %v, wantErr %t", err, tt.wantErr)
+			}
+			if got != tt.wantEnabled {
+				t.Errorf("IsPrivateVulnerabilityReportingEnabled() = %t, want %t", got, tt.wantEnabled)
+			}
+		})
+	}
+}
+
+func TestPrivateVulnerabilityReportingRequiresHead(t *testing.T) {
+	t.Parallel()
+	client := &Client{
+		repourl: &Repo{commitSHA: "0123456789abcdef"},
+	}
+
+	_, err := client.IsPrivateVulnerabilityReportingEnabled()
+	if !errors.Is(err, clients.ErrUnsupportedFeature) {
+		t.Errorf("IsPrivateVulnerabilityReportingEnabled() error = %v, want %v", err, clients.ErrUnsupportedFeature)
+	}
+}

--- a/clients/repo_client.go
+++ b/clients/repo_client.go
@@ -59,3 +59,10 @@ type RepoClient interface {
 	SearchCommits(request SearchCommitsOptions) ([]Commit, error)
 	Close() error
 }
+
+// PrivateVulnerabilityReportingClient exposes repository-level support for
+// privately reporting vulnerabilities. Not every repository provider supports
+// this capability, so it is intentionally kept separate from RepoClient.
+type PrivateVulnerabilityReportingClient interface {
+	IsPrivateVulnerabilityReportingEnabled() (bool, error)
+}

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -592,6 +592,11 @@ This check examines the contents of the security policy file awarding points
 for those policies that express vulnerability process(es), disclosure timelines,
 and have links (e.g., URL(s) and email(s)) to support the users.
 
+For GitHub repositories, the check also verifies whether private vulnerability
+reporting is enabled. A repository with private vulnerability reporting enabled
+receives a score of at least 8. A repository that also publishes a security
+policy containing a link or email receives a score of 10.
+
 Linking Requirements (one or more) (6/10 points):
   - A valid form of an email address to contact for vulnerabilities
   - A valid form of a http/https address to support vulnerability reporting
@@ -615,6 +620,7 @@ Security Policy Specific Text (1/10 points):
 - Place a security policy file `SECURITY.md` in the root directory of your repository. This makes it easily discoverable by a vulnerability reporter.
 - The file should contain information on what constitutes a vulnerability and a way to report it securely (e.g. issue tracker with private issue support, encrypted email with a published public key). Follow the [coordinated vulnerability disclosure guidelines](https://github.com/ossf/oss-vulnerability-guide/blob/main/maintainer-guide.md) to respond to vulnerability disclosures.
 - For GitHub, see more information [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
+- For GitHub, enable private vulnerability reporting in the repository security settings.
 
 ## Signed-Releases 
 

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -602,7 +602,7 @@ checks:
 
   Security-Policy:
     risk: Medium
-    short: Determines if the project has published a security policy.
+    short: Determines if the project provides a security policy or private vulnerability reporting.
     repos: GitHub, GitLab, Azure DevOps, local
     tags: supply-chain, security, policy
     description: |
@@ -619,6 +619,11 @@ checks:
       This check examines the contents of the security policy file awarding points
       for those policies that express vulnerability process(es), disclosure timelines,
       and have links (e.g., URL(s) and email(s)) to support the users.
+
+      For GitHub repositories, the check also verifies whether private vulnerability
+      reporting is enabled. A repository with private vulnerability reporting enabled
+      receives a score of at least 8. A repository that also publishes a security
+      policy containing a link or email receives a score of 10.
 
       Linking Requirements (one or more) (6/10 points):
         - A valid form of an email address to contact for vulnerabilities
@@ -651,6 +656,8 @@ checks:
       - >-
         For GitHub, see more information
         [here](https://docs.github.com/en/code-security/getting-started/adding-a-security-policy-to-your-repository).
+      - >-
+        For GitHub, enable private vulnerability reporting in the repository security settings.
   Signed-Releases:
     risk: High
     tags: supply-chain, security, releases

--- a/docs/osps-baseline-coverage.md
+++ b/docs/osps-baseline-coverage.md
@@ -79,7 +79,7 @@ coverage status and evidence columns accordingly.
 | OSPS-SA-02.01 | Docs describe external interfaces | GAP | None | Documentation control. Requires attestation. |
 | OSPS-SA-03.01 | Security assessment performed | GAP | None | Process control. Requires attestation with evidence link. |
 | OSPS-VM-01.01 | CVD policy with response timeframe | PARTIAL | `securityPolicyContainsVulnerabilityDisclosure`, `securityPolicyContainsText` | Security-Policy check detects disclosure language. Does not verify explicit timeframe commitment. |
-| OSPS-VM-03.01 | Private vulnerability reporting method | PARTIAL | `securityPolicyContainsLinks` | Detects links in SECURITY.md. Does not verify private reporting is actually enabled (e.g., GitHub PSIRT feature). |
+| OSPS-VM-03.01 | Private vulnerability reporting method | PARTIAL | `securityPolicyContainsLinks`, `securityPolicyPrivateVulnerabilityReportingEnabled` | Detects links in SECURITY.md and verifies GitHub private vulnerability reporting. Other repository providers are not yet supported. |
 | OSPS-VM-04.01 | Publicly publish vulnerability data | GAP | None | No probe checks for GitHub Security Advisories, OSV entries, or CVE publication. |
 
 ## Level 3 controls (17)
@@ -179,8 +179,8 @@ Direct match for Phase 2 deliverable.
 ### Private vulnerability reporting (OSPS-VM-03.01)
 - [#2465](https://github.com/ossf/scorecard/issues/2465) — Factor whether or not private vulnerability reporting is enabled into the scorecard
 
-Direct match. GitHub's private vulnerability reporting API could provide
-platform-level evidence.
+Direct match. The Security-Policy check now queries GitHub's private vulnerability
+reporting API. Support for other repository providers remains an opportunity.
 
 ### Vulnerability disclosure improvements (OSPS-VM-01.01, VM-04.01)
 - [#4192](https://github.com/ossf/scorecard/issues/4192) — Test for security policy in other places than SECURITY.md

--- a/docs/probes.md
+++ b/docs/probes.md
@@ -621,6 +621,22 @@ If no security policy is found, the probe returns one finding with OutcomeFalse.
 If no security file is found, one finding with OutcomeFalse is returned.
 
 
+## securityPolicyPrivateVulnerabilityReportingEnabled
+
+**Lifecycle**: experimental
+
+**Description**: Check whether private vulnerability reporting is enabled for the repository.
+
+**Motivation**: Private vulnerability reporting gives security researchers a confidential channel for reporting vulnerabilities.
+
+**Implementation**: The implementation queries the repository provider for the private vulnerability reporting setting. GitHub is the only supported provider at this time.
+
+**Outcomes**: If private vulnerability reporting is enabled, one finding with OutcomeTrue is returned.
+If private vulnerability reporting is disabled, one finding with OutcomeFalse is returned.
+If the provider does not support this setting, one finding with OutcomeNotSupported is returned.
+If the setting cannot be retrieved, one finding with OutcomeNotAvailable is returned.
+
+
 ## testsRunInCI
 
 **Lifecycle**: stable

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -61,6 +61,7 @@ import (
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsText"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyContainsVulnerabilityDisclosure"
 	"github.com/ossf/scorecard/v5/probes/securityPolicyPresent"
+	"github.com/ossf/scorecard/v5/probes/securityPolicyPrivateVulnerabilityReportingEnabled"
 	"github.com/ossf/scorecard/v5/probes/testsRunInCI"
 	"github.com/ossf/scorecard/v5/probes/topLevelPermissions"
 	"github.com/ossf/scorecard/v5/probes/unsafeblock"
@@ -83,6 +84,7 @@ var (
 		securityPolicyContainsLinks.Run,
 		securityPolicyContainsVulnerabilityDisclosure.Run,
 		securityPolicyContainsText.Run,
+		securityPolicyPrivateVulnerabilityReportingEnabled.Run,
 	}
 	// DependencyToolUpdates is all the probes for the
 	// DependencyUpdateTool check.

--- a/probes/securityPolicyPrivateVulnerabilityReportingEnabled/def.yml
+++ b/probes/securityPolicyPrivateVulnerabilityReportingEnabled/def.yml
@@ -1,0 +1,41 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: securityPolicyPrivateVulnerabilityReportingEnabled
+lifecycle: experimental
+short: Check whether private vulnerability reporting is enabled for the repository.
+motivation: >
+  Private vulnerability reporting gives security researchers a confidential channel for reporting vulnerabilities.
+implementation: >
+  The implementation queries the repository provider for the private vulnerability reporting setting.
+  GitHub is the only supported provider at this time.
+outcome:
+  - If private vulnerability reporting is enabled, one finding with OutcomeTrue is returned.
+  - If private vulnerability reporting is disabled, one finding with OutcomeFalse is returned.
+  - If the provider does not support this setting, one finding with OutcomeNotSupported is returned.
+  - If the setting cannot be retrieved, one finding with OutcomeNotAvailable is returned.
+remediation:
+  onOutcome: False
+  effort: Low
+  text:
+    - Enable private vulnerability reporting in the repository security settings.
+    - See https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository.
+  markdown:
+    - Enable private vulnerability reporting in the repository security settings.
+    - See [GitHub's private vulnerability reporting documentation](https://docs.github.com/en/code-security/how-tos/report-and-fix-vulnerabilities/configure-vulnerability-reporting/configure-for-a-repository).
+ecosystem:
+  languages:
+    - all
+  clients:
+    - github

--- a/probes/securityPolicyPrivateVulnerabilityReportingEnabled/impl.go
+++ b/probes/securityPolicyPrivateVulnerabilityReportingEnabled/impl.go
@@ -1,0 +1,71 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securityPolicyPrivateVulnerabilityReportingEnabled
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/checknames"
+	"github.com/ossf/scorecard/v5/internal/probes"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/uerror"
+)
+
+func init() {
+	probes.MustRegister(Probe, Run, []checknames.CheckName{checknames.SecurityPolicy})
+}
+
+//go:embed *.yml
+var fs embed.FS
+
+const Probe = "securityPolicyPrivateVulnerabilityReportingEnabled"
+
+var errUnknownPrivateVulnerabilityReportingStatus = errors.New(
+	"unknown private vulnerability reporting status")
+
+func Run(raw *checker.RawResults) ([]finding.Finding, string, error) {
+	if raw == nil {
+		return nil, "", fmt.Errorf("%w: raw", uerror.ErrNil)
+	}
+
+	var message string
+	var outcome finding.Outcome
+	switch raw.SecurityPolicyResults.PrivateVulnerabilityReporting {
+	case checker.PrivateVulnerabilityReportingEnabled:
+		message = "private vulnerability reporting is enabled"
+		outcome = finding.OutcomeTrue
+	case checker.PrivateVulnerabilityReportingDisabled:
+		message = "private vulnerability reporting is disabled"
+		outcome = finding.OutcomeFalse
+	case checker.PrivateVulnerabilityReportingNotAvailable:
+		message = "private vulnerability reporting status is not available"
+		outcome = finding.OutcomeNotAvailable
+	case checker.PrivateVulnerabilityReportingNotSupported:
+		message = "private vulnerability reporting is not supported"
+		outcome = finding.OutcomeNotSupported
+	default:
+		return nil, Probe, errUnknownPrivateVulnerabilityReportingStatus
+	}
+
+	f, err := finding.NewWith(fs, Probe, message, nil, outcome)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("create finding: %w", err)
+	}
+	f = f.WithRemediationMetadata(raw.Metadata.Metadata)
+	return []finding.Finding{*f}, Probe, nil
+}

--- a/probes/securityPolicyPrivateVulnerabilityReportingEnabled/impl_test.go
+++ b/probes/securityPolicyPrivateVulnerabilityReportingEnabled/impl_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package securityPolicyPrivateVulnerabilityReportingEnabled
+
+import (
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/test"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/uerror"
+)
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		raw      *checker.RawResults
+		outcomes []finding.Outcome
+		err      error
+	}{
+		{
+			name:     "enabled",
+			raw:      rawResults(checker.PrivateVulnerabilityReportingEnabled),
+			outcomes: []finding.Outcome{finding.OutcomeTrue},
+		},
+		{
+			name:     "disabled",
+			raw:      rawResults(checker.PrivateVulnerabilityReportingDisabled),
+			outcomes: []finding.Outcome{finding.OutcomeFalse},
+		},
+		{
+			name:     "not available",
+			raw:      rawResults(checker.PrivateVulnerabilityReportingNotAvailable),
+			outcomes: []finding.Outcome{finding.OutcomeNotAvailable},
+		},
+		{
+			name:     "not supported",
+			raw:      rawResults(checker.PrivateVulnerabilityReportingNotSupported),
+			outcomes: []finding.Outcome{finding.OutcomeNotSupported},
+		},
+		{
+			name: "nil raw results",
+			err:  uerror.ErrNil,
+		},
+		{
+			name: "unknown status",
+			raw:  rawResults(checker.PrivateVulnerabilityReportingStatus(99)),
+			err:  errUnknownPrivateVulnerabilityReportingStatus,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			findings, probe, err := Run(tt.raw)
+			if !cmp.Equal(tt.err, err, cmpopts.EquateErrors()) {
+				t.Errorf("mismatch in error: %s", cmp.Diff(tt.err, err, cmpopts.EquateErrors()))
+			}
+			if err != nil {
+				return
+			}
+			if diff := cmp.Diff(Probe, probe); diff != "" {
+				t.Errorf("mismatch in probe: %s", diff)
+			}
+			test.AssertOutcomes(t, findings, tt.outcomes)
+		})
+	}
+}
+
+func rawResults(status checker.PrivateVulnerabilityReportingStatus) *checker.RawResults {
+	return &checker.RawResults{
+		SecurityPolicyResults: checker.SecurityPolicyData{
+			PrivateVulnerabilityReporting: status,
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- Query the GitHub private vulnerability reporting setting through the existing go-github client.
- Add a dedicated Security-Policy probe with enabled, disabled, unsupported, and unavailable outcomes.
- Include private vulnerability reporting in the Security-Policy score.
- Keep existing results unchanged when the repository provider does not support the setting or the API is unavailable.
- Update the generated check and probe documentation.

## Why

The Security-Policy check currently inspects policy files, links, and disclosure text. It cannot determine whether a GitHub repository has an actual private reporting channel enabled. This leaves the check unable to verify the repository setting covered by issue #2465 and OSPS-VM-03.01.

## Scoring

| Repository state | Score behavior |
| --- | --- |
| Private reporting enabled without a policy file | 8 |
| Private reporting enabled with a linked policy | 10 |
| Private reporting enabled with an incomplete policy | At least 8 |
| Setting disabled, unsupported, or unavailable | Existing policy score remains unchanged |

Historical commit scans and file-only scans do not use the current repository setting.

## Validation

- GitHub client unit tests
- Security-Policy raw result tests
- Security-Policy evaluation tests
- Existing and new Security-Policy probe tests
- Security-Policy integration test
- `go vet` for the changed packages
- Documentation validation
- `git diff --check`

Fixes #2465
