### PR TITLE
:sparkles: Add hasSelfHostedRunners probe

### DIFF
--- a/docs/probes.md
+++ b/docs/probes.md
@@ -340,6 +340,21 @@ If an SBOM artifact is not found, the probe returns a single OutcomeFalse.
 If an SBOM file is not found, the probe returns a single OutcomeFalse.
 
 
+## hasSelfHostedRunners
+
+**Lifecycle**: experimental
+
+**Description**: Flags GitHub Actions jobs that run on self-hosted runners.
+
+**Motivation**: GitHub-hosted runners are ephemeral and isolated, so they're thrown away after each job. Self-hosted runners carry no such guarantee: unless the maintainer hardens them, they persist between jobs and a malicious pull request can poison the machine. A poisoned runner can steal secrets and tokens, tamper with release artifacts, or falsify test results, so knowing a project exposes self-hosted runners is a useful signal on its own.
+
+**Implementation**: The probe parses each GitHub Actions workflow under .github/workflows and inspects the runs-on clause of every job. A job is flagged when it targets a runner group (which only exist for self-hosted runners) or when its labels include the "self-hosted" label that GitHub assigns to every self-hosted runner. Jobs whose runs-on is entirely a ${{ }} expression can't be resolved statically and are left alone. Note this misses jobs that reach a self-hosted runner purely through a custom label, since those labels are indistinguishable from custom GitHub-hosted larger-runner labels without querying the runner configuration.
+
+**Outcomes**: The probe returns one OutcomeTrue per job that runs on a self-hosted runner.
+If no job uses a self-hosted runner, the probe returns a single OutcomeFalse.
+If a workflow file can't be parsed, the probe returns an OutcomeError for that file.
+
+
 ## hasUnverifiedBinaryArtifacts
 
 **Lifecycle**: stable

