### PR TITLE
:book: docs: fix broken markdown links and a typo

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -34,7 +34,7 @@ will send a more detailed response within an additional three (3) business days
 indicating the next steps in handling your report.
 
 If you've been unable to successfully draft a vulnerability report via GitHub
-or have not received a response during the alloted response window, please
+or have not received a response during the allotted response window, please
 reach out via the [OpenSSF security contact email](mailto:security@openssf.org).
 
 After the initial reply to your report, the maintainers will endeavor to keep

--- a/cron/k8s/README.md
+++ b/cron/k8s/README.md
@@ -3,7 +3,7 @@
 Currently there is no automation to sync changes to these files to the GKE cluster.
 Changes must be manually applied with `kubectl` by a user with permissions to modify the cluster.
 
-Before committing any changes, it is recommended to check your YAML files for errors with [yamllint](yamllint.readthedocs.io). To check all YAML files in this directory, run:
+Before committing any changes, it is recommended to check your YAML files for errors with [yamllint](https://yamllint.readthedocs.io). To check all YAML files in this directory, run:
 ```
 yamllint -d relaxed .
 ```

--- a/docs/design/scalable_scorecard.md
+++ b/docs/design/scalable_scorecard.md
@@ -8,7 +8,7 @@ Scale OSSF Scorecard to 100k+ repositories.
 
 ## Background
 
-[Scorecard](github.com/oosf/scorecard) is an open source project by Google in
+[Scorecard](https://github.com/ossf/scorecard) is an open source project by Google in
 collaboration with [OpenSSF](https://openssf.org/) to automate the analysis and
 trust decisions on the security posture of an open source project. As part of
 this project we (Google) maintain a cron job, which calculates Scorecard results


### PR DESCRIPTION
#### What kind of change does this PR introduce?

A docs fix — two broken markdown links and one spelling correction.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Two markdown links omit the URL scheme, so GitHub resolves them as repository-relative paths and they 404:

- `docs/design/scalable_scorecard.md`: `[Scorecard](github.com/oosf/scorecard)` renders as `/ossf/scorecard/blob/main/docs/design/github.com/oosf/scorecard`. The org is also misspelled (`oosf` instead of `ossf`).
- `cron/k8s/README.md`: `[yamllint](yamllint.readthedocs.io)` renders as `/ossf/scorecard/blob/main/cron/k8s/yamllint.readthedocs.io`.

Separately, `SECURITY.md` uses "alloted" where "allotted" is intended.

#### What is the new behavior (if this is a feature change)?

Both links now use absolute `https://` URLs and resolve correctly, and the spelling is corrected. No code or behavior changes.

- [x] Tests for the changes have been added (for bug fixes/features) — N/A, documentation only

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

Documentation only; no Go files touched. Each rendered URL was verified against the live rendering on `main` before the change.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
