### PR TITLE
🐛 Fix resource leaks in gitlab tarball extraction

### DIFF
--- a/clients/gitlabrepo/tarball.go
+++ b/clients/gitlabrepo/tarball.go
@@ -144,6 +144,7 @@ func (handler *tarballHandler) getTarball() error {
 	if err != nil {
 		return fmt.Errorf("os.CreateTemp: %w", err)
 	}
+	defer ciFile.Close()
 	err = handler.apiFunction(url, tempDir, ciFile)
 	if err != nil {
 		return fmt.Errorf("gitlab.apiFunction: %w", err)
@@ -210,10 +211,12 @@ func (handler *tarballHandler) extractTarball() error {
 	if err != nil {
 		return fmt.Errorf("os.OpenFile: %w", err)
 	}
+	defer in.Close()
 	gz, err := gzip.NewReader(in)
 	if err != nil {
 		return fmt.Errorf("%w: gzip.NewReader %v %w", errTarballCorrupted, handler.tempTarFile, err)
 	}
+	defer gz.Close()
 	tr := tar.NewReader(gz)
 	for {
 		header, err := tr.Next()
@@ -260,6 +263,7 @@ func (handler *tarballHandler) extractTarball() error {
 			// Potential for DoS vulnerability via decompression bomb.
 			// Since such an attack will only impact a single shard, ignoring this for now.
 			if _, err := io.Copy(outFile, tr); err != nil {
+				outFile.Close()
 				return fmt.Errorf("%w io.Copy: %w", errTarballCorrupted, err)
 			}
 			outFile.Close()


### PR DESCRIPTION
## Summary

Fix resource leaks in GitLab tarball extraction by adding proper defer Close() calls for file handles.

## Changes

- Add `defer ciFile.Close()` after `os.CreateTemp()` in `getTarball()` to prevent file handle leak if `apiFunction()` or subsequent operations fail
- Add `defer in.Close()` for the tar file opened with `os.OpenFile()` in `extractTarball()`
- Add `defer gz.Close()` for the gzip reader created with `gzip.NewReader()` in `extractTarball()`
- Add `outFile.Close()` in error path during `io.Copy()` to prevent file handle leak when extraction fails

## Impact

These changes prevent resource leaks when processing GitLab repository tarballs. Without these fixes, file handles could remain open if errors occur during tarball download or extraction, potentially leading to resource exhaustion.

## Testing

Local environment limitations prevent full dynamic testing; relying on CI/CD automated tests for verification.
