### PR TITLE
:bug: reject oversized zip entries in azuredevopsrepo extractZip

### DIFF
--- a/clients/azuredevopsrepo/zip.go
+++ b/clients/azuredevopsrepo/zip.go
@@ -189,31 +189,42 @@ func (z *zipHandler) extractZip() error {
 			continue
 		}
 
-		outFile, err := os.OpenFile(filenamepath, os.O_CREATE|os.O_WRONLY, 0o644)
-		if err != nil {
-			return fmt.Errorf("os.OpenFile: %w", err)
+		if err := extractEntry(file, filenamepath); err != nil {
+			return err
 		}
-
-		rc, err := file.Open()
-		if err != nil {
-			return fmt.Errorf("file.Open: %w", err)
-		}
-
-		// Read one byte past the limit so an entry that is exactly maxSize still
-		// succeeds while anything larger trips the check below. io.CopyN caps the
-		// copy at its third argument, so passing maxSize here would make written
-		// top out at maxSize and the comparison could never be true.
-		written, err := io.CopyN(outFile, rc, maxSize+1)
-		if err != nil && !errors.Is(err, io.EOF) {
-			return fmt.Errorf("%w io.Copy: %w", errZipNotFound, err)
-		}
-		if written > maxSize {
-			return errFileTooLarge
-		}
-		outFile.Close()
 
 		filename := strings.TrimPrefix(filenamepath, destinationPrefix)
 		z.files = append(z.files, filepath.ToSlash(filename))
+	}
+	return nil
+}
+
+// extractEntry writes a single zip entry to filenamepath, enforcing the
+// per-entry size cap. The defers guarantee both the destination file and the
+// entry reader are closed on every return path, including the error ones.
+func extractEntry(file *zip.File, filenamepath string) error {
+	outFile, err := os.OpenFile(filenamepath, os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("os.OpenFile: %w", err)
+	}
+	defer outFile.Close()
+
+	rc, err := file.Open()
+	if err != nil {
+		return fmt.Errorf("file.Open: %w", err)
+	}
+	defer rc.Close()
+
+	// Read one byte past the limit so an entry that is exactly maxSize still
+	// succeeds while anything larger trips the check below. io.CopyN caps the
+	// copy at its third argument, so passing maxSize here would make written
+	// top out at maxSize and the comparison could never be true.
+	written, err := io.CopyN(outFile, rc, maxSize+1)
+	if err != nil && !errors.Is(err, io.EOF) {
+		return fmt.Errorf("%w io.Copy: %w", errZipNotFound, err)
+	}
+	if written > maxSize {
+		return errFileTooLarge
 	}
 	return nil
 }

--- a/clients/azuredevopsrepo/zip.go
+++ b/clients/azuredevopsrepo/zip.go
@@ -215,12 +215,10 @@ func extractEntry(file *zip.File, filenamepath string) error {
 	}
 	defer rc.Close()
 
