### PR TITLE
🐛 Recognize GitHub self-repository action references

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -768,10 +768,7 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 		}
 
 		if job.WorkflowCall != nil && job.WorkflowCall.Uses != nil {
-			//nolint:lll
-			// Check whether this is an action defined in the same repo,
-			// https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#referencing-an-action-in-the-same-repository-where-a-workflow-file-uses-the-action.
-			if !strings.HasPrefix(job.WorkflowCall.Uses.Value, "./") {
+			if !isSameRepositoryReference(job.WorkflowCall.Uses.Value) {
 				dep := newGHActionDependency(job.WorkflowCall.Uses.Value, pathfn, job.WorkflowCall.Uses.Pos.Line)
 				pdata.Dependencies = append(pdata.Dependencies, dep)
 			}
@@ -794,10 +791,7 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 				continue
 			}
 
-			//nolint:lll
-			// Check whether this is an action defined in the same repo,
-			// https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#referencing-an-action-in-the-same-repository-where-a-workflow-file-uses-the-action.
-			if strings.HasPrefix(execAction.Uses.Value, "./") {
+			if isSameRepositoryReference(execAction.Uses.Value) {
 				continue
 			}
 			dep := newGHActionDependency(execAction.Uses.Value, pathfn, execAction.Uses.Pos.Line)
@@ -806,6 +800,10 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 	}
 
 	return true, nil
+}
+
+func isSameRepositoryReference(uses string) bool {
+	return strings.HasPrefix(uses, "./") || strings.HasPrefix(uses, "$/")
 }
 
 func newGHActionDependency(uses, pathfn string, line int) checker.Dependency {
@@ -831,6 +829,10 @@ func newGHActionDependency(uses, pathfn string, line int) checker.Dependency {
 }
 
 func isActionDependencyPinned(actionUses string) bool {
+	if isSameRepositoryReference(actionUses) {
+		return true
+	}
+
 	localActionRegex := regexp.MustCompile(`^\..+[^/]`)
 	if localActionRegex.MatchString(actionUses) {
 		return true

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -165,6 +165,11 @@ func TestGithubWorkflowPinningPattern(t *testing.T) {
 			ispinned: true,
 		},
 		{
+			desc:     "self repository action",
+			uses:     "$/.github/actions/example",
+			ispinned: true,
+		},
+		{
 			desc:     "non-github docker image pinned by digest",
 			uses:     "docker://gcr.io/distroless/static-debian11@sha256:9e6f8952f12974d088f648ed6252ea1887cdd8641719c8acd36bf6d2537e71c0",
 			ispinned: true,
@@ -193,6 +198,64 @@ func TestGithubWorkflowPinningPattern(t *testing.T) {
 				t.Fatalf("dependency %s ispinned?: %v expected?: %v", tt.uses, p, tt.ispinned)
 			}
 		})
+	}
+}
+
+func TestIsSameRepositoryReference(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		uses string
+		want bool
+	}{
+		{
+			name: "workspace-relative action",
+			uses: "./.github/actions/example",
+			want: true,
+		},
+		{
+			name: "self repository action",
+			uses: "$/.github/actions/example",
+			want: true,
+		},
+		{
+			name: "external action",
+			uses: "example/action@main",
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isSameRepositoryReference(tt.uses); got != tt.want {
+				t.Errorf("isSameRepositoryReference(%q) = %v, want %v", tt.uses, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGithubWorkflowSelfRepositoryReferences(t *testing.T) {
+	t.Parallel()
+
+	content := []byte(`
+on: push
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: $/.github/actions/example
+  workflow:
+    uses: $/.github/workflows/example.yml
+`)
+	var result checker.PinningDependenciesData
+
+	_, err := validateGitHubActionWorkflow(".github/workflows/example.yml", content, &result)
+	if err != nil {
+		t.Fatalf("validateGitHubActionWorkflow: %v", err)
+	}
+	if len(result.Dependencies) != 0 {
+		t.Errorf("expected no dependencies, got %v", result.Dependencies)
 	}
 }
 


### PR DESCRIPTION
Treat GitHub's `$/` syntax as a same-repository reference in the Pinned-Dependencies check, matching the existing handling for `./` references.

```yaml
uses: $/.github/actions/example
```

See [the shared-workflows usage that exposed this false positive](https://github.com/open-telemetry/shared-workflows/blob/52987636e38f35a2bdb712f5a2b5989f6a5f6f8a/.github/workflows/pull-request-dashboard-repo.yml#L48-L50).

[GitHub documents](https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/find-and-customize-actions#adding-an-action-from-the-same-repository) that this syntax resolves from the workflow repository at the running commit, so Scorecard no longer reports these actions or reusable workflows as unpinned third-party dependencies.

Note: the CI failure appears to be unrelated to this PR: [golangci-lint / check-linter (pull_request)](https://github.com/ossf/scorecard/actions/runs/32495932588/job/96814189007?pr=5191)