### PR TITLE
🐛 serialize in-toto statements with protojson

### DIFF
--- a/pkg/scorecard/statement.go
+++ b/pkg/scorecard/statement.go
@@ -15,11 +15,14 @@
 package scorecard
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
 
 	intoto "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/types/known/structpb"
 
 	docs "github.com/ossf/scorecard/v5/docs/checks"
 	sce "github.com/ossf/scorecard/v5/errors"
@@ -30,12 +33,7 @@ const (
 	InTotoPredicateType = "https://scorecard.dev/result/v0.1"
 )
 
-type statement struct {
-	Predicate InTotoPredicate `json:"predicate"`
-	intoto.Statement
-}
-
-// Predicate overrides JSONScorecardResultV2 with a nullable Repo field.
+// InTotoPredicate overrides JSONScorecardResultV2 with a nullable Repo field.
 type InTotoPredicate struct {
 	Repo *jsonRepoV2 `json:"repo,omitempty"`
 	JSONScorecardResultV2
@@ -47,17 +45,8 @@ type AsInTotoResultOption struct {
 	AsJSON2ResultOption
 }
 
-// AsStatement converts the results as an in-toto statement.
+// AsInToto writes the results as an in-toto attestation statement.
 func (r *Result) AsInToto(writer io.Writer, checkDocs docs.Doc, opt *AsInTotoResultOption) error {
-	// Build the attestation subject from the result Repo.
-	subject := intoto.ResourceDescriptor{
-		Name: r.Repo.Name,
-		Uri:  fmt.Sprintf("git+https://%s@%s", r.Repo.Name, r.Repo.CommitSHA),
-		Digest: map[string]string{
-			"gitCommit": r.Repo.CommitSHA,
-		},
-	}
-
 	if opt == nil {
 		opt = &AsInTotoResultOption{
 			AsJSON2ResultOption{
@@ -73,24 +62,71 @@ func (r *Result) AsInToto(writer io.Writer, checkDocs docs.Doc, opt *AsInTotoRes
 		return sce.WithMessage(sce.ErrScorecardInternal, err.Error())
 	}
 
-	out := statement{
-		Statement: intoto.Statement{
-			Type: intoto.StatementTypeUri,
-			Subject: []*intoto.ResourceDescriptor{
-				&subject,
-			},
-			PredicateType: InTotoPredicateType,
-		},
-		Predicate: InTotoPredicate{
-			JSONScorecardResultV2: json2,
-			Repo:                  nil,
-		},
+	predicate, err := inTotoPredicateToStruct(&json2)
+	if err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, err.Error())
 	}
 
-	encoder := json.NewEncoder(writer)
-	if err := encoder.Encode(&out); err != nil {
-		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("encoder.Encode: %v", err))
+	stmt := &intoto.Statement{
+		Type: intoto.StatementTypeUri,
+		// Build the attestation subject from the result Repo.
+		Subject: []*intoto.ResourceDescriptor{
+			{
+				Name: r.Repo.Name,
+				Uri:  fmt.Sprintf("git+https://%s@%s", r.Repo.Name, r.Repo.CommitSHA),
+				Digest: map[string]string{
+					"gitCommit": r.Repo.CommitSHA,
+				},
+			},
+		},
+		PredicateType: InTotoPredicateType,
+		Predicate:     predicate,
+	}
+	if err := stmt.Validate(); err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("invalid in-toto statement: %v", err))
+	}
+
+	// The statement types are generated from protobuf definitions, so they must
+	// be serialized with protojson to get the field names defined by the in-toto
+	// spec (_type, predicateType, etc).
+	data, err := protojson.Marshal(stmt)
+	if err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("protojson.Marshal: %v", err))
+	}
+
+	// protojson intentionally randomizes its whitespace, so compact the output to
+	// make it deterministic.
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, data); err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("json.Compact: %v", err))
+	}
+	buf.WriteByte('\n')
+
+	if _, err := writer.Write(buf.Bytes()); err != nil {
+		return sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("writer.Write: %v", err))
 	}
 
 	return nil
+}
+
+// inTotoPredicateToStruct converts the JSON results into a protobuf Struct so
+// they can be embedded as the predicate of an in-toto statement.
+func inTotoPredicateToStruct(json2 *JSONScorecardResultV2) (*structpb.Struct, error) {
+	predicate := InTotoPredicate{
+		JSONScorecardResultV2: *json2,
+		Repo:                  nil,
+	}
+
+	// Round trip through JSON to honor the custom marshaling of the result types.
+	data, err := json.Marshal(&predicate)
+	if err != nil {
+		return nil, fmt.Errorf("marshaling predicate: %w", err)
+	}
+
+	s := &structpb.Struct{}
+	if err := protojson.Unmarshal(data, s); err != nil {
+		return nil, fmt.Errorf("converting predicate to struct: %w", err)
+	}
+
+	return s, nil
 }

--- a/pkg/scorecard/statement_test.go
+++ b/pkg/scorecard/statement_test.go
@@ -21,6 +21,9 @@ import (
 	"testing"
 	"time"
 
+	intoto "github.com/in-toto/attestation/go/v1"
+	"google.golang.org/protobuf/encoding/protojson"
+
 	"github.com/ossf/scorecard/v5/finding"
 )
 
@@ -61,39 +64,78 @@ func TestInToto(t *testing.T) {
 		t.Error("unexpected error: ", err)
 	}
 
-	// Unmarshal the written json to a generic map
-	stmt := statement{}
-	if err := json.Unmarshal(w.Bytes(), &stmt); err != nil {
-		t.Error("error unmarshaling statement", err)
-		return
+	// The output must be stable across runs.
+	var w2 bytes.Buffer
+	if err := result.AsInToto(&w2, jsonMockDocRead(), nil); err != nil {
+		t.Error("unexpected error: ", err)
+	}
+	if !bytes.Equal(w.Bytes(), w2.Bytes()) {
+		t.Error("statement output is not deterministic")
+	}
+
+	// The statement must use the field names defined by the in-toto spec,
+	// not the names encoding/json derives from the generated protobuf types.
+	raw := map[string]json.RawMessage{}
+	if err := json.Unmarshal(w.Bytes(), &raw); err != nil {
+		t.Fatal("error unmarshaling statement to map", err)
+	}
+	for _, key := range []string{"_type", "subject", "predicateType", "predicate"} {
+		if _, ok := raw[key]; !ok {
+			t.Errorf("statement is missing the %q field", key)
+		}
+	}
+	for _, key := range []string{"type", "predicate_type"} {
+		if _, ok := raw[key]; ok {
+			t.Errorf("statement has unexpected field %q", key)
+		}
+	}
+
+	// Unmarshal the written json to an in-toto statement
+	stmt := &intoto.Statement{}
+	if err := protojson.Unmarshal(w.Bytes(), stmt); err != nil {
+		t.Fatal("error unmarshaling statement", err)
+	}
+	if err := stmt.Validate(); err != nil {
+		t.Error("statement failed validation", err)
 	}
 
 	// Check the data
-	if len(stmt.Subject) != 1 {
-		t.Error("unexpected statement subject length")
+	if stmt.GetType() != intoto.StatementTypeUri {
+		t.Error("incorrect statement type", stmt.GetType())
 	}
-	if stmt.Subject[0].GetDigest()["gitCommit"] != result.Repo.CommitSHA {
+	if len(stmt.GetSubject()) != 1 {
+		t.Fatal("unexpected statement subject length")
+	}
+	if stmt.GetSubject()[0].GetDigest()["gitCommit"] != result.Repo.CommitSHA {
 		t.Error("mismatched statement subject digest")
 	}
-	if stmt.Subject[0].GetName() != result.Repo.Name {
+	if stmt.GetSubject()[0].GetName() != result.Repo.Name {
 		t.Error("mismatched statement subject name")
 	}
 
-	if stmt.PredicateType != InTotoPredicateType {
-		t.Error("incorrect predicate type", stmt.PredicateType)
+	if stmt.GetPredicateType() != InTotoPredicateType {
+		t.Error("incorrect predicate type", stmt.GetPredicateType())
 	}
 
 	// Check the predicate
-	if stmt.Predicate.Scorecard.Commit != result.Scorecard.CommitSHA {
+	predicateJSON, err := protojson.Marshal(stmt.GetPredicate())
+	if err != nil {
+		t.Fatal("error marshaling predicate", err)
+	}
+	predicate := InTotoPredicate{}
+	if err := json.Unmarshal(predicateJSON, &predicate); err != nil {
+		t.Fatal("error unmarshaling predicate", err)
+	}
+	if predicate.Scorecard.Commit != result.Scorecard.CommitSHA {
 		t.Error("mismatch in scorecard commit")
 	}
-	if stmt.Predicate.Scorecard.Version != result.Scorecard.Version {
+	if predicate.Scorecard.Version != result.Scorecard.Version {
 		t.Error("mismatch in scorecard version")
 	}
-	if stmt.Predicate.Repo != nil {
+	if predicate.Repo != nil {
 		t.Error("repo should be null")
 	}
-	if !slices.Equal(stmt.Predicate.Metadata, result.Metadata) {
+	if !slices.Equal(predicate.Metadata, result.Metadata) {
 		t.Error("mismatched metadata")
 	}
 }


### PR DESCRIPTION
#### What kind of change does this PR introduce?

bug fix

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

The in-toto statement types are generated from protobuf definitions, so encoding them with encoding/json produced the wrong field names ("type" and "predicate_type" instead of "_type" and "predicateType"), making the output an invalid in-toto statement.

#### What is the new behavior (if this is a feature change)?

This commit modifies how we embed the results and we now convert them to a protobuf Struct and serialize the whole statement with protojson. Before rendering, we compact the output so it is deterministic and validate the statement.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #5224

#### Special notes for your reviewer

Related but not dependen on https://github.com/ossf/scorecard-action/pull/1702

#### Does this PR introduce a user-facing change?

```release-note
The intoto attestation (when `--format=intoto`) is not rendered with protojson to fix a bug where some fields names in the intoto output were rendered wrong
```