--- a/probes/entries.go
+++ b/probes/entries.go
@@ -41,6 +41,7 @@ import (
 	"github.com/ossf/scorecard/v5/probes/hasRecentCommits"
 	"github.com/ossf/scorecard/v5/probes/hasReleaseSBOM"
 	"github.com/ossf/scorecard/v5/probes/hasSBOM"
+	"github.com/ossf/scorecard/v5/probes/hasSelfHostedRunners"
 	"github.com/ossf/scorecard/v5/probes/hasUnverifiedBinaryArtifacts"
 	"github.com/ossf/scorecard/v5/probes/issueActivityByProjectMember"
 	"github.com/ossf/scorecard/v5/probes/jobLevelPermissions"
@@ -176,6 +177,7 @@ var (
 	// Probes which don't use pre-computed raw data but rather collect it themselves.
 	Independent = []IndependentProbeImpl{
 		unsafeblock.Run,
+		hasSelfHostedRunners.Run,
 	}
 )
 

--- a/probes/hasSelfHostedRunners/def.yml
+++ b/probes/hasSelfHostedRunners/def.yml
@@ -1,0 +1,47 @@
+# Copyright 2025 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+id: hasSelfHostedRunners
+lifecycle: experimental
+short: Flags GitHub Actions jobs that run on self-hosted runners.
+motivation: >
+  GitHub-hosted runners are ephemeral and isolated, so they're thrown away after each job.
+  Self-hosted runners carry no such guarantee: unless the maintainer hardens them, they persist
+  between jobs and a malicious pull request can poison the machine. A poisoned runner can steal
+  secrets and tokens, tamper with release artifacts, or falsify test results, so knowing a project
+  exposes self-hosted runners is a useful signal on its own.
+implementation: >
+  The probe parses each GitHub Actions workflow under .github/workflows and inspects the runs-on
+  clause of every job. A job is flagged when it targets a runner group (which only exist for
+  self-hosted runners) or when its labels include the "self-hosted" label that GitHub assigns to
+  every self-hosted runner. Jobs whose runs-on is entirely a ${{ }} expression can't be resolved
+  statically and are left alone. Note this misses jobs that reach a self-hosted runner purely
+  through a custom label, since those labels are indistinguishable from custom GitHub-hosted
+  larger-runner labels without querying the runner configuration.
+outcome:
+  - The probe returns one OutcomeTrue per job that runs on a self-hosted runner.
+  - If no job uses a self-hosted runner, the probe returns a single OutcomeFalse.
+  - If a workflow file can't be parsed, the probe returns an OutcomeError for that file.
+remediation:
+  onOutcome: True
+  effort: Low
+  text:
+    - Confirm the job actually needs a self-hosted runner. GitHub-hosted runners cover most cases and are ephemeral by default.
+    - If a self-hosted runner is unavoidable (for example an architecture GitHub doesn't offer), make it ephemeral and sandboxed, and keep it off workflows exposed to untrusted pull requests.
+    - See the GitHub guidance on [hardening self-hosted runners](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#hardening-for-self-hosted-runners).
+ecosystem:
+  languages:
+    - all
+  clients:
+    - github

--- a/probes/hasSelfHostedRunners/impl.go
+++ b/probes/hasSelfHostedRunners/impl.go
@@ -1,0 +1,154 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hasSelfHostedRunners
+
+import (
+	"embed"
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+
+	"github.com/rhysd/actionlint"
+
+	"github.com/ossf/scorecard/v5/checker"
+	"github.com/ossf/scorecard/v5/checks/fileparser"
+	"github.com/ossf/scorecard/v5/finding"
+	"github.com/ossf/scorecard/v5/internal/probes"
+	"github.com/ossf/scorecard/v5/probes/internal/utils/uerror"
+)
+
+//go:embed *.yml
+var fs embed.FS
+
+var errInvalidArg = errors.New("invalid arg")
+
+const (
+	Probe = "hasSelfHostedRunners"
+	// selfHostedLabel is the label GitHub automatically applies to every self-hosted runner.
+	// https://docs.github.com/en/actions/hosting-your-own-runners/using-self-hosted-runners-in-a-workflow
+	selfHostedLabel = "self-hosted"
+)
+
+func init() {
+	probes.MustRegisterIndependent(Probe, Run)
+}
+
+func Run(raw *checker.CheckRequest) ([]finding.Finding, string, error) {
+	if raw == nil {
+		return nil, Probe, fmt.Errorf("%w: raw", uerror.ErrNil)
+	}
+
+	findings := []finding.Finding{}
+	err := fileparser.OnMatchingFileContentDo(raw.RepoClient, fileparser.PathMatcher{
+		Pattern:       ".github/workflows/*",
+		CaseSensitive: false,
+	}, checkSelfHostedRunners, &findings)
+	if err != nil {
+		return nil, Probe, fmt.Errorf("checking self-hosted runners: %w", err)
+	}
+
+	if len(findings) == 0 {
+		f, err := finding.NewWith(fs, Probe,
+			"no self-hosted runners found in GitHub Actions workflows", nil, finding.OutcomeFalse)
+		if err != nil {
+			return nil, Probe, fmt.Errorf("create finding: %w", err)
+		}
+		findings = append(findings, *f)
+	}
+	return findings, Probe, nil
+}
+
+var checkSelfHostedRunners fileparser.DoWhileTrueOnFileContent = func(path string,
+	content []byte,
+	args ...interface{},
+) (bool, error) {
+	if !fileparser.IsWorkflowFile(path) {
+		return true, nil
+	}
+	if len(args) != 1 {
+		return false, fmt.Errorf("%w: expected 1 arg, got %d", errInvalidArg, len(args))
+	}
+	findings, ok := args[0].(*[]finding.Finding)
+	if !ok {
+		panic(fmt.Sprintf("expected *[]finding.Finding, got %v", reflect.TypeOf(args[0])))
+	}
+
+	workflow, errs := actionlint.Parse(content)
+	if len(errs) > 0 && workflow == nil {
+		f, err := finding.NewWith(fs, Probe, "malformed GitHub Actions workflow file",
+			&finding.Location{Path: path}, finding.OutcomeError)
+		if err != nil {
+			return false, fmt.Errorf("create finding: %w", err)
+		}
+		*findings = append(*findings, *f)
+		return true, nil
+	}
+
+	// Collect first so the findings for a single file are emitted in a stable order.
+	// actionlint stores jobs in a map, whose iteration order is random.
+	type flagged struct {
+		id   string
+		line uint
+	}
+	var jobs []flagged
+	for _, job := range workflow.Jobs {
+		pos := selfHostedRunnerPos(job)
+		if pos == nil {
+			continue
+		}
+		id := ""
+		if job.ID != nil {
+			id = job.ID.Value
+		}
+		jobs = append(jobs, flagged{id: id, line: uint(pos.Line)})
+	}
+	sort.Slice(jobs, func(i, j int) bool {
+		return jobs[i].line < jobs[j].line
+	})
+
+	for i := range jobs {
+		line := jobs[i].line
+		f, err := finding.NewWith(fs, Probe,
+			fmt.Sprintf("job %q runs on a self-hosted runner", jobs[i].id),
+			&finding.Location{Path: path, LineStart: &line}, finding.OutcomeTrue)
+		if err != nil {
+			return false, fmt.Errorf("create finding: %w", err)
+		}
+		*findings = append(*findings, *f)
+	}
+
+	return true, nil
+}
+
+// selfHostedRunnerPos reports the position of the runs-on element that marks the job
+// as running on a self-hosted runner, or nil if the job uses a GitHub-hosted runner
+// (or can't be resolved statically).
+func selfHostedRunnerPos(job *actionlint.Job) *actionlint.Pos {
+	if job == nil || job.RunsOn == nil {
+		return nil
+	}
+	// Runner groups only exist for self-hosted runners.
+	if job.RunsOn.Group != nil && job.RunsOn.Group.Value != "" {
+		return job.RunsOn.Group.Pos
+	}
+	for _, label := range job.RunsOn.Labels {
+		if label != nil && strings.EqualFold(label.Value, selfHostedLabel) {
+			return label.Pos
+		}
+	}
+	return nil
+}

--- a/probes/hasSelfHostedRunners/impl_test.go
+++ b/probes/hasSelfHostedRunners/impl_test.go
@@ -1,0 +1,213 @@
+// Copyright 2025 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package hasSelfHostedRunners
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"go.uber.org/mock/gomock"
+
+	"github.com/ossf/scorecard/v5/checker"
+	mockrepo "github.com/ossf/scorecard/v5/clients/mockclients"
+	"github.com/ossf/scorecard/v5/finding"
+)
+
+func toUint(u uint) *uint { return &u }
+
+var remediation = &finding.Remediation{
+	Text: "Confirm the job actually needs a self-hosted runner. GitHub-hosted runners cover most cases and are ephemeral by default.\n" +
+		"If a self-hosted runner is unavoidable (for example an architecture GitHub doesn't offer), make it ephemeral and sandboxed, and keep it off workflows exposed to untrusted pull requests.\n" +
+		"See the GitHub guidance on [hardening self-hosted runners](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#hardening-for-self-hosted-runners).",
+	Effort: finding.RemediationEffortLow,
+}
+
+func Test_Run(t *testing.T) {
+	t.Parallel()
+	//nolint:govet
+	tests := []struct {
+		name      string
+		filenames []string
+		expected  []finding.Finding
+		err       error
+	}{
+		{
+			name:      "no workflows",
+			filenames: []string{},
+			expected: []finding.Finding{
+				{
+					Probe:   Probe,
+					Message: "no self-hosted runners found in GitHub Actions workflows",
+					Outcome: finding.OutcomeFalse,
+				},
+			},
+		},
+		{
+			name:      "github-hosted runner only",
+			filenames: []string{".github/workflows/secure.yml"},
+			expected: []finding.Finding{
+				{
+					Probe:   Probe,
+					Message: "no self-hosted runners found in GitHub Actions workflows",
+					Outcome: finding.OutcomeFalse,
+				},
+			},
+		},
+		{
+			name:      "self-hosted label",
+			filenames: []string{".github/workflows/self-hosted.yml"},
+			expected: []finding.Finding{
+				{
+					Probe:       Probe,
+					Message:     `job "build" runs on a self-hosted runner`,
+					Outcome:     finding.OutcomeTrue,
+					Location:    &finding.Location{Path: ".github/workflows/self-hosted.yml", LineStart: toUint(5)},
+					Remediation: remediation,
+				},
+			},
+		},
+		{
+			name:      "runner group",
+			filenames: []string{".github/workflows/group.yml"},
+			expected: []finding.Finding{
+				{
+					Probe:       Probe,
+					Message:     `job "build" runs on a self-hosted runner`,
+					Outcome:     finding.OutcomeTrue,
+					Location:    &finding.Location{Path: ".github/workflows/group.yml", LineStart: toUint(6)},
+					Remediation: remediation,
+				},
+			},
+		},
+		{
+			name:      "mixed hosted and self-hosted jobs",
+			filenames: []string{".github/workflows/mixed.yml"},
+			expected: []finding.Finding{
+				{
+					Probe:       Probe,
+					Message:     `job "selfhosted" runs on a self-hosted runner`,
+					Outcome:     finding.OutcomeTrue,
+					Location:    &finding.Location{Path: ".github/workflows/mixed.yml", LineStart: toUint(9)},
+					Remediation: remediation,
+				},
+			},
+		},
+		{
+			name:      "runs-on expression is not resolved",
+			filenames: []string{".github/workflows/expression.yml"},
+			expected: []finding.Finding{
+				{
+					Probe:   Probe,
+					Message: "no self-hosted runners found in GitHub Actions workflows",
+					Outcome: finding.OutcomeFalse,
+				},
+			},
+		},
+		{
+			name:      "malformed workflow",
+			filenames: []string{".github/workflows/malformed.yml"},
+			expected: []finding.Finding{
+				{
+					Probe:    Probe,
+					Message:  "malformed GitHub Actions workflow file",
+					Outcome:  finding.OutcomeError,
+					Location: &finding.Location{Path: ".github/workflows/malformed.yml"},
+				},
+			},
+		},
+		{
+			name: "multiple workflows",
+			filenames: []string{
+				".github/workflows/secure.yml",
+				".github/workflows/self-hosted.yml",
+				".github/workflows/group.yml",
+			},
+			expected: []finding.Finding{
+				{
+					Probe:       Probe,
+					Message:     `job "build" runs on a self-hosted runner`,
+					Outcome:     finding.OutcomeTrue,
+					Location:    &finding.Location{Path: ".github/workflows/self-hosted.yml", LineStart: toUint(5)},
+					Remediation: remediation,
+				},
+				{
+					Probe:       Probe,
+					Message:     `job "build" runs on a self-hosted runner`,
+					Outcome:     finding.OutcomeTrue,
+					Location:    &finding.Location{Path: ".github/workflows/group.yml", LineStart: toUint(6)},
+					Remediation: remediation,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ctrl := gomock.NewController(t)
+			raw := &checker.CheckRequest{}
+			mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+			mockRepoClient.EXPECT().ListFiles(gomock.Any()).DoAndReturn(
+				func(predicate func(string) (bool, error)) ([]string, error) {
+					var matches []string
+					for _, f := range tt.filenames {
+						match, err := predicate(f)
+						if err != nil {
+							t.Fatalf("unexpected err: %v", err)
+						}
+						if match {
+							matches = append(matches, f)
+						}
+					}
+					return matches, nil
+				}).AnyTimes()
+			mockRepoClient.EXPECT().GetFileReader(gomock.Any()).DoAndReturn(
+				func(file string) (io.ReadCloser, error) {
+					return os.Open(filepath.Join("testdata", filepath.Base(file)))
+				}).AnyTimes()
+			raw.RepoClient = mockRepoClient
+
+			findings, _, err := Run(raw)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if diff := cmp.Diff(tt.expected, findings, cmpopts.IgnoreUnexported(finding.Finding{})); diff != "" {
+				t.Error(diff)
+			}
+		})
+	}
+}
+
+func Test_Run_NilRaw(t *testing.T) {
+	t.Parallel()
+	if _, _, err := Run(nil); err == nil {
+		t.Fatal("expected error for nil raw request")
+	}
+}
+
+func Test_Run_ListFilesError(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+	mockRepoClient.EXPECT().ListFiles(gomock.Any()).Return(nil, fmt.Errorf("listing error")).AnyTimes()
+	raw := &checker.CheckRequest{RepoClient: mockRepoClient}
+	if _, _, err := Run(raw); err == nil {
+		t.Fatal("expected error when ListFiles fails")
+	}
+}

--- a/probes/hasSelfHostedRunners/testdata/expression.yml
+++ b/probes/hasSelfHostedRunners/testdata/expression.yml
@@ -1,0 +1,10 @@
+name: expression
+on: push
+jobs:
+  build:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - run: echo hello

--- a/probes/hasSelfHostedRunners/testdata/group.yml
+++ b/probes/hasSelfHostedRunners/testdata/group.yml
@@ -1,0 +1,8 @@
+name: group
+on: push
+jobs:
+  build:
+    runs-on:
+      group: my-runner-group
+    steps:
+      - run: echo hello

--- a/probes/hasSelfHostedRunners/testdata/malformed.yml
+++ b/probes/hasSelfHostedRunners/testdata/malformed.yml
@@ -1,0 +1,7 @@
+name: malformed
+on: push
+jobs:
+  build:
+    runs-on: [self-hosted
+    steps:
+      - run: echo hello

--- a/probes/hasSelfHostedRunners/testdata/mixed.yml
+++ b/probes/hasSelfHostedRunners/testdata/mixed.yml
@@ -1,0 +1,11 @@
+name: mixed
+on: push
+jobs:
+  hosted:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello
+  selfhosted:
+    runs-on: [self-hosted, linux, x64]
+    steps:
+      - run: echo hello

--- a/probes/hasSelfHostedRunners/testdata/secure.yml
+++ b/probes/hasSelfHostedRunners/testdata/secure.yml
@@ -1,0 +1,7 @@
+name: secure
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo hello

--- a/probes/hasSelfHostedRunners/testdata/self-hosted.yml
+++ b/probes/hasSelfHostedRunners/testdata/self-hosted.yml
@@ -1,0 +1,7 @@
+name: self-hosted
+on: push
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - run: echo hello


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Feature. Adds a new probe, `hasSelfHostedRunners`.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Nothing surfaces whether a project runs CI on self-hosted runners. GitHub-hosted runners are ephemeral, self-hosted ones usually aren't, so a poisoned self-hosted runner can leak secrets, tamper with release artifacts, or fake test results (background in #3801).

#### What is the new behavior (if this is a feature change)?

An independent probe (no check wired up yet) that walks `.github/workflows`, parses each file with actionlint, and looks at every job's `runs-on`. It returns `OutcomeTrue` per job that targets a self-hosted runner, and a single `OutcomeFalse` when none do. Detection keys off two things that only exist for self-hosted runners: the `self-hosted` label GitHub auto-applies to every self-hosted runner, and runner groups. A `runs-on` that's entirely a `${{ }}` expression can't be resolved statically, so those jobs are left alone.

I went with the independent-probe route @spencerschrock suggested on the issue instead of a scored check, since the scoring side (how to weigh PR-exposed vs. privileged-workflow runners) still needs discussion. This is the data-collection piece to build that on.

One known gap, also noted in the def.yml: a job that reaches a self-hosted runner purely through a custom label (with no `self-hosted` in the workflow) won't be flagged, because that label is indistinguishable from a custom GitHub-hosted larger-runner label without querying the runner config. Happy to widen the heuristic if you'd rather trade those false negatives for some false positives.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Related to #3801 (first step, doesn't fully close it).

#### Special notes for your reviewer

Table-driven tests in `impl_test.go` cover a github-hosted-only workflow, the `self-hosted` label, a runner group, a mixed file, the expression case, a malformed file, and multiple workflows in one run. `docs/probes.md` is regenerated from the def.yml.

Ran locally: `go build ./...`, `go test ./probes/hasSelfHostedRunners/...`, and `go test ./probes/... ./internal/probes/...`, all green.

#### Does this PR introduce a user-facing change?

```release-note
Added the `hasSelfHostedRunners` probe, which flags GitHub Actions jobs that run on self-hosted runners.
```
