### PR TITLE
:sparkles: Analyze Makefile recipes for unpinned downloads

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -15,6 +15,7 @@
 package raw
 
 import (
+	"bufio"
 	"bytes"
 	"errors"
 	"fmt"
@@ -66,6 +67,11 @@ func PinningDependencies(c *checker.CheckRequest) (checker.PinningDependenciesDa
 
 	// Script downloads.
 	if err := collectShellScriptInsecureDownloads(c, &results); err != nil {
+		return checker.PinningDependenciesData{}, err
+	}
+
+	// Makefile downloads.
+	if err := collectMakefileInsecureDownloads(c, &results); err != nil {
 		return checker.PinningDependenciesData{}, err
 	}
 
@@ -288,6 +294,108 @@ func collectShellScriptInsecureDownloads(c *checker.CheckRequest, r *checker.Pin
 		Pattern:       "*",
 		CaseSensitive: false,
 	}, validateShellScriptIsFreeOfInsecureDownloads, r)
+}
+
+func collectMakefileInsecureDownloads(c *checker.CheckRequest, r *checker.PinningDependenciesData) error {
+	return fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
+		Pattern:       "*Makefile*",
+		CaseSensitive: false,
+	}, validateMakefileInsecureDownloads, r)
+}
+
+var validateMakefileInsecureDownloads fileparser.DoWhileTrueOnFileContent = func(
+	pathfn string,
+	content []byte,
+	args ...interface{},
+) (bool, error) {
+	if len(args) != 1 {
+		return false, fmt.Errorf(
+			"validateMakefileInsecureDownloads requires exactly 1 arguments: got %v: %w",
+			len(args), errInvalidArgLength)
+	}
+
+	if fileIsInVendorDir(pathfn) || !isMakefile(pathfn) {
+		return true, nil
+	}
+
+	pdata := dataAsPinnedDependenciesPointer(args[0])
+	taintedFiles := make(map[string]bool)
+	scanner := bufio.NewScanner(bytes.NewReader(content))
+	var command strings.Builder
+	var startLine uint
+	lineNumber := uint(0)
+
+	validateCommand := func(endLine uint) error {
+		if command.Len() == 0 {
+			return nil
+		}
+		err := validateShellFile(pathfn, startLine, endLine, []byte(command.String()), taintedFiles, pdata)
+		command.Reset()
+		return err
+	}
+
+	for scanner.Scan() {
+		line := scanner.Text()
+		cmd, ok := makeRecipeCommand(line)
+		if !ok {
+			endLine := lineNumber
+			if endLine > 0 {
+				endLine--
+			}
+			if err := validateCommand(endLine); err != nil {
+				return false, err
+			}
+			lineNumber++
+			continue
+		}
+
+		if command.Len() == 0 {
+			startLine = lineNumber
+		}
+		command.WriteString(cmd)
+		if strings.HasSuffix(strings.TrimRight(cmd, " \t\r"), "\\") {
+			command.WriteByte('\n')
+			lineNumber++
+			continue
+		}
+
+		if err := validateCommand(lineNumber); err != nil {
+			return false, err
+		}
+		lineNumber++
+	}
+	if err := scanner.Err(); err != nil {
+		return false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("scan Makefile: %v", err))
+	}
+	endLine := lineNumber
+	if endLine > 0 {
+		endLine--
+	}
+	if err := validateCommand(endLine); err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func isMakefile(pathfn string) bool {
+	name := strings.ToLower(filepath.Base(pathfn))
+	return name == "makefile" || name == "gnumakefile" || strings.HasPrefix(name, "makefile.")
+}
+
+func makeRecipeCommand(line string) (string, bool) {
+	if !strings.HasPrefix(line, "\t") {
+		return "", false
+	}
+
+	command := strings.TrimLeft(line[1:], " \t")
+	for len(command) > 0 && strings.ContainsRune("@-+", rune(command[0])) {
+		command = strings.TrimLeft(command[1:], " \t")
+	}
+	if command == "" || strings.HasPrefix(command, "#") {
+		return "", false
+	}
+	return command, true
 }
 
 var validateShellScriptIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFileContent = func(

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -1606,6 +1606,65 @@ func TestShellScriptDownload(t *testing.T) {
 	}
 }
 
