### PR TITLE
🐛 fix: match selected security policies by exact path

### DIFF
--- a/checks/fileparser/listing.go
+++ b/checks/fileparser/listing.go
@@ -41,8 +41,9 @@ func isMatchingPath(fullpath string, matchPathTo PathMatcher) (bool, error) {
 		return false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("%v: %v", errInternalFilenameMatch, err))
 	}
 
-	// No match on the fullpath, let's try on the filename only.
-	if !match {
+	// No match on the fullpath, optionally try on the filename only.
+	// ExactPath callers have already selected a specific repository path.
+	if !match && !matchPathTo.ExactPath {
 		if match, err = path.Match(pattern, filename); err != nil {
 			return false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("%v: %v", errInternalFilenameMatch, err))
 		}
@@ -63,6 +64,9 @@ func isTestdataFile(fullpath string) bool {
 type PathMatcher struct {
 	Pattern       string
 	CaseSensitive bool
+	// ExactPath disables the filename fallback and matches Pattern only against
+	// the complete repository path.
+	ExactPath bool
 }
 
 // DoWhileTrueOnFileReader takes a filepath, its reader and

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -185,6 +185,7 @@ func Test_isMatchingPath(t *testing.T) {
 		pattern       string
 		fullpath      string
 		caseSensitive bool
+		exactPath     bool
 	}
 	tests := []struct {
 		name    string
@@ -192,6 +193,26 @@ func Test_isMatchingPath(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
+		{
+			name: "exact path does not fall back to matching a filename",
+			args: args{
+				pattern:       "SECURITY.md",
+				fullpath:      ".review-pro/node/security.md",
+				caseSensitive: false,
+				exactPath:     true,
+			},
+			want: false,
+		},
+		{
+			name: "exact path still matches the selected file",
+			args: args{
+				pattern:       "SECURITY.md",
+				fullpath:      "SECURITY.md",
+				caseSensitive: false,
+				exactPath:     true,
+			},
+			want: true,
+		},
 		{
 			name: "matching path",
 			args: args{
@@ -317,6 +338,7 @@ func Test_isMatchingPath(t *testing.T) {
 			got, err := isMatchingPath(tt.args.fullpath, PathMatcher{
 				Pattern:       tt.args.pattern,
 				CaseSensitive: tt.args.caseSensitive,
+				ExactPath:     tt.args.exactPath,
 			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("isMatchingPath() error = %v, wantErr %v", err, tt.wantErr)

--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -50,6 +50,7 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 			err := fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
 				Pattern:       data.files[idx].File.Path,
 				CaseSensitive: false,
+				ExactPath:     true,
 			}, checkSecurityPolicyFileContent, &data.files[idx].File, &data.files[idx].Information)
 			if err != nil {
 				return checker.SecurityPolicyData{}, err
@@ -89,6 +90,7 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 			err := fileparser.OnMatchingFileContentDo(client, fileparser.PathMatcher{
 				Pattern:       filePattern,
 				CaseSensitive: false,
+				ExactPath:     true,
 			}, checkSecurityPolicyFileContent, &data.files[idx].File, &data.files[idx].Information)
 			if err != nil {
 				return checker.SecurityPolicyData{}, err

--- a/checks/raw/security_policy_test.go
+++ b/checks/raw/security_policy_test.go
@@ -174,6 +174,54 @@ func TestSecurityPolicy(t *testing.T) {
 	}
 }
 
+func TestSecurityPolicyReadsOnlySelectedPolicyPath(t *testing.T) {
+	t.Parallel()
+	ctrl := gomock.NewController(t)
+	mockRepoClient := mockrepo.NewMockRepoClient(ctrl)
+	mockRepo := mockrepo.NewMockRepo(ctrl)
+	files := []string{
+		"SECURITY.md",
+		".review-pro/node/security.md",
+	}
+
+	mockRepoClient.EXPECT().ListFiles(gomock.Any()).DoAndReturn(
+		func(predicate func(string) (bool, error)) ([]string, error) {
+			matched := make([]string, 0, len(files))
+			for _, file := range files {
+				matches, err := predicate(file)
+				if err != nil {
+					return nil, err
+				}
+				if matches {
+					matched = append(matched, file)
+				}
+			}
+			return matched, nil
+		},
+	).Times(2)
+	// The root policy is selected first but intentionally has no content. A
+	// basename fallback would then incorrectly read the nested file instead.
+	mockRepoClient.EXPECT().GetFileReader("SECURITY.md").Return(
+		io.NopCloser(strings.NewReader("")), nil,
+	)
+
+	dl := scut.TestDetailLogger{}
+	result, err := SecurityPolicy(&checker.CheckRequest{
+		RepoClient: mockRepoClient,
+		Repo:       mockRepo,
+		Dlogger:    &dl,
+	})
+	if err != nil {
+		t.Fatalf("SecurityPolicy() error = %v", err)
+	}
+	if len(result.PolicyFiles) != 1 || result.PolicyFiles[0].File.Path != "SECURITY.md" {
+		t.Fatalf("SecurityPolicy() PolicyFiles = %+v, want only SECURITY.md", result.PolicyFiles)
+	}
+	if len(result.PolicyFiles[0].Information) != 0 {
+		t.Errorf("SecurityPolicy() unexpectedly read information from another file: %+v", result.PolicyFiles[0].Information)
+	}
+}
+
 // Test_collectPolicyHits tests the regexes in collectPolicyHits for positive and negative cases.
 func Test_collectPolicyHits(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
Fixes #5198\n\nSecurity-Policy first discovers an approved policy path, but its content pass previously allowed a basename fallback. An unrelated nested security.md could therefore be read instead of the selected policy.\n\nThis adds an ExactPath option to the shared matcher and uses it only for Security-Policy content reads, preserving existing basename fallback behavior for other callers.\n\nValidation:\n- go test ./checks/fileparser ./checks/raw (Go 1.26.1, GitHub Codespaces)