### PR TITLE
:bug: Detect explicit unsafe fork checkouts

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -73,6 +73,9 @@ var (
 	triggerWorkflowRun              = triggerName("workflow_run")
 	checkoutUntrustedPullRequestRef = "github.event.pull_request"
 	checkoutUntrustedWorkflowRunRef = "github.event.workflow_run"
+	checkoutUntrustedHeadRef        = "github.head_ref"
+	checkoutUntrustedForkRepository = "github.event.pull_request.head.repo.full_name"
+	checkoutAllowUnsafePRInput      = "allow-unsafe-pr-checkout"
 )
 
 // DangerousWorkflow retrieves the raw data for the DangerousWorkflow check.
@@ -174,6 +177,21 @@ func createJob(job *actionlint.Job) *checker.WorkflowJob {
 	return &r
 }
 
+func isExplicitUnsafeForkCheckout(action *actionlint.ExecAction, ref string) bool {
+	repository, ok := action.Inputs["repository"]
+	if !ok || repository.Value == nil {
+		return false
+	}
+	allowUnsafe, ok := action.Inputs[checkoutAllowUnsafePRInput]
+	if !ok || allowUnsafe.Value == nil {
+		return false
+	}
+
+	return strings.Contains(repository.Value.Value, checkoutUntrustedForkRepository) &&
+		strings.Contains(ref, checkoutUntrustedHeadRef) &&
+		strings.EqualFold(strings.TrimSpace(allowUnsafe.Value.Value), "true")
+}
+
 func checkJobForUntrustedCodeCheckout(job *actionlint.Job, path string,
 	pdata *checker.DangerousWorkflowData,
 ) error {
@@ -202,7 +220,8 @@ func checkJobForUntrustedCodeCheckout(job *actionlint.Job, path string,
 		}
 
 		if strings.Contains(ref.Value.Value, checkoutUntrustedPullRequestRef) ||
-			strings.Contains(ref.Value.Value, checkoutUntrustedWorkflowRunRef) {
+			strings.Contains(ref.Value.Value, checkoutUntrustedWorkflowRunRef) ||
+			isExplicitUnsafeForkCheckout(e, ref.Value.Value) {
 			line := fileparser.GetLineNumber(step.Pos)
 			pdata.Workflows = append(pdata.Workflows,
 				checker.DangerousWorkflow{

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/rhysd/actionlint"
 	"go.uber.org/mock/gomock"
 
 	"github.com/ossf/scorecard/v5/checker"
@@ -141,6 +142,72 @@ func TestUntrustedContextVariables(t *testing.T) {
 			t.Parallel()
 			if r := containsUntrustedContextPattern(tt.variable); !r == tt.expected {
 				t.Fail()
+			}
+		})
+	}
+}
+
+func TestValidateUntrustedCodeCheckout(t *testing.T) {
+	t.Parallel()
+
+	const workflowPrefix = `on:
+  pull_request_target:
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+`
+	tests := []struct {
+		name     string
+		inputs   string
+		expected int
+	}{
+		{
+			name: "explicit unsafe fork checkout",
+			inputs: `          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+          allow-unsafe-pr-checkout: true
+`,
+			expected: 1,
+		},
+		{
+			name: "protected by checkout default",
+			inputs: `          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.head_ref }}
+`,
+			expected: 0,
+		},
+		{
+			name: "head ref without fork repository",
+			inputs: `          ref: ${{ github.head_ref }}
+          allow-unsafe-pr-checkout: true
+`,
+			expected: 0,
+		},
+		{
+			name: "existing pull request expression",
+			inputs: `          ref: ${{ github.event.pull_request.head.sha }}
+`,
+			expected: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow, errs := actionlint.Parse([]byte(workflowPrefix + tt.inputs))
+			if workflow == nil {
+				t.Fatalf("failed to parse workflow: %v", errs)
+			}
+
+			data := checker.DangerousWorkflowData{}
+			if err := validateUntrustedCodeCheckout(workflow, "workflow.yml", &data); err != nil {
+				t.Fatal(err)
+			}
+			if diff := cmp.Diff(tt.expected, len(data.Workflows)); diff != "" {
+				t.Errorf("dangerous workflow count mismatch (-want +got):\n%s", diff)
 			}
 		})
 	}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix for the Dangerous-Workflow check.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

A privileged `pull_request_target` workflow can explicitly check out an external contributor's fork without being reported when it uses this combination:

```yaml
- uses: actions/checkout@v4
  with:
    repository: ${{ github.event.pull_request.head.repo.full_name }}
    ref: ${{ github.head_ref }}
    allow-unsafe-pr-checkout: true
```

The current check recognizes references containing `github.event.pull_request` or `github.event.workflow_run`, but not `github.head_ref` combined with an attacker-controlled fork repository.

#### What is the new behavior (if this is a feature change)?

Dangerous-Workflow reports the checkout when all three high-confidence indicators are present:

- the repository is selected from `github.event.pull_request.head.repo.full_name`;
- the ref uses `github.head_ref`; and
- checkout's `allow-unsafe-pr-checkout` input is explicitly `true`.

The narrow combination avoids reporting workflows that remain protected by checkout's safer default. Tests cover the unsafe combination, the protected default, a same-repository `head_ref`, and the existing pull-request expression behavior.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Towards #2404

#### Special notes for your reviewer

This is a draft pending maintainer feedback on the detection boundary. The focused tests pass locally on Go 1.25.6. The full `checks/raw` package has pre-existing Windows path-related failures in pinned-dependency tests; those failures do not touch the modified files.

#### Does this PR introduce a user-facing change?

Yes. Repositories with an explicitly unsafe fork checkout in a privileged workflow will receive a Dangerous-Workflow finding.

```release-note
Dangerous-Workflow: detect explicit unsafe checkouts of pull request fork code in privileged workflows.
```