+func TestMakefileDownload(t *testing.T) {
+	t.Parallel()
+
+	content := []byte("INSTALL_URL = https://example.com/install.sh\n" +
+		"install:\n" +
+		"\t@curl -sSL https://example.com/install.sh | bash\n" +
+		"\t# curl -sSL https://example.com/comment.sh | bash\n" +
+		"download:\n" +
+		"\t-curl -sSL https://example.com/tool.sh > /tmp/tool\n" +
+		"run:\n" +
+		"\t+bash /tmp/tool\n" +
+		"continued:\n" +
+		"\tcurl -sSL https://example.com/continued.sh \\\n" +
+		"\t\t| bash\n")
+
+	var result checker.PinningDependenciesData
+	_, err := validateMakefileInsecureDownloads("Makefile", content, &result)
+	if err != nil {
+		t.Fatalf("validateMakefileInsecureDownloads() error = %v", err)
+	}
+
+	want := []struct {
+		line uint
+	}{
+		{line: 3},
+		{line: 8},
+		{line: 10},
+	}
+	for _, expected := range want {
+		found := func(dep checker.Dependency) bool {
+			return !*dep.Pinned && dep.Location.Path == "Makefile" &&
+				dep.Location.Offset == expected.line && dep.Type == checker.DependencyUseTypeDownloadThenRun
+		}
+		if !scut.ValidatePinningDependencies(found, &result) {
+			t.Errorf("missing Makefile finding at line %d", expected.line)
+		}
+	}
+	if got := countUnpinned(result.Dependencies); got != len(want) {
+		t.Errorf("expected %d unpinned dependencies, got %d", len(want), got)
+	}
+	if len(result.ProcessingErrors) != 0 {
+		t.Errorf("expected no processing errors, got %d", len(result.ProcessingErrors))
+	}
+}
+
+func TestMakefileDownloadIgnoresNonMakefiles(t *testing.T) {
+	t.Parallel()
+
+	var result checker.PinningDependenciesData
+	_, err := validateMakefileInsecureDownloads("NotAMakefile.txt",
+		[]byte("\tcurl -sSL https://example.com/install.sh | bash\n"), &result)
+	if err != nil {
+		t.Fatalf("validateMakefileInsecureDownloads() error = %v", err)
+	}
+	if len(result.Dependencies) != 0 {
+		t.Errorf("expected non-Makefile content to be ignored, got %d dependencies", len(result.Dependencies))
+	}
+}
+
 func TestShellScriptDownloadPinned(t *testing.T) {
 	t.Parallel()
 	//nolint:govet


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Feature: extend the Dependency-Pinning check to analyze Makefile recipe commands.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The check analyzes shell scripts, workflow `run` blocks, and Dockerfile `RUN` commands, but it does not detect unpinned download-and-execute patterns in Makefile recipes.

#### What is the new behavior (if this is a feature change)?

Makefile recipe commands are passed through the existing shell download validator. The implementation:

- recognizes conventional Makefile names case-insensitively
- ignores non-recipe syntax and recipe comments
- handles Make command prefixes (`@`, `-`, and `+`)
- joins backslash-continued recipe commands
- preserves source line locations
- tracks downloaded files across recipes in the same Makefile

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #884

#### Special notes for your reviewer

Validation completed:

- `go test ./checks/... -count=1`
- `tools/bin/golangci-lint run -c .golangci.yml --new-from-rev=HEAD` (0 issues)
- `git diff --check`

The repository-wide `make check-linter` currently also reports two pre-existing findings outside this change in `policy/policy.go:144` (cognitive complexity) and `policy/policy_test.go:311` (field alignment).

#### Does this PR introduce a user-facing change?

```release-note
Dependency-Pinning now detects unpinned download-and-execute commands in Makefile recipes.
```
