### PR TITLE
:sparkles: feat: detect winget publishing workflows in Packaging check

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -624,10 +624,12 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 			LogText: "candidate winget publishing workflow using winget-releaser",
 		},
 		{
-			// Winget packages using wingetcreate.
+			// Winget packages using wingetcreate. These workflows run on Windows and
+			// commonly split the command with PowerShell's backtick continuation,
+			// which is not stripped like a backslash is, so match across newlines.
 			Steps: []*JobMatcherStep{
 				{
-					Run: "wingetcreate.*submit",
+					Run: "(?s)wingetcreate.*submit",
 				},
 			},
 			LogText: "candidate winget publishing workflow using wingetcreate",

--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -604,6 +604,34 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 			},
 			LogText: "candidate publishing workflow using elixir",
 		},
+		{
+			// Winget packages using winget-releaser.
+			Steps: []*JobMatcherStep{
+				{
+					Uses: "vedantmgoyal9/winget-releaser",
+				},
+			},
+			LogText: "candidate winget publishing workflow using winget-releaser",
+		},
+		{
+			// Winget packages using winget-releaser under its old owner name,
+			// which is still used by some projects.
+			Steps: []*JobMatcherStep{
+				{
+					Uses: "vedantmgoyal2009/winget-releaser",
+				},
+			},
+			LogText: "candidate winget publishing workflow using winget-releaser",
+		},
+		{
+			// Winget packages using wingetcreate.
+			Steps: []*JobMatcherStep{
+				{
+					Run: "wingetcreate.*submit",
+				},
+			},
+			LogText: "candidate winget publishing workflow using wingetcreate",
+		},
 	}
 
 	return AnyJobsMatch(workflow, jobMatchers, fp, "not a publishing workflow")

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -1004,6 +1004,16 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			filename: "../testdata/.github/workflows/github-workflow-packaging-elixir.yaml",
 			expected: true,
 		},
+		{
+			name:     "winget publish using winget-releaser",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-winget.yaml",
+			expected: true,
+		},
+		{
+			name:     "winget publish using wingetcreate",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-wingetcreate.yaml",
+			expected: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -1010,8 +1010,18 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "winget publish using winget-releaser under its previous owner name",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-winget-legacy-owner.yaml",
+			expected: true,
+		},
+		{
 			name:     "winget publish using wingetcreate",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-wingetcreate.yaml",
+			expected: true,
+		},
+		{
+			name:     "winget publish using wingetcreate with PowerShell backtick continuation",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-wingetcreate-powershell.yaml",
 			expected: true,
 		},
 	}

--- a/checks/testdata/.github/workflows/github-workflow-packaging-winget-legacy-owner.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-winget-legacy-owner.yaml
@@ -1,0 +1,30 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# winget-releaser under its previous owner name. The account was renamed to
+# vedantmgoyal9, and GitHub redirects the old path, so workflows that were
+# never updated still reference vedantmgoyal2009 and keep working.
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal2009/winget-releaser@v2
+        with:
+          identifier: Foo.Bar
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/checks/testdata/.github/workflows/github-workflow-packaging-winget.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-winget.yaml
@@ -1,0 +1,26 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: Foo.Bar
+          token: ${{ secrets.WINGET_TOKEN }}

--- a/checks/testdata/.github/workflows/github-workflow-packaging-wingetcreate-powershell.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-wingetcreate-powershell.yaml
@@ -1,0 +1,33 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# wingetcreate driven from PowerShell, where the command is split using the
+# backtick continuation character rather than a backslash. Modelled on
+# microsoft/PowerToys' package-submissions.yml.
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Submit package to Windows Package Manager Community Repository
+        run: |
+          curl.exe -JLO https://aka.ms/wingetcreate/latest
+          .\wingetcreate.exe update Foo.Bar `
+            --version $env:RELEASE_VERSION `
+            --urls "https://example.com/foo.exe" `
+            --submit

--- a/checks/testdata/.github/workflows/github-workflow-packaging-wingetcreate.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-wingetcreate.yaml
@@ -1,0 +1,24 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - run: |
+          wingetcreate update Foo.Bar --version ${{ github.event.release.tag_name }} --submit


### PR DESCRIPTION
#### What kind of change does this PR introduce?

New feature — the `Packaging` check now recognizes winget (Windows Package Manager) publishing workflows.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`IsPackagingWorkflow` (in `checks/fileparser/github_workflow.go`) has no matchers for winget publishing patterns, so repositories that publish to winget via `winget-releaser` or `wingetcreate` don't get credit for having an automated packaging workflow.

#### What is the new behavior (if this is a feature change)?

Adds three matchers to `IsPackagingWorkflow`:
- `vedantmgoyal9/winget-releaser` (current owner)
- `vedantmgoyal2009/winget-releaser` (older owner name, still used by some projects)
- a `Run` matcher for `wingetcreate.*submit`

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #5168

#### Special notes for your reviewer

This only teaches the `Packaging` check to recognize winget publishing workflows. It's independent of #5100 / #5101, which are about adding a `--winget` input flag so Scorecard can score a package by its winget identifier.

#### Does this PR introduce a user-facing change?

Yes — repositories using `winget-releaser` or `wingetcreate` to publish packages will now pass the `Packaging` check.

```release-note
The `Packaging` check now detects winget publishing workflows using `winget-releaser` or `wingetcreate`.
```