### PR TITLE
:bug: don't forward gitlab PRIVATE-TOKEN across cross-host redirects

### DIFF
--- a/clients/gitlabrepo/tarball.go
+++ b/clients/gitlabrepo/tarball.go
@@ -43,6 +43,7 @@ var (
 	errTarballNotFound  = errors.New("tarball not found")
 	errTarballCorrupted = errors.New("corrupted tarball")
 	errZipSlip          = errors.New("ZipSlip path detected")
+	errTooManyRedirects = errors.New("stopped after 10 redirects")
 )
 
 func extractAndValidateArchivePath(path, dest string) (string, error) {
@@ -186,7 +187,23 @@ func (handler *tarballHandler) apiFunction(url, tempDir string, repoFile *os.Fil
 		return fmt.Errorf("http.NewRequestWithContext: %w", err)
 	}
 	req.Header.Set("PRIVATE-TOKEN", os.Getenv("GITLAB_AUTH_TOKEN"))
-	resp, err := http.DefaultClient.Do(req)
+	// The archive endpoint commonly 302s to object storage or a CDN. Go only
+	// strips a fixed set of well-known auth headers across a redirect, so the
+	// PRIVATE-TOKEN would otherwise be replayed to whatever host we land on.
+	// Drop it once the redirect leaves the original host so the credential is
+	// never handed to a third party.
+	client := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 10 {
+				return errTooManyRedirects
+			}
+			if req.URL.Host != via[0].URL.Host {
+				req.Header.Del("PRIVATE-TOKEN")
+			}
+			return nil
+		},
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("%w io.Copy: %w", errTarballNotFound, err)
 	}

--- a/clients/gitlabrepo/tarball_redirect_test.go
+++ b/clients/gitlabrepo/tarball_redirect_test.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Security Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package gitlabrepo
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"sync"
+	"testing"
+)
+
+func TestApiFunctionTokenNotForwardedOnRedirect(t *testing.T) {
+	const token = "super-secret-pat"
+	t.Setenv("GITLAB_AUTH_TOKEN", token)
+
+	var forwarded string
+	// Stands in for the redirect target (object storage / CDN / attacker host).
+	other := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		forwarded = r.Header.Get("PRIVATE-TOKEN")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer other.Close()
+
+	// Stands in for the GitLab instance; redirects the archive request elsewhere.
+	instance := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Redirect(w, r, other.URL, http.StatusFound)
+	}))
+	defer instance.Close()
+
+	tempDir := t.TempDir()
+	repoFile, err := os.CreateTemp(tempDir, repoFilename)
+	if err != nil {
+		t.Fatalf("os.CreateTemp: %v", err)
+	}
+	defer repoFile.Close()
+
+	handler := tarballHandler{ctx: context.Background(), once: new(sync.Once)}
+	if err := handler.apiFunction(instance.URL, tempDir, repoFile); err != nil {
+		t.Fatalf("apiFunction: %v", err)
+	}
+
+	if forwarded != "" {
+		t.Fatalf("PRIVATE-TOKEN forwarded to redirect host: got %q, want it dropped", forwarded)
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`apiFunction` in `clients/gitlabrepo/tarball.go` sets the `PRIVATE-TOKEN` header to `GITLAB_AUTH_TOKEN` and sends the request with `http.DefaultClient`, which follows redirects. Go's `net/http` only strips its built-in auth headers (`Authorization`, `Cookie`, and friends) when a redirect crosses to a different host; a custom header like `PRIVATE-TOKEN` is copied to every hop. So when the `archive.tar.gz` or `ci/lint` endpoint responds with a 302, the operator's GitLab token rides along to whatever host the redirect points at. That target can be object storage or a CDN for a legitimate instance, or an arbitrary host for a self-managed URL, and the same request path is reachable from the `?repo=` input and the cron project list.

#### What is the new behavior (if this is a feature change)?

The request now goes through a client whose `CheckRedirect` removes `PRIVATE-TOKEN` once a redirect leaves the original host, while keeping the standard 10-redirect limit. Same-host redirects are unaffected, so normal downloads keep working.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

The relevant stdlib logic is `net/http/client.go` (the sensitive-header list is fixed and does not include custom headers). I compared on `req.URL.Host` rather than hostname alone so a change in host or port drops the credential; that is the conservative choice, and GitLab's archive redirects go to a pre-signed URL that does not need the token anyway. The added test drives `apiFunction` through a redirect to a second server and asserts the header is not forwarded; it fails on the current code and passes with the fix.

#### Does this PR introduce a user-facing change?

```release-note
Avoid forwarding the GitLab `PRIVATE-TOKEN` to redirect targets when downloading a project archive.
```
