### PR TITLE
:bug: Fall back when check suites are truncated

### DIFF
--- a/clients/githubrepo/checkruns.go
+++ b/clients/githubrepo/checkruns.go
@@ -49,6 +49,9 @@ type checkRunsGraphqlData struct {
 													Conclusion githubv4.CheckConclusionState
 													Status     githubv4.CheckStatusState
 												}
+												PageInfo struct {
+													HasNextPage bool
+												}
 											} `graphql:"checkSuites(first: $checksToAnalyze)"`
 										}
 									}
@@ -148,7 +151,12 @@ func parseCheckRuns(data *checkRunsGraphqlData) checkRunsByRef {
 	for _, commit := range data.Repository.Object.Commit.History.Nodes {
 		for _, pr := range commit.AssociatedPullRequests.Nodes {
 			var crs []clients.CheckRun
+			hasAllCheckSuites := true
 			for _, c := range pr.Commits.Nodes {
+				if c.Commit.CheckSuites.PageInfo.HasNextPage {
+					hasAllCheckSuites = false
+					break
+				}
 				for _, checkRun := range c.Commit.CheckSuites.Nodes {
 					crs = append(crs, clients.CheckRun{
 						// the REST API returns lowercase. the graphQL API returns upper
@@ -159,6 +167,9 @@ func parseCheckRuns(data *checkRunsGraphqlData) checkRunsByRef {
 						},
 					})
 				}
+			}
+			if !hasAllCheckSuites {
+				continue
 			}
 			headRef := string(pr.HeadRefOid)
 			checkCache[headRef] = crs

--- a/clients/githubrepo/checkruns_test.go
+++ b/clients/githubrepo/checkruns_test.go
@@ -15,7 +15,13 @@
 package githubrepo
 
 import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
 	"testing"
+
+	"github.com/google/go-github/v82/github"
 
 	sce "github.com/ossf/scorecard/v5/errors"
 )
@@ -27,4 +33,97 @@ func Test_init_clearsErr(t *testing.T) {
 	if handler.errSetup != nil {
 		t.Errorf("expected nil error, got %v", handler.errSetup)
 	}
+}
+
+func Test_listCheckRunsForRef_fallsBackForTruncatedGraphQLData(t *testing.T) {
+	t.Parallel()
+	data := checkRunsGraphQLFixture(t)
+	data.Repository.Object.Commit.History.Nodes[0].AssociatedPullRequests.Nodes[0].
+		Commits.Nodes[0].Commit.CheckSuites.PageInfo.HasNextPage = true
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got, want := r.URL.Path, "/repos/owner/repo/commits/head/check-runs"; got != want {
+			t.Errorf("request path = %q, want %q", got, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if _, err := w.Write([]byte(`{
+			"total_count": 1,
+			"check_runs": [{
+				"status": "completed",
+				"conclusion": "success",
+				"url": "https://api.github.com/check-runs/1",
+				"app": {"slug": "github-actions"}
+			}]
+		}`)); err != nil {
+			t.Errorf("write response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL + "/")
+	if err != nil {
+		t.Fatalf("parse server URL: %v", err)
+	}
+	client := github.NewClient(server.Client())
+	client.BaseURL = baseURL
+
+	handler := new(checkrunsHandler)
+	handler.init(t.Context(), &Repo{owner: "owner", repo: "repo"}, 1)
+	handler.client = client
+	handler.setupOnce.Do(func() {
+		handler.checkRunsByRef = parseCheckRuns(data)
+	})
+
+	checkRuns, err := handler.listCheckRunsForRef("head")
+	if err != nil {
+		t.Fatalf("listCheckRunsForRef() error = %v", err)
+	}
+	if got, want := len(checkRuns), 1; got != want {
+		t.Fatalf("len(checkRuns) = %d, want %d", got, want)
+	}
+	if got, want := checkRuns[0].App.Slug, "github-actions"; got != want {
+		t.Errorf("check run app = %q, want %q", got, want)
+	}
+}
+
+func checkRunsGraphQLFixture(t *testing.T) *checkRunsGraphqlData {
+	t.Helper()
+	const fixture = `{
+		"Repository": {
+			"Object": {
+				"Commit": {
+					"History": {
+						"Nodes": [{
+							"AssociatedPullRequests": {
+								"Nodes": [{
+									"HeadRefOid": "head",
+									"Commits": {
+										"Nodes": [{
+											"Commit": {
+												"CheckSuites": {
+													"Nodes": [{
+														"App": {"Slug": "third-party"},
+														"Conclusion": "SUCCESS",
+														"Status": "COMPLETED"
+													}],
+													"PageInfo": {"HasNextPage": false}
+												}
+											}
+										}]
+									}
+								}]
+							}
+						}]
+					}
+				}
+			}
+		}
+	}`
+
+	var data checkRunsGraphqlData
+	//nolint:musttag // GraphQL response structs are populated by field name and intentionally have no JSON tags.
+	if err := json.Unmarshal([]byte(fixture), &data); err != nil {
+		t.Fatalf("unmarshal GraphQL fixture: %v", err)
+	}
+	return &data
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

GitHub GraphQL check-suite results are cached even when the `checkSuites` connection is truncated.

When a commit has more check suites than the GraphQL query returns, the partial result is treated as complete. Because the commit SHA is present in the cache, `listCheckRunsForRef` does not use its existing REST fallback.

As a result, successful CI check runs located after the first GraphQL page can be missed by the CI-Tests and SAST checks.

#### What is the new behavior (if this is a feature change)?

The GitHub client now reads `PageInfo.HasNextPage` from the `checkSuites` connection.

When the GraphQL result is truncated, the pull request head SHA is not added to the check-run cache. This produces a cache miss and allows the existing REST fallback to retrieve the check runs for that ref.

A regression test verifies that truncated GraphQL data triggers the REST fallback and returns a successful `github-actions` check run.

- [x] Tests for the changes have been added

#### Which issue(s) this PR fixes

Fixes #5149

#### Special notes for your reviewer

All contributor and merge commits include the required DCO sign-off.

Latest local validation after merging the current `main`:

- Go 1.25.6
- targeted regression and handler initialization tests: passed
- `go vet ./clients/githubrepo`: passed
- `git diff --check upstream/main...HEAD`: passed

The full Windows package suite was not counted as passing: its Ginkgo `BeforeSuite` requires GitHub authentication, and an unrelated upstream tarball test encountered a Windows temporary-file lock.

#### Does this PR introduce a user-facing change?

```release-note
Scorecard now falls back to the GitHub REST API when GraphQL check-suite results are truncated, preventing CI-Tests and SAST from missing successful check runs.
```