### PR TITLE
:bug: stop an unterminated ${{ from aborting the DangerousWorkflow check

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/ossf/scorecard/v5/checker"
 	"github.com/ossf/scorecard/v5/checks/fileparser"
-	sce "github.com/ossf/scorecard/v5/errors"
 	"github.com/ossf/scorecard/v5/finding"
 )
 
@@ -257,7 +256,11 @@ func checkVariablesInScript(script string, pos *actionlint.Pos,
 
 		e := strings.Index(script[s:], "}}")
 		if e == -1 {
-			return sce.WithMessage(sce.ErrScorecardInternal, errInvalidGitHubWorkflow.Error())
+			// No closing delimiter means there's no complete expression left to
+			// inspect. Stop scanning this script instead of failing the whole
+			// check, so one malformed workflow can't suppress script-injection
+			// detection in every other workflow file.
+			break
 		}
 
 		// Check if the variable may be untrustworthy.

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -213,6 +213,11 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 			filename: ".github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection-tojson.yml",
 			expected: ret{nb: 1},
 		},
+		{
+			name:     "unterminated expression does not hide later injection",
+			filename: ".github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection-unterminated.yml",
+			expected: ret{nb: 1},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection-unterminated.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection-unterminated.yml
@@ -1,0 +1,28 @@
+# Copyright 2021 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+on: [pull_request]
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Unterminated expression
+      run: |
+        echo "prefix ${{ github.actor "
+
+    - name: Check title
+      run: |
+        title="${{ github.event.issue.title }}"
+        echo "$title"


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`checkVariablesInScript` in `checks/raw/dangerous_workflow.go` scans a step's `run:` body for `${{ ... }}` expressions. When it finds a `${{` with no closing `}}`, it returns an internal error. That error bubbles up through `validateScriptInjection` and the `OnMatchingFileContentDo` callback, which stops iterating over the remaining workflow files and makes the whole Dangerous-Workflow check error out.

`actionlint.Parse` treats a `run:` body as an opaque string and does not validate expression syntax inside it, so an unterminated `${{` parses fine. The practical effect is that a single analyzed workflow file containing one unterminated expression suppresses script-injection detection for every other workflow in the repo, so a genuinely dangerous workflow can go unreported.

#### What is the new behavior (if this is a feature change)?

When there is no closing `}}`, the scan loop now breaks instead of returning an error. With no closing delimiter there is no complete expression left to inspect, so scanning stops for that one script and the rest of the check continues normally. Valid expressions in other steps and other files are still evaluated.

- [x] Tests for the changes have been added (for bug fixes/features)

Added `github-workflow-dangerous-pattern-untrusted-script-injection-unterminated.yml`: its first step has an unterminated `${{` and its second step has a real `github.event.issue.title` injection. Before this change the check returned an error and reported 0 findings; now it reports the injection.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

The `error` return on `checkVariablesInScript` is now always `nil`. I kept the signature as-is to keep the diff small and leave room for a future real error condition, but I am happy to drop it if you would rather see it removed.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```
