### PR TITLE
:bug: Use GitLab MR diff head SHA for CI statuses

### DIFF
--- a/clients/gitlabrepo/commits.go
+++ b/clients/gitlabrepo/commits.go
@@ -109,7 +109,9 @@ func (handler *commitsHandler) zip(commitsRaw []*gitlab.Commit, data graphqlData
 		for _, commit := range mr.Commits.Nodes {
 			commitToMRIID[commit.SHA] = mr.IID
 		}
-		commitToMRIID[mr.MergeCommitSHA] = mr.IID
+		if mr.MergeCommitSHA != "" {
+			commitToMRIID[mr.MergeCommitSHA] = mr.IID
+		}
 	}
 
 	iidToMr := make(map[string]clients.PullRequest)
@@ -164,7 +166,7 @@ func (handler *commitsHandler) zip(commitsRaw []*gitlab.Commit, data graphqlData
 		iidToMr[mr.IID] = clients.PullRequest{
 			Number:   mrno,
 			MergedAt: mr.MergedAt,
-			HeadSHA:  mr.MergeCommitSHA,
+			HeadSHA:  mr.DiffHeadSHA,
 			Author:   clients.User{Login: mr.Author.Username, ID: int64(mr.Author.ID.ID)},
 			Reviews:  vals,
 			MergedBy: clients.User{Login: mr.MergedBy.Username, ID: int64(mr.MergedBy.ID.ID)},

--- a/clients/gitlabrepo/commits_test.go
+++ b/clients/gitlabrepo/commits_test.go
@@ -17,6 +17,7 @@ package gitlabrepo
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 	gitlab "gitlab.com/gitlab-org/api/client-go"
@@ -132,5 +133,51 @@ func TestListRawCommits(t *testing.T) {
 				t.Errorf("listCommits() = %v, want %v", len(commits), cmp.Diff(len(commits), tt.want))
 			}
 		})
+	}
+}
+
+func TestZipUsesDiffHeadShaForMergeRequestHead(t *testing.T) {
+	t.Parallel()
+
+	committedDate := time.Now()
+	handler := &commitsHandler{}
+	commits := handler.zip([]*gitlab.Commit{
+		{
+			ID:            "commit-sha",
+			CommittedDate: &committedDate,
+		},
+	}, graphqlData{
+		Project: struct {
+			MergeRequests struct {
+				Nodes []graphqlMergeRequestNode `graphql:"nodes"`
+			} `graphql:"mergeRequests(sort: MERGED_AT_DESC, state: merged, mergedBefore: $mergedBefore)"`
+		}{
+			MergeRequests: struct {
+				Nodes []graphqlMergeRequestNode `graphql:"nodes"`
+			}{
+				Nodes: []graphqlMergeRequestNode{
+					{
+						IID:            "7",
+						DiffHeadSHA:    "diff-head-sha",
+						MergeCommitSHA: "merge-commit-sha",
+						Commits: struct {
+							Nodes []struct {
+								SHA string `graphql:"sha"`
+							} `graphql:"nodes"`
+						}{
+							Nodes: []struct {
+								SHA string `graphql:"sha"`
+							}{
+								{SHA: "commit-sha"},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	if got, want := commits[0].AssociatedMergeRequest.HeadSHA, "diff-head-sha"; got != want {
+		t.Errorf("AssociatedMergeRequest.HeadSHA = %q, want %q", got, want)
 	}
 }

--- a/clients/gitlabrepo/graphql.go
+++ b/clients/gitlabrepo/graphql.go
@@ -93,6 +93,7 @@ type graphqlMergeRequestNode struct {
 			ID       GitlabGID `graphql:"id"`
 		} `graphql:"nodes"`
 	} `graphql:"approvedBy"`
+	DiffHeadSHA    string `graphql:"diffHeadSha"`
 	MergeCommitSHA string `graphql:"mergeCommitSha"`
 	// Labels         struct {
 	// 	Nodes []struct {


### PR DESCRIPTION
## Summary
- query GitLab merge requests for `diffHeadSha`
- use the diff head SHA as the associated merge request head SHA so CI status lookups target the MR head instead of the merge commit
- avoid indexing empty merge commit SHAs when GitLab returns no merge commit

Fixes #3701

## Verification
- `go test ./clients/gitlabrepo`
- `git diff --check`
