### PR TITLE
:bug: Fix GitHub workflow run line offsets

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -606,6 +606,55 @@ var validateDockerfilesPinning fileparser.DoWhileTrueOnFileContent = func(
 	return true, nil
 }
 
+// getGitHubWorkflowRunScriptOffset returns the base line offset used when
+// mapping parsed shell commands back to the workflow source. Block and folded
+// scalars execute from lines after the run key, while inline scalars execute on
+// the run key's line. The shell parser adds its own 1-based command offset.
+func getGitHubWorkflowRunScriptOffset(content []byte, execRun *actionlint.ExecRun) uint {
+	if execRun == nil || execRun.Run == nil {
+		return checker.OffsetDefault
+	}
+
+	var startLine uint
+	switch {
+	case execRun.RunPos != nil && execRun.RunPos.Line > 0:
+		startLine = uint(execRun.RunPos.Line)
+	case execRun.Run.Pos != nil && execRun.Run.Pos.Line > 0:
+		startLine = uint(execRun.Run.Pos.Line)
+	default:
+		return checker.OffsetDefault
+	}
+
+	if execRun.RunPos == nil || execRun.RunPos.Line < 1 || execRun.RunPos.Col < 1 {
+		return startLine
+	}
+	lines := bytes.Split(content, []byte{'\n'})
+	lineIndex := execRun.RunPos.Line - 1
+	if lineIndex >= len(lines) {
+		return startLine
+	}
+	line := lines[lineIndex]
+	columnIndex := execRun.RunPos.Col - 1
+	if columnIndex >= len(line) {
+		return startLine
+	}
+
+	runSource := string(line[columnIndex:])
+	colon := strings.IndexByte(runSource, ':')
+	if colon < 0 {
+		return startLine
+	}
+	value := strings.TrimSpace(runSource[colon+1:])
+	if value == "" || strings.HasPrefix(value, "|") || strings.HasPrefix(value, ">") || strings.HasPrefix(value, "#") {
+		return startLine
+	}
+
+	if startLine > 0 {
+		return startLine - 1
+	}
+	return startLine
+}
+
 func collectGitHubWorkflowScriptInsecureDownloads(c *checker.CheckRequest, r *checker.PinningDependenciesData) error {
 	return fileparser.OnMatchingFileContentDo(c.RepoClient, fileparser.PathMatcher{
 		Pattern:       ".github/workflows/*",
@@ -696,7 +745,8 @@ var validateGitHubWorkflowIsFreeOfInsecureDownloads fileparser.DoWhileTrueOnFile
 
 			// We replace the `${{ github.variable }}` to avoid shell parsing failures.
 			script := githubVarRegex.ReplaceAll([]byte(run), []byte("GITHUB_REDACTED_VAR"))
-			if err := validateShellFile(pathfn, uint(execRun.Run.Pos.Line), uint(execRun.Run.Pos.Line),
+			startLine := getGitHubWorkflowRunScriptOffset(content, execRun)
+			if err := validateShellFile(pathfn, startLine, startLine,
 				script, taintedFiles, pdata); err != nil {
 				pdata.Dependencies = append(pdata.Dependencies, checker.Dependency{
 					Msg: asPointer(err.Error()),

--- a/checks/raw/pinned_dependencies_workflow_line_test.go
+++ b/checks/raw/pinned_dependencies_workflow_line_test.go
@@ -1,0 +1,55 @@
+// Copyright 2026 OpenSSF Scorecard Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package raw
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ossf/scorecard/v5/checker"
+)
+
+func TestGitHubWorkflowRunLineOffsets(t *testing.T) {
+	t.Parallel()
+	content := []byte(`on: push
+jobs:
+  jobOne:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl https://example.com | bash
+      - run: curl https://example.com | bash
+`)
+
+	var result checker.PinningDependenciesData
+	_, err := validateGitHubWorkflowIsFreeOfInsecureDownloads(
+		".github/workflows/test.yaml", content, &result,
+	)
+	if err != nil {
+		t.Fatalf("validateGitHubWorkflowIsFreeOfInsecureDownloads: %v", err)
+	}
+
+	var got []uint
+	for _, dependency := range result.Dependencies {
+		if dependency.Type != checker.DependencyUseTypeDownloadThenRun {
+			continue
+		}
+		got = append(got, dependency.Location.Offset)
+	}
+	want := []uint{7, 8}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("downloadThenRun offsets = %v, want %v", got, want)
+	}
+}


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix. This corrects source line locations reported for GitHub Actions `run:` steps when the command is written as an inline scalar rather than a block scalar.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

For GitHub Actions workflows, Scorecard currently uses the parsed `run` position as the base line for shell findings.

For a block-style step:

```yaml
      - run: |
          curl https://example.com | bash