### PR TITLE
:bug: Fall back to REST when GraphQL checkSuites is truncated

### DIFF
--- a/clients/githubrepo/checkruns.go
+++ b/clients/githubrepo/checkruns.go
@@ -49,6 +49,9 @@ type checkRunsGraphqlData struct {
 													Conclusion githubv4.CheckConclusionState
 													Status     githubv4.CheckStatusState
 												}
+												PageInfo struct {
+													HasNextPage bool
+												}
 											} `graphql:"checkSuites(first: $checksToAnalyze)"`
 										}
 									}
@@ -148,7 +151,16 @@ func parseCheckRuns(data *checkRunsGraphqlData) checkRunsByRef {
 	for _, commit := range data.Repository.Object.Commit.History.Nodes {
 		for _, pr := range commit.AssociatedPullRequests.Nodes {
 			var crs []clients.CheckRun
+			truncated := false
 			for _, c := range pr.Commits.Nodes {
+				// checkSuites(first: $checksToAnalyze) is not paginated. Empty
+				// suites from installed apps sort first, so a successful
+				// github-actions suite can sit past this page. Caching the
+				// partial list would hide it from the REST fallback. (#5149)
+				if c.Commit.CheckSuites.PageInfo.HasNextPage {
+					truncated = true
+					break
+				}
 				for _, checkRun := range c.Commit.CheckSuites.Nodes {
 					crs = append(crs, clients.CheckRun{
 						// the REST API returns lowercase. the graphQL API returns upper
@@ -159,6 +171,9 @@ func parseCheckRuns(data *checkRunsGraphqlData) checkRunsByRef {
 						},
 					})
 				}
+			}
+			if truncated {
+				continue
 			}
 			headRef := string(pr.HeadRefOid)
 			checkCache[headRef] = crs

--- a/clients/githubrepo/checkruns_test.go
+++ b/clients/githubrepo/checkruns_test.go
@@ -15,6 +15,7 @@
 package githubrepo
 
 import (
+	"encoding/json"
 	"testing"
 
 	sce "github.com/ossf/scorecard/v5/errors"
@@ -27,4 +28,87 @@ func Test_init_clearsErr(t *testing.T) {
 	if handler.errSetup != nil {
 		t.Errorf("expected nil error, got %v", handler.errSetup)
 	}
+}
+
+func Test_parseCheckRuns_skipsTruncatedCheckSuites(t *testing.T) {
+	t.Parallel()
+	const headSHA = "98deba2249aaf487cd8b609939f75b91a54b5bd7"
+	data := checkRunsGraphqlFixture(t, headSHA, true)
+	got := parseCheckRuns(data)
+	if _, cached := got[headSHA]; cached {
+		t.Fatalf("truncated checkSuites page was cached for %s", headSHA)
+	}
+}
+
+func Test_parseCheckRuns_cachesCompleteCheckSuites(t *testing.T) {
+	t.Parallel()
+	const headSHA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	data := checkRunsGraphqlFixture(t, headSHA, false)
+	got := parseCheckRuns(data)
+	crs, cached := got[headSHA]
+	if !cached {
+		t.Fatalf("complete checkSuites page was not cached for %s", headSHA)
+	}
+	if len(crs) != 1 {
+		t.Fatalf("got %d check runs, want 1", len(crs))
+	}
+	if crs[0].App.Slug != "github-actions" {
+		t.Fatalf("got app slug %q, want github-actions", crs[0].App.Slug)
+	}
+	if crs[0].Status != "completed" || crs[0].Conclusion != "success" {
+		t.Fatalf("got status=%q conclusion=%q", crs[0].Status, crs[0].Conclusion)
+	}
+}
+
+func checkRunsGraphqlFixture(t *testing.T, headSHA string, hasNextPage bool) *checkRunsGraphqlData {
+	t.Helper()
+	raw, err := json.Marshal(map[string]any{
+		"Repository": map[string]any{
+			"Object": map[string]any{
+				"Commit": map[string]any{
+					"History": map[string]any{
+						"Nodes": []any{
+							map[string]any{
+								"AssociatedPullRequests": map[string]any{
+									"Nodes": []any{
+										map[string]any{
+											"HeadRefOid": headSHA,
+											"Commits": map[string]any{
+												"Nodes": []any{
+													map[string]any{
+														"Commit": map[string]any{
+															"CheckSuites": map[string]any{
+																"Nodes": []any{
+																	map[string]any{
+																		"App":        map[string]any{"Slug": "github-actions"},
+																		"Conclusion": "SUCCESS",
+																		"Status":     "COMPLETED",
+																	},
+																},
+																"PageInfo": map[string]any{
+																	"HasNextPage": hasNextPage,
+																},
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("marshal fixture: %v", err)
+	}
+	var data checkRunsGraphqlData
+	if err := json.Unmarshal(raw, &data); err != nil {
+		t.Fatalf("unmarshal fixture: %v", err)
+	}
+	return &data
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

`checkSuites(first: $checksToAnalyze)` is not paginated. `parseCheckRuns` still caches that page as the complete set of check runs for the PR head SHA, so `listCheckRunsForRef` never falls back to REST.

On a commit with more than 30 check suites, a successful `github-actions` suite can sit past that page. CI-Tests then scores the PR as untested.

I reproduced the cache-key part of this on current `main` (`d1fab88`). The issue's public fixture (`oaslananka/easyeda-mcp-pro#466`) has the first successful `github-actions` suite at index 34.

#### What is the new behavior (if this is a feature change)?

If GraphQL reports `pageInfo.hasNextPage` on `checkSuites`, that SHA is left out of the cache. `listCheckRunsForRef` then uses the existing REST check-runs API.

REST lists check *runs*, not empty integration suites, so the `github-actions` runs in the issue reproduction are visible to `testsRunInCI`.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #5149

#### Special notes for your reviewer

I did not paginate the nested GraphQL connection. Nested cursors per PR would be more code and more query cost. The REST fallback already exists; this only stops a truncated GraphQL page from hiding it.

This does not paginate REST `ListCheckRunsForRef`. That path was already a single page.

#### Does this PR introduce a user-facing change?

```release-note
CI-Tests and SAST now fall back to the REST check-runs API when GitHub returns more check suites than the GraphQL page. Repositories whose successful GitHub Actions suites sorted after empty integration suites were previously scored as untested.
```