-	// Read one byte past the limit so an entry that is exactly maxSize still
-	// succeeds while anything larger trips the check below. io.CopyN caps the
-	// copy at its third argument, so passing maxSize here would make written
-	// top out at maxSize and the comparison could never be true.
-	written, err := io.CopyN(outFile, rc, maxSize+1)
-	if err != nil && !errors.Is(err, io.EOF) {
+	// Allow one byte past the limit so an entry that is exactly maxSize still
+	// succeeds while anything larger trips the check below.
+	written, err := io.Copy(outFile, io.LimitReader(rc, maxSize+1))
+	if err != nil {
 		return fmt.Errorf("%w io.Copy: %w", errZipNotFound, err)
 	}
 	if written > maxSize {

--- a/clients/azuredevopsrepo/zip.go
+++ b/clients/azuredevopsrepo/zip.go
@@ -199,7 +199,11 @@ func (z *zipHandler) extractZip() error {
 			return fmt.Errorf("file.Open: %w", err)
 		}
 
-		written, err := io.CopyN(outFile, rc, maxSize)
+		// Read one byte past the limit so an entry that is exactly maxSize still
+		// succeeds while anything larger trips the check below. io.CopyN caps the
+		// copy at its third argument, so passing maxSize here would make written
+		// top out at maxSize and the comparison could never be true.
+		written, err := io.CopyN(outFile, rc, maxSize+1)
 		if err != nil && !errors.Is(err, io.EOF) {
 			return fmt.Errorf("%w io.Copy: %w", errZipNotFound, err)
 		}

--- a/clients/azuredevopsrepo/zip_test.go
+++ b/clients/azuredevopsrepo/zip_test.go
@@ -15,10 +15,12 @@
 package azuredevopsrepo
 
 import (
+	"archive/zip"
 	"errors"
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -69,6 +71,49 @@ func setup(inputFile string) (zipHandler, error) {
 		// here, it won't get executed later when setup() is called.
 	})
 	return zipHandler, nil
+}
+
+func TestExtractZipTooLarge(t *testing.T) {
+	t.Parallel()
+
+	tempDir := t.TempDir()
+	zipFile, err := os.Create(filepath.Join(tempDir, "repo.zip"))
+	if err != nil {
+		t.Fatalf("os.Create: %v", err)
+	}
+
+	// A single entry one byte past the cap. Zeros deflate to a tiny archive, so
+	// this stays small on disk while decompressing to more than maxSize.
+	zw := zip.NewWriter(zipFile)
+	w, err := zw.Create("bomb")
+	if err != nil {
+		t.Fatalf("zip.Create: %v", err)
+	}
+	if _, err := io.CopyN(w, zeroReader{}, maxSize+1); err != nil {
+		t.Fatalf("write entry: %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip.Close: %v", err)
+	}
+	if err := zipFile.Close(); err != nil {
+		t.Fatalf("file.Close: %v", err)
+	}
+
+	handler := zipHandler{tempDir: tempDir, tempZipFile: zipFile.Name()}
+	if err := handler.extractZip(); !errors.Is(err, errFileTooLarge) {
+		t.Errorf("expected errFileTooLarge, got %v", err)
+	}
+}
+
+// zeroReader is an infinite source of zero bytes, used to inflate a zip entry
+// past the size cap without allocating the whole payload up front.
+type zeroReader struct{}
+
+func (zeroReader) Read(p []byte) (int, error) {
+	for i := range p {
+		p[i] = 0
+	}
+	return len(p), nil
 }
 
 //nolint:gocognit


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix. The per-entry size limit in the Azure DevOps zip extractor never rejects anything today, so an oversized entry is silently truncated instead of being refused.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`extractZip` copies each entry with `io.CopyN(outFile, rc, maxSize)` and then checks `written > maxSize` to return `errFileTooLarge`. `io.CopyN` copies at most its third argument, so `written` tops out at `maxSize` and the comparison is never true. The effect is that `errFileTooLarge` is unreachable, and an entry larger than `maxSize` is written out truncated to `maxSize` bytes and appended to `z.files` as if it extracted cleanly. Later checks then read a partial file believing it is the whole thing. With `resolveLfs=true` on the download, a small LFS pointer in the repo can expand server-side into an entry past the cap, so this is reachable without pushing a large blob through git.

- [x] Tests for the changes have been added (for bug fixes/features)

#### What is the new behavior (if this is a feature change)?

The copy now reads `maxSize+1`, so an entry that exceeds the cap makes `written > maxSize` true and is rejected, while an entry of exactly `maxSize` still extracts. The new test builds a zip whose single entry is one byte over the cap and checks `extractZip` returns `errFileTooLarge`; on the current code that entry extracts and the test fails.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

I left the GitHub and GitLab tarball handlers alone. They intentionally waive the size cap with a `//nolint:gosec` and a comment, so this stays scoped to the Azure path where the check already exists but does not fire.

#### Does this PR introduce a user-facing change?

```release-note
In Azure DevOps mode, a repository file larger than the zip extraction size limit is now rejected instead of being silently truncated.
```
