### PR TITLE
:bug: contain git-mode file reads within the checkout root

### DIFF
--- a/clients/git/client.go
+++ b/clients/git/client.go
@@ -239,13 +239,12 @@ func (c *Client) ListFiles(predicate func(string) (bool, error)) ([]string, erro
 }
 
 func (c *Client) GetFileReader(filename string) (io.ReadCloser, error) {
-	// Create the full path of the file
-	fullPath := filepath.Join(c.tempDir, filename)
-
-	// Read the file
-	f, err := os.Open(fullPath)
+	// Read the file while staying inside the checkout root. os.OpenInRoot
+	// refuses names that escape via "../" or a symlink materialized by the
+	// clone that points outside the worktree.
+	f, err := os.OpenInRoot(c.tempDir, filename)
 	if err != nil {
-		return nil, fmt.Errorf("os.Open: %w", err)
+		return nil, fmt.Errorf("os.OpenInRoot: %w", err)
 	}
 
 	return f, nil

--- a/internal/gitfile/gitfile.go
+++ b/internal/gitfile/gitfile.go
@@ -17,11 +17,8 @@ package gitfile
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
 	"sync"
 
 	"github.com/go-git/go-git/v5"
@@ -30,8 +27,6 @@ import (
 
 	"github.com/ossf/scorecard/v5/clients"
 )
-
-var errPathTraversal = errors.New("requested file outside repo")
 
 const repoDir = "repo*"
 
@@ -160,13 +155,10 @@ func (h *Handler) GetFile(filename string) (*os.File, error) {
 		return nil, fmt.Errorf("setup: %w", err)
 	}
 
-	// check for path traversal
-	path := filepath.Join(h.tempDir, filename)
-	if !strings.HasPrefix(path, filepath.Clean(h.tempDir)+string(os.PathSeparator)) {
-		return nil, errPathTraversal
-	}
-
-	f, err := os.Open(path)
+	// Open the file within the checkout root. os.OpenInRoot keeps the read
+	// contained even when the requested name resolves through a symlink that
+	// the clone materialized on disk pointing outside the repo.
+	f, err := os.OpenInRoot(h.tempDir, filename)
 	if err != nil {
 		return nil, fmt.Errorf("open file: %w", err)
 	}

--- a/internal/gitfile/gitfile_test.go
+++ b/internal/gitfile/gitfile_test.go
@@ -15,7 +15,6 @@
 package gitfile
 
 import (
-	"errors"
 	"io"
 	"os"
 	"path/filepath"
@@ -76,9 +75,28 @@ func TestHandlerPathTraversal(t *testing.T) {
 	var h Handler
 	h.Init(t.Context(), dir, "HEAD")
 
-	_, err := h.GetFile("../example.txt")
-	if !errors.Is(err, errPathTraversal) {
-		t.Fatalf("expected path traversal error: got %v", err)
+	if _, err := h.GetFile("../example.txt"); err == nil {
+		t.Fatal("expected error reading a path outside the repo, got nil")
+	}
+}
+
+func TestHandlerSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	secret := filepath.Join(t.TempDir(), "secret.txt")
+	if err := os.WriteFile(secret, []byte("host secret"), 0o600); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	dir := setupGitRepoWithSymlink(t, secret)
+
+	var h Handler
+	h.Init(t.Context(), dir, "HEAD")
+
+	// The symlink is listed as a regular file, but reading it must not follow
+	// the link to a location outside the checkout.
+	if _, err := h.GetFile("innocent.txt"); err == nil {
+		t.Fatal("expected error reading a symlink that escapes the repo, got nil")
 	}
 }
 
@@ -102,6 +120,41 @@ func setupGitRepo(t *testing.T) string {
 	}
 
 	if _, err = w.Add("example.txt"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err = w.Commit("commit message", &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  "John Doe",
+			Email: "john@doe.org",
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	return dir
+}
+
+func setupGitRepoWithSymlink(t *testing.T, target string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	r, err := git.PlainInitWithOptions(dir, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	w, err := r.Worktree()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if err = os.Symlink(target, filepath.Join(dir, "innocent.txt")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if _, err = w.Add("innocent.txt"); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix (security): keeps file reads in git mode inside the repository checkout.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

In git mode (`--file-mode git`) the target repo is cloned to a temp dir with a
non-bare `git.PlainClone`, which materializes symlinks on disk for symlink
entries in the tree. `internal/gitfile`'s `GetFile` checks the requested name for
`../` traversal but then reads with `os.Open`, which follows symlinks. A scanned
repo can commit a symlink whose name matches a check's file predicate (a workflow
file, a `Dockerfile`, and so on) and make the read resolve outside the checkout:

    innocent.txt -> /etc/passwd   # committed in the scanned repo
    GetFile("innocent.txt")       # os.Open follows the link, reads the host file

`clients/git`'s `GetFileReader` has the same non-bare-clone plus `os.Open` shape
with no containment check at all.

- [x] Tests for the changes have been added (for bug fixes/features)

#### What is the new behavior (if this is a feature change)?

Both readers now use `os.OpenInRoot(tempDir, filename)`, which refuses names that
escape the root through `../` or a symlink, so a within-repo path reads normally
while an escaping one returns an error. This is the same approach
`clients/localdir` already uses. A regression test commits an escaping symlink
and checks the read is refused; the existing `../` traversal test still passes.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

`os.OpenInRoot` landed in Go 1.24 and the module is already on 1.25, so no
version bump is needed. I left the archive/zip handlers alone since they skip
symlink entries during extraction and never write them to disk, so the same read
path is not reachable there.

#### Does this PR introduce a user-facing change?

```release-note
In git file mode, file reads are now contained to the repository checkout, so a symlink committed in a scanned repo can no longer redirect a read to a file outside it.
```