### PR TITLE
:seedling: update e2e test to account for new vulns

### DIFF
--- a/e2e/vulnerabilities_test.go
+++ b/e2e/vulnerabilities_test.go
@@ -30,6 +30,7 @@ import (
 
 var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 	Context("E2E TEST:Validating vulnerabilities status", func() {
+		const numOpen62541Vulns = 7 // this may change as new vulns are discovered
 		It("Should return that there are vulnerabilities", func() {
 			repo, err := githubrepo.MakeGithubRepo("ossf-tests/scorecard-check-vulnerabilities-open62541")
 			Expect(err).Should(BeNil())
@@ -47,8 +48,8 @@ var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         checker.MaxResultScore - 4, // 4 vulnerabilities remove 4 points.
-				NumberOfWarn:  4,
+				Score:         checker.MaxResultScore - min(numOpen62541Vulns, checker.MaxResultScore),
+				NumberOfWarn:  numOpen62541Vulns,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}
@@ -74,8 +75,8 @@ var _ = Describe("E2E TEST:"+checks.CheckVulnerabilities, func() {
 			}
 			expected := scut.TestReturn{
 				Error:         nil,
-				Score:         checker.MaxResultScore - 4, // 4 vulnerabilities remove 4 points.
-				NumberOfWarn:  4,
+				Score:         checker.MaxResultScore - min(numOpen62541Vulns, checker.MaxResultScore),
+				NumberOfWarn:  numOpen62541Vulns,
 				NumberOfInfo:  0,
 				NumberOfDebug: 0,
 			}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

test fix

- [X] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?
The vuln e2e tests are failing because new vulns were discovered in dependencies used in the test repo. 

#### What is the new behavior (if this is a feature change)?
The expected vuln count is incremented, a similar thing happened in #4640 

- [ ] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes
NONE
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.

Fixes #

or

NONE
-->

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

For user-facing changes, please add a concise, human-readable release note to
the `release-note`

(In particular, describe what changes users might need to make in their
application as a result of this pull request.)

<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below.
If the PR requires additional action from users switching to the new release,
include the string "ACTION REQUIRED".

For more information on release notes see: https://git.k8s.io/release/cmd/release-notes/README.md
-->

```release-note
NONE
```
