### PR TITLE
:bug: Packaging: recognize erlef/setup-beam for Elixir publishing workflows

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -593,10 +593,25 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 			LogText: "candidate publishing workflow using semantic-release",
 		},
 		{
-			// Elixir packaging
+			// Elixir packaging. erlef/setup-elixir is the pre-rename name of
+			// erlef/setup-beam (same repository, github.com/erlef/setup-elixir
+			// redirects to it); matched here for projects that still pin the
+			// old name.
 			Steps: []*JobMatcherStep{
 				{
 					Uses: "erlef/setup-elixir",
+				},
+				{
+					Run: ".*hex.publish.*",
+				},
+			},
+			LogText: "candidate publishing workflow using elixir",
+		},
+		{
+			// Elixir packaging, current action name.
+			Steps: []*JobMatcherStep{
+				{
+					Uses: "erlef/setup-beam",
 				},
 				{
 					Run: ".*hex.publish.*",

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -1004,6 +1004,11 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			filename: "../testdata/.github/workflows/github-workflow-packaging-elixir.yaml",
 			expected: true,
 		},
+		{
+			name:     "elixir-setup-beam",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-elixir-setup-beam.yaml",
+			expected: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/testdata/.github/workflows/github-workflow-packaging-elixir-setup-beam.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-elixir-setup-beam.yaml
@@ -1,0 +1,25 @@
+name: ElixirTorrent Publish
+
+on:
+  push:
+    tags: ["[0-9]*.[0-9]*.[0-9]*"]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Publish to Hex.pm
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: erlef/setup-beam@54075bcc5e249e4758d363f27d099f55d843f124 # v1.24.1
+        with:
+          version-file: .tool-versions
+          version-type: strict
+      - name: Install dependencies
+        run: mix deps.get --check-locked
+      - name: Publish package and docs to Hex.pm
+        env:
+          HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
+        run: mix hex.publish --yes


### PR DESCRIPTION
## What

Adds a second `Packaging` JobMatcher for Elixir/Hex publishing workflows that use `erlef/setup-beam` instead of `erlef/setup-elixir`.

## Why

`erlef/setup-elixir` was renamed upstream to `erlef/setup-beam` (same repository — `github.com/erlef/setup-elixir` redirects to `github.com/erlef/setup-beam`). The existing Elixir matcher added in #2564 only recognizes the pre-rename name, so any Elixir project correctly using the current action name gets `packaging workflow not detected` even when it has a working `mix hex.publish` step.

Example: https://github.com/daniboybye/ElixirTorrent/actions/workflows/build-and-publish.yml uses `erlef/setup-beam` and `mix hex.publish --yes` in the same job, but was scored as having no packaging workflow.

## How

Follows the existing pattern used for the two Docker matchers (`docker push` vs `docker/build-push-action`) — adds a second, independent `JobMatcher` entry rather than modifying the existing one, so projects pinned to either action name are recognized.

Added a test fixture (`github-workflow-packaging-elixir-setup-beam.yaml`) and a corresponding `TestIsPackagingWorkflow` case; existing tests and fixtures are untouched.

## Testing

```
go test ./checks/fileparser/... -run TestIsPackagingWorkflow -v
```
All cases pass, including the new `elixir-setup-beam` one.
