### PR TITLE
feat: detect cargo-dist in Packaging check

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -572,6 +572,20 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 			LogText: "candidate rust publishing workflow using cargo",
 		},
 		{
+			// Rust packages via cargo-dist (axodotdev). Builds multi-platform
+			// release artifacts; often used instead of bare `cargo publish` in
+			// the top-level workflow. See https://opensource.axo.dev/cargo-dist/
+			// and https://github.com/ossf/scorecard/issues/5145.
+			Steps: []*JobMatcherStep{
+				{
+					// Match `dist plan|build|publish` or `cargo dist ...`.
+					// Word boundary on `dist` avoids matching "distribution".
+					Run: `(?:^|[\s;&|])dist (?:plan|build|publish)\b|cargo dist\b`,
+				},
+			},
+			LogText: "candidate rust publishing workflow using cargo-dist",
+		},
+		{
 			// Ko container action. https://github.com/google/ko
 			Steps: []*JobMatcherStep{
 				{

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -990,6 +990,16 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "cargo-dist plan/build",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-cargo-dist.yaml",
+			expected: true,
+		},
+		{
+			name:     "cargo-dist false positive (distribution prose)",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-cargo-dist-false.yaml",
+			expected: false,
+		},
+		{
 			name:     "semantic-release publish",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-semantic-release.yaml",
 			expected: true,

--- a/checks/testdata/.github/workflows/github-workflow-packaging-cargo-dist-false.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-cargo-dist-false.yaml
@@ -1,0 +1,21 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+jobs:
+  notes:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Not cargo-dist
+        run: echo "This job documents distribution of artifacts only"

--- a/checks/testdata/.github/workflows/github-workflow-packaging-cargo-dist.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-cargo-dist.yaml
@@ -1,0 +1,31 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Minimal cargo-dist-shaped release workflow (axodotdev).
+# See https://github.com/ossf/scorecard/issues/5145.
+jobs:
+  plan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dist
+        run: curl --proto '=https' --tlsv1.2 -LsSf https://github.com/axodotdev/cargo-dist/releases/download/v0.28.0/cargo-dist-installer.sh | sh
+      - name: Plan
+        run: dist plan --output-format=json > dist-manifest.json
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build artifacts
+        run: dist build --output-format=json > dist-manifest.json


### PR DESCRIPTION
## Summary

The Packaging check did not recognize **cargo-dist** (axodotdev) release workflows. Rust projects that use `dist plan` / `dist build` for multi-platform GitHub Release artifacts (often without a top-level bare `cargo publish` step) scored Packaging **-1** / "packaging workflow not detected".

This is the same class of matcher gap as #5131 (goreleaser fork), #5096 (changesets), and #5133 (ko dual setup).

**Fixes #5145**

## Changes

- Add `JobMatcher` for cargo-dist CLI: `dist plan|build|publish` or `cargo dist`
- Word-boundary style regex so prose about "distribution" does not match
- Positive fixture modeled on cargo-dist-shaped release jobs
- Negative fixture for "distribution" documentation-only steps
- Unit tests in `TestIsPackagingWorkflow`

## Notes

- Existing `cargo.*publish` matcher is unchanged.
- Reusable `workflow_call`-only `cargo publish` files still need successful run attribution to credit Packaging (called out in #5145 as a secondary issue); this PR only adds cargo-dist detection.
- Example project that hit the false negative: https://github.com/patchloom/patchloom (documented in their SECURITY.md). Live Packaging can still pass via other matchers (e.g. npm) without detecting cargo-dist.

## Test plan

- [x] `go test ./checks/fileparser/ -run TestIsPackagingWorkflow -count=1`