### PR TITLE
fix: handle duplicate tarball directories

### DIFF
--- a/clients/githubrepo/tarball.go
+++ b/clients/githubrepo/tarball.go
@@ -191,8 +191,8 @@ func (handler *tarballHandler) extractTarball() error {
 				continue
 			}
 
-			if err := os.Mkdir(dirpath, 0o755); err != nil {
-				return fmt.Errorf("error during os.Mkdir: %w", err)
+			if err := os.MkdirAll(dirpath, 0o755); err != nil {
+				return fmt.Errorf("error during os.MkdirAll: %w", err)
 			}
 		case tar.TypeReg:
 			if header.Size <= 0 {
@@ -204,8 +204,8 @@ func (handler *tarballHandler) extractTarball() error {
 			}
 
 			if _, err := os.Stat(filepath.Dir(filenamepath)); os.IsNotExist(err) {
-				if err := os.Mkdir(filepath.Dir(filenamepath), 0o755); err != nil {
-					return fmt.Errorf("os.Mkdir: %w", err)
+				if err := os.MkdirAll(filepath.Dir(filenamepath), 0o755); err != nil {
+					return fmt.Errorf("os.MkdirAll: %w", err)
 				}
 			}
 			outFile, err := os.Create(filenamepath)

--- a/clients/gitlabrepo/tarball.go
+++ b/clients/gitlabrepo/tarball.go
@@ -234,8 +234,8 @@ func (handler *tarballHandler) extractTarball() error {
 				continue
 			}
 
-			if err := os.Mkdir(dirpath, 0o755); err != nil {
-				return fmt.Errorf("error during os.Mkdir: %w", err)
+			if err := os.MkdirAll(dirpath, 0o755); err != nil {
+				return fmt.Errorf("error during os.MkdirAll: %w", err)
 			}
 		case tar.TypeReg:
 			if header.Size <= 0 {
@@ -247,8 +247,8 @@ func (handler *tarballHandler) extractTarball() error {
 			}
 
 			if _, err := os.Stat(filepath.Dir(filenamepath)); os.IsNotExist(err) {
-				if err := os.Mkdir(filepath.Dir(filenamepath), 0o755); err != nil {
-					return fmt.Errorf("os.Mkdir: %w", err)
+				if err := os.MkdirAll(filepath.Dir(filenamepath), 0o755); err != nil {
+					return fmt.Errorf("os.MkdirAll: %w", err)
 				}
 			}
 			outFile, err := os.Create(filenamepath)


### PR DESCRIPTION
## What changed

Use idempotent directory creation when extracting GitHub and GitLab tarballs. This handles archives with repeated directory entries and creates missing nested parent directories without changing the existing archive path validation.

## Testing

- git diff --check passed
- Go tests could not be run because Go is not installed in the local environment

Fixes #5023