### PR TITLE
fix: improve error messages for branch-protection and pip-install checks

### DIFF
--- a/clients/githubrepo/branches.go
+++ b/clients/githubrepo/branches.go
@@ -32,7 +32,8 @@ import (
 const (
 	refPrefix = "refs/heads/"
 	//nolint:lll
-	classicBranchErrMsg = "some github tokens can't read classic branch protection rules: https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md"
+	classicBranchErrMsg = "branch protection rules are not accessible with the current token (GITHUB_TOKEN lacks administration:read permission); " +
+		"use a fine-grained personal access token with 'administration: read' scope instead: https://github.com/ossf/scorecard-action/blob/main/docs/authentication/fine-grained-auth-token.md"
 )
 
 // See https://github.community/t/graphql-api-protected-branch/14380
@@ -474,7 +475,10 @@ func getBranchRefFrom(data *branch, rules []*repoRuleSet) *clients.BranchRef {
 }
 
 func isPermissionsError(err error) bool {
-	return strings.Contains(err.Error(), "Resource not accessible")
+	// GitHub GraphQL may return "Resource not accessible by integration" when using
+	// GITHUB_TOKEN or a fine-grained token without admin permission. Check
+	// case-insensitively to guard against capitalisation differences across API versions.
+	return strings.Contains(strings.ToLower(err.Error()), "resource not accessible")
 }
 
 const (

--- a/probes/pinsDependencies/impl.go
+++ b/probes/pinsDependencies/impl.go
@@ -127,6 +127,11 @@ func generateTextUnpinned(rr *checker.Dependency) string {
 		return fmt.Sprintf("%s not pinned by hash", owner)
 	}
 
+	if rr.Type == checker.DependencyUseTypePipCommand {
+		//nolint:lll
+		return "pipCommand not pinned by hash: add --require-hashes to pin package hashes, or use a requirements file with hashes (see https://pip.pypa.io/en/stable/topics/secure-installs/)"
+	}
+
 	return fmt.Sprintf("%s not pinned by hash", rr.Type)
 }
 


### PR DESCRIPTION
## Summary

- Makes `isPermissionsError` case-insensitive so the helpful error message is always shown when `GITHUB_TOKEN` lacks branch protection read permission, regardless of API capitalisation
- Rewrites `classicBranchErrMsg` to name the missing permission (`administration:read`) and link directly to the fix
- Adds a pip-specific message in `generateTextUnpinned` explaining how to pin pip dependencies with `--require-hashes` or a requirements file

Fixes #2946
Fixes #2444

## Notes

The previous PR #5043 addressed these same issues but went stale and was closed without merging. This picks up that work.

## Test plan

- [ ] `make unit-test` passes with no failures
- [ ] `go test ./clients/githubrepo/... ./probes/pinsDependencies/...` passes