### PR TITLE
:book: docs: Code-Review scoring is proportional, not leveled; list Phabricator/Piper

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -204,19 +204,21 @@ malicious code (either as a malicious contributor or as an attacker who has
 subverted a contributor's account), because a reviewer might detect the
 subversion.
 
-The check determines whether the most recent changes (over the last ~30 commits) have 
+The check determines whether the most recent changes (over the last ~30 commits) have
 an approval on GitHub/GitLab
-or if the merger is different from the committer (implicit review). It also
+or if the merger is different from the pull request author (implicit review). It also
 performs a similar check for reviews using
 [Prow](https://github.com/kubernetes/test-infra/tree/master/prow#readme) (labels
-"lgtm" or "approved") and [Gerrit](https://www.gerritcodereview.com/) ("Reviewed-on" and "Reviewed-by").
+"lgtm" or "approved"), [Gerrit](https://www.gerritcodereview.com/) ("Reviewed-on:"
+and "Reviewed-by:" in the commit message), Phabricator ("Differential Revision:"
+in the commit message) and Piper ("PiperOrigin-RevId:" in the commit message).
 If recent changes are solely bot activity (e.g. Dependabot, Renovate bot, or custom bots),
 the check returns inconclusively.
 
-Scoring is leveled instead of proportional to make the check more predictable.
-If any bot-originated changes are unreviewed, 3 points are deducted. If any human
-changes are unreviewed, 7 points are deducted if a single change is unreviewed, and
-another 3 are deducted if multiple changes are unreviewed.
+The score is proportional: `10 × (approved changesets ÷ total changesets)`, using
+integer arithmetic (rounded down), over the changesets examined. Bot-authored
+changesets that were approved are excluded from both counts. Unreviewed
+bot-authored changesets are included and lower the score.
 
 Review by bots, including bots powered by
 artificial intelligence / machine learning (AI/ML),

--- a/docs/checks/internal/checks.yaml
+++ b/docs/checks/internal/checks.yaml
@@ -302,19 +302,21 @@ checks:
       subverted a contributor's account), because a reviewer might detect the
       subversion.
 
-      The check determines whether the most recent changes (over the last ~30 commits) have 
+      The check determines whether the most recent changes (over the last ~30 commits) have
       an approval on GitHub/GitLab
-      or if the merger is different from the committer (implicit review). It also
+      or if the merger is different from the pull request author (implicit review). It also
       performs a similar check for reviews using
       [Prow](https://github.com/kubernetes/test-infra/tree/master/prow#readme) (labels
-      "lgtm" or "approved") and [Gerrit](https://www.gerritcodereview.com/) ("Reviewed-on" and "Reviewed-by").
+      "lgtm" or "approved"), [Gerrit](https://www.gerritcodereview.com/) ("Reviewed-on:"
+      and "Reviewed-by:" in the commit message), Phabricator ("Differential Revision:"
+      in the commit message) and Piper ("PiperOrigin-RevId:" in the commit message).
       If recent changes are solely bot activity (e.g. Dependabot, Renovate bot, or custom bots),
       the check returns inconclusively.
 
-      Scoring is leveled instead of proportional to make the check more predictable.
-      If any bot-originated changes are unreviewed, 3 points are deducted. If any human
-      changes are unreviewed, 7 points are deducted if a single change is unreviewed, and
-      another 3 are deducted if multiple changes are unreviewed.
+      The score is proportional: `10 × (approved changesets ÷ total changesets)`, using
+      integer arithmetic (rounded down), over the changesets examined. Bot-authored
+      changesets that were approved are excluded from both counts. Unreviewed
+      bot-authored changesets are included and lower the score.
 
       Review by bots, including bots powered by
       artificial intelligence / machine learning (AI/ML),


### PR DESCRIPTION
#### What kind of change does this PR introduce?

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

Documentation fix. Source is `docs/checks/internal/checks.yaml`; `docs/checks.md` regenerated with `make generate-docs`.

#### What is the current behavior?

`docs/checks.md` (and `docs/checks/internal/checks.yaml`) describe Code-Review scoring as "leveled instead of proportional" with 3/7/3 point deductions. That text was added in #2542 (2023-01). The leveled implementation was reverted to proportional in #2882 (2023-06); the diff touched `checks/evaluation/code_review.go` only, and the docs were not updated. #3979 (2024-04, probe migration) kept `CreateProportionalScoreResult`.

Current behaviour is `min(10 * approved / total, 10)` using integer arithmetic. Live example: https://github.com/mapyr/rbn-d-selfmerge — 1 of 2 changesets approved scores 5 (`Found 1/2 approved changesets -- score normalized to 5`); the docs say 3.

The same section lists GitHub/GitLab, Prow and Gerrit as detected review systems. `checks/raw/code_review.go` also detects Phabricator (`Differential Revision:`, #1884) and Piper (`PiperOrigin-RevId:`, #1889); neither is mentioned.

It also says the implicit-review rule fires when the merger differs from the *committer*; `probes/codeApproved` compares the merger to the pull request *author*.

Bot handling in the docs implied a single "bot changes deduct 3" rule. The probe excludes only *approved* bot-authored changesets from both counts (`probes/codeApproved/impl.go`, #2450); unreviewed bot-authored changesets still count against the score.

#### What is the new behavior (if this is a feature change)?

- [ ] Tests for the changes have been added (for bug fixes/features)

Docs describe what the code does:

- scoring paragraph replaced with the proportional formula, including the approved-bot exclusion and that unreviewed bot changesets still count;
- Phabricator and Piper added to the list of detected systems, with the markers used;
- "committer" → "pull request author" for implicit review.

No code changes.

#### Which issue(s) this PR fixes

NONE — documentation drift; happy to open an issue first if preferred.

#### Special notes for your reviewer

Verified against `d1fab88f54636ff366076edfc5c239f97b3c8e66` (still `origin/main` at time of writing). The live 1/2 → 5 result is on https://github.com/mapyr/rbn-d-selfmerge.

#### Does this PR introduce a user-facing change?

```release-note
NONE
```

Made with [Cursor](https://cursor.com)