### PR TITLE
:seedling: Fix stale version comments on two SHA-pinned actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -79,7 +79,7 @@ jobs:
           GITHUB_AUTH_TOKEN: ${{ secrets.GH_AUTH_TOKEN }}
        run: make e2e-pat
      - name: codecov
-       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # 2.1.0
+       uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # 7.0.0
        if: ${{ github.event_name != 'pull_request' || github.actor != 'dependabot[bot]' }}
        with:
          files: "*e2e-coverage.out"

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -31,7 +31,7 @@ jobs:
       with:
         egress-policy: audit # TODO: change to 'egress-policy: block' after couple of runs
 
-    - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v3.0.18
+    - uses: actions/stale@4391f3da665fdf50b6810c1a66712fb9ba21aa93 # v11.0.0
       with:
         repo-token: ${{ secrets.GITHUB_TOKEN }}
         stale-issue-message: 'This issue has been marked stale because it has been open for 60 days with no activity.'


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix, docs-level: two SHA-pinned actions carry a version comment naming a release the pinned commit does not have. No SHA is changed, so there is no behavioural difference.

#### What is the current behavior?

| File | Action | Pinned SHA | Comment says | Commit actually is |
|---|---|---|---|---|
| `.github/workflows/main.yml:82` | `codecov/codecov-action` | `fb8b3582` | `2.1.0` | **7.0.0** |
| `.github/workflows/stale.yml:34` | `actions/stale` | `4391f3da` | `v3.0.18` | **v11.0.0** |

The codecov one is self-evident from this repo alone: line 71 and line 82 of `main.yml` pin the **same commit** `fb8b3582`, but line 71 labels it `7.0.0` and line 82 labels it `2.1.0`. One of the two has to be wrong, and it is line 82.

For `actions/stale`, the comment is eight majors behind the pinned commit.

#### What is the new behavior (if this is a feature change)?

Comments match the tag each pinned commit carries. Existing per-file style is preserved: `main.yml` writes versions without a `v` prefix, `stale.yml` writes them with one.

Verification, one call each:

```bash
# what tags does the pinned commit carry?
gh api repos/actions/stale/tags --paginate \
  --jq '.[] | select(.commit.sha=="4391f3da665fdf50b6810c1a66712fb9ba21aa93") | .name'
# -> v11.0.0, v11

# where does the claimed tag actually point?
gh api repos/actions/stale/git/ref/tags/v3.0.18 --jq '.object.sha'
# -> 3b3c3f03cd4d8e2b61e179ef744a0d20efbe90b4   (a different commit)
```

For codecov, `2.1.0` does not resolve at all — that tag does not exist in the repository.

Every pinned action in `.github/workflows/` was checked (96 pins); these two were the only mismatches.

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

Both pins are also genuinely old, which is a separate decision from a wrong label, so this PR does not touch versions. `actions/stale` at v11.0.0 is current; `codecov-action` at `fb8b3582` is tagged both `7.0.0` and `6.0.2` upstream, so I used `7.0.0` to match line 71 rather than pick a different line's answer.
