### PR TITLE
✨ Dangerous-Workflow: detect more attacker-controlled event fields

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -51,7 +51,15 @@ func containsUntrustedContextPattern(variable string) bool {
 			`blocked_user\.email|` +
 			`pull_request\.head\.ref|` +
 			`pull_request\.head\.label|` +
-			`pull_request\.head\.repo\.default_branch).*`)
+			`pull_request\.head\.repo\.default_branch|` +
+			`pull_request\.head\.repo\.description|` +
+			`pull_request\.head\.repo\.homepage|` +
+			`fork\.forkee\.name|` +
+			`fork\.forkee\.description|` +
+			`fork\.forkee\.default_branch|` +
+			`fork\.forkee\.homepage|` +
+			`workflow_run\.head_branch|` +
+			`workflow_run\.head_repository\.description).*`)
 
 	if strings.Contains(variable, "github.head_ref") {
 		return true

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -135,6 +135,66 @@ func TestUntrustedContextVariables(t *testing.T) {
 			variable: "toJSON(github.repository)",
 			expected: false,
 		},
+		{
+			name:     "fork forkee name",
+			variable: "github.event.fork.forkee.name",
+			expected: true,
+		},
+		{
+			name:     "fork forkee description",
+			variable: "github.event.fork.forkee.description",
+			expected: true,
+		},
+		{
+			name:     "fork forkee default branch",
+			variable: "github.event.fork.forkee.default_branch",
+			expected: true,
+		},
+		{
+			name:     "fork forkee homepage",
+			variable: "github.event.fork.forkee.homepage",
+			expected: true,
+		},
+		{
+			name:     "trusted fork forkee id",
+			variable: "github.event.fork.forkee.id",
+			expected: false,
+		},
+		{
+			name:     "pull request head repo description",
+			variable: "github.event.pull_request.head.repo.description",
+			expected: true,
+		},
+		{
+			name:     "pull request head repo homepage",
+			variable: "github.event.pull_request.head.repo.homepage",
+			expected: true,
+		},
+		{
+			name:     "trusted pull request head repo id",
+			variable: "github.event.pull_request.head.repo.id",
+			expected: false,
+		},
+		{
+			name:     "workflow run head branch",
+			variable: "github.event.workflow_run.head_branch",
+			expected: true,
+		},
+		{
+			name:     "workflow run head commit message",
+			variable: "github.event.workflow_run.head_commit.message",
+			expected: true,
+		},
+		{
+			name:     "workflow run head repository description",
+			variable: "github.event.workflow_run.head_repository.description",
+			expected: true,
+		},
+		{
+			name:     "trusted workflow run id",
+			variable: "github.event.workflow_run.id",
+			expected: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Fixes #3915

## What

`containsUntrustedContextPattern` in `checks/raw/dangerous_workflow.go` missed
several GitHub event fields that an unprivileged external user controls, so
workflows interpolating them into a `run:` block were not flagged as script
injection risks. This adds eight of them.

| Field | Who controls it |
|---|---|
| `pull_request.head.repo.description` | Anyone opening a PR, on their own fork |
| `pull_request.head.repo.homepage` | Same |
| `fork.forkee.name` | Anyone who can fork the repo |
| `fork.forkee.description` | Same |
| `fork.forkee.default_branch` | Same |
| `fork.forkee.homepage` | Same |
| `workflow_run.head_branch` | Fork branch name reaching `workflow_run` |
| `workflow_run.head_repository.description` | Attacker's fork metadata, same path |

## Scoping: what I deliberately left out

`release.body`, `milestone.title` and `project_card.note` are also undetected,
but all three require write access to set. An attacker who can set them is
already trusted, so I did not treat them as untrusted input. Happy to add them
if you'd rather the pattern be exhaustive rather than threat-model-driven —
this is the main judgment call in the PR and I'd value a second opinion on it.

## Note on the examples in the issue

Two of the three fields named in #3915 are already detected today:
`issue_comment.comment.body` and `commit_comment.comment.body` both match the
existing `comment\.body` alternative. Only `fork.forkee.name` was genuinely
missing. I verified this against the current pattern before making changes.

I also dropped `workflow_run.head_commit.message` from my first draft after
confirming the existing `head_commit\.message` alternative already covers it.
Its test case is retained as a regression guard.

## Score impact

Per the "Changing score results" section of CONTRIBUTING.md: this will lower
Dangerous-Workflow scores for repositories that interpolate these fields into
`run:` blocks. That is the intent — these are real injection vectors and the
check was silently passing them. The change was discussed in #3915 before
implementation, and the issue author reviewed the scoping approach there.

## Testing

- Added 12 cases to `TestUntrustedContextVariables`: one per added field, plus
  negatives for adjacent non-injectable properties (`forkee.id`,
  `head.repo.id`, `workflow_run.id`) to catch the pattern getting too loose.
- `go test ./checks/... ./probes/...` passes (54 packages).
- `gofmt` clean.
