### PR TITLE
:bug: Split ko matcher so either setup-ko spelling is detected

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -573,10 +573,20 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 		},
 		{
 			// Ko container action. https://github.com/google/ko
+			// The action was renamed from imjasonh/setup-ko to ko-build/setup-ko,
+			// so both spellings need their own single-step matcher: JobMatcher
+			// requires every listed step to match, and a workflow uses only one
+			// of them. See https://github.com/ossf/scorecard/issues/5133.
 			Steps: []*JobMatcherStep{
 				{
 					Uses: "imjasonh/setup-ko",
 				},
+			},
+			LogText: "candidate container publishing workflow using ko",
+		},
+		{
+			// Ko container action. https://github.com/google/ko
+			Steps: []*JobMatcherStep{
 				{
 					Uses: "ko-build/setup-ko",
 				},

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -985,6 +985,16 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "ko publish (renamed action)",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-ko-renamed-action.yaml",
+			expected: true,
+		},
+		{
+			name:     "ko publish (legacy action)",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-ko-legacy-action.yaml",
+			expected: true,
+		},
+		{
 			name:     "cargo publish",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-cargo.yaml",
 			expected: true,

--- a/checks/testdata/.github/workflows/github-workflow-packaging-ko-legacy-action.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-ko-legacy-action.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ko publish (legacy action)
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: imjasonh/setup-ko@v0.6
+      - run: ko build ./

--- a/checks/testdata/.github/workflows/github-workflow-packaging-ko-renamed-action.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-ko-renamed-action.yaml
@@ -1,0 +1,27 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: ko publish
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ko-build/setup-ko@v0.6
+      - run: ko build ./


### PR DESCRIPTION
## Description

Fixes #5133.

The ko entry in `IsPackagingWorkflow` (`checks/fileparser/github_workflow.go`) listed `imjasonh/setup-ko` and `ko-build/setup-ko` as two steps of a **single** `JobMatcher`. `JobMatcher.matches()` requires *every* listed step to match (AND semantics), but a real workflow uses only one of the two spellings — they are the pre-/post-rename names of the same action — so the ko matcher could never fire and ko container publishing was never detected by the Packaging check.

This change splits the entry into two single-step matchers, which is the shape every other ecosystem entry uses, and adds test fixtures for both spellings.

Additive only: no existing workflow's detection result can change; ko workflows simply move from "packaging workflow not detected" to detected.

## Verification

Reproduced failing-then-passing with the new fixtures:

1. With only the new fixtures/tests added and the **old** matcher code restored:
   `go test ./checks/fileparser -run 'TestIsPackagingWorkflow/ko' -count=1` →
   `FAIL: TestIsPackagingWorkflow/ko_publish_(renamed_action)` and `FAIL: .../ko_publish_(legacy_action)` (`isPackagingWorkflow() = false, expected true`)
2. With this fix applied:
   - `go test ./checks/fileparser -run 'TestIsPackagingWorkflow' -count=1` → all 20 subtests PASS (including the 2 new ones)
   - `go test ./checks/fileparser -count=1` → full package suite PASS
   - `gofmt -l checks/fileparser/` → clean
   - `go vet ./checks/fileparser` → clean
   - `git diff --check` → clean

Signed-off per [CONTRIBUTING.md](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md) (DCO).