### PR TITLE
:bug: detect untrusted workflow expressions in index and re-cased forms

### DIFF
--- a/checks/raw/dangerous_workflow.go
+++ b/checks/raw/dangerous_workflow.go
@@ -27,7 +27,25 @@ import (
 	"github.com/ossf/scorecard/v5/finding"
 )
 
+// contextIndexPattern matches a quoted index accessor, e.g. ['issue'] or
+// ["title"], so it can be rewritten to the equivalent dotted form.
+var contextIndexPattern = regexp.MustCompile(`\[\s*['"]([^'"]*)['"]\s*\]`)
+
+// normalizeContextExpression rewrites a GitHub Actions expression into the
+// dotted, lower-case spelling the patterns below are written against. GitHub
+// evaluates these expressions case-insensitively and lets a property be reached
+// with either dereference (github.event.issue.title) or index syntax
+// (github.event['issue']['title'], github['event'].issue.title), so without
+// this a re-cased or index-form expression accesses the same untrusted value
+// while slipping past detection. This matches the case-insensitive handling the
+// toJSON pattern already relies on. Numeric indexes like commits[0] are left
+// alone because the patterns already account for them.
+func normalizeContextExpression(expr string) string {
+	return strings.ToLower(contextIndexPattern.ReplaceAllString(expr, ".$1"))
+}
+
 func containsUntrustedContextPattern(variable string) bool {
+	variable = normalizeContextExpression(variable)
 	// GitHub event context details that may be attacker controlled.
 	// See https://securitylab.github.com/research/github-actions-untrusted-input/
 	untrustedContextPattern := regexp.MustCompile(
@@ -191,7 +209,7 @@ func checkJobForUntrustedCodeCheckout(job *actionlint.Job, path string,
 		if !ok || e.Uses == nil {
 			continue
 		}
-		if !strings.Contains(e.Uses.Value, "actions/checkout") {
+		if !strings.Contains(strings.ToLower(e.Uses.Value), "actions/checkout") {
 			continue
 		}
 		// Check for reference. If not defined for a pull_request_target event, this defaults to
@@ -201,8 +219,9 @@ func checkJobForUntrustedCodeCheckout(job *actionlint.Job, path string,
 			continue
 		}
 
-		if strings.Contains(ref.Value.Value, checkoutUntrustedPullRequestRef) ||
-			strings.Contains(ref.Value.Value, checkoutUntrustedWorkflowRunRef) {
+		refValue := normalizeContextExpression(ref.Value.Value)
+		if strings.Contains(refValue, checkoutUntrustedPullRequestRef) ||
+			strings.Contains(refValue, checkoutUntrustedWorkflowRunRef) {
 			line := fileparser.GetLineNumber(step.Pos)
 			pdata.Workflows = append(pdata.Workflows,
 				checker.DangerousWorkflow{

--- a/checks/raw/dangerous_workflow_test.go
+++ b/checks/raw/dangerous_workflow_test.go
@@ -135,6 +135,51 @@ func TestUntrustedContextVariables(t *testing.T) {
 			variable: "toJSON(github.repository)",
 			expected: false,
 		},
+		{
+			name:     "untrusted event with index leaf",
+			variable: "github.event.issue['title']",
+			expected: true,
+		},
+		{
+			name:     "untrusted event with double-quoted index leaf",
+			variable: "github.event.pull_request[\"body\"]",
+			expected: true,
+		},
+		{
+			name:     "untrusted event fully indexed",
+			variable: "github['event']['issue']['title']",
+			expected: true,
+		},
+		{
+			name:     "untrusted head_ref indexed",
+			variable: "github['head_ref']",
+			expected: true,
+		},
+		{
+			name:     "toJSON github event indexed",
+			variable: "toJSON(github['event'])",
+			expected: true,
+		},
+		{
+			name:     "trusted event with index leaf",
+			variable: "github.event.pull_request['number']",
+			expected: false,
+		},
+		{
+			name:     "untrusted event upper-cased property",
+			variable: "github.event.issue.TITLE",
+			expected: true,
+		},
+		{
+			name:     "untrusted context re-cased",
+			variable: "GitHub.Event.Issue.Title",
+			expected: true,
+		},
+		{
+			name:     "untrusted head_ref re-cased",
+			variable: "github.HEAD_REF",
+			expected: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -174,6 +219,11 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 			expected: ret{nb: 1},
 		},
 		{
+			name:     "run untrusted code checkout test with index syntax",
+			filename: ".github/workflows/github-workflow-dangerous-pattern-untrusted-checkout-index.yml",
+			expected: ret{nb: 1},
+		},
+		{
 			name:     "run trusted code checkout test",
 			filename: ".github/workflows/github-workflow-dangerous-pattern-trusted-checkout.yml",
 			expected: ret{nb: 0},
@@ -186,6 +236,11 @@ func TestGithubDangerousWorkflow(t *testing.T) {
 		{
 			name:     "run script injection",
 			filename: ".github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection.yml",
+			expected: ret{nb: 1},
+		},
+		{
+			name:     "run script injection with index syntax",
+			filename: ".github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection-index.yml",
 			expected: ret{nb: 1},
 		},
 		{

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-untrusted-checkout-index.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-untrusted-checkout-index.yml
@@ -1,0 +1,29 @@
+# Copyright 2021 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+on:
+  pull_request_target
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/Checkout@v2
+      with:
+        ref: ${{ github.event['pull_request'].head.sha }}
+
+    - uses: actions/setup-node@v1
+    - run: |
+        npm install
+        npm build

--- a/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection-index.yml
+++ b/checks/testdata/.github/workflows/github-workflow-dangerous-pattern-untrusted-script-injection-index.yml
@@ -1,0 +1,27 @@
+# Copyright 2021 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+on: [issues]
+
+jobs:
+  build:
+    name: Build and test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check title
+      run: |
+        echo "Some first line"
+        if [[ ! ${{ github.event['issue']['title'] }} =~ ^.*:\ .*$ ]]; then
+          echo "Bad issue title"
+          exit 1
+        fi


### PR DESCRIPTION
#### What kind of change does this PR introduce?

Bug fix for the DangerousWorkflow check.

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

**Untrusted-input detection only recognizes the lower-case, dotted spelling of a GitHub expression.**

`containsUntrustedContextPattern` gates on the literal substrings `github.event.` / `github.head_ref` and a case-sensitive dotted regex, and `checkJobForUntrustedCodeCheckout` matches `actions/checkout` and the untrusted ref with case-sensitive `strings.Contains`. GitHub evaluates expressions case-insensitively and lets a property be reached with index syntax, so all of these access the same attacker-controlled value yet slip past detection:

```yaml
# script injection, reported as safe today
- run: echo "${{ github.event['issue']['title'] }}"
- run: echo "${{ github.event.issue.TITLE }}"
# untrusted checkout under pull_request_target, reported as safe today
- uses: actions/Checkout@v4
  with:
    ref: ${{ github.event['pull_request'].head.sha }}
```

The `toJSON` path is already matched case-insensitively (`(?i)` at the toJSON regex, with a matching test), so this was an inconsistency in the same function rather than a deliberate choice.

#### What is the new behavior (if this is a feature change)?

`normalizeContextExpression` rewrites quoted index accessors (`['x']`/`["x"]`) to dotted form and lower-cases the expression before matching; it runs in both the script-injection and untrusted-checkout paths, and the action name is lower-cased so `actions/Checkout` is still recognized. Numeric indexes like `commits[0]` are left alone since the existing patterns already handle them. Valid inputs are unaffected and the reported snippet keeps its original casing.

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

NONE

#### Special notes for your reviewer

Kept to the two detectors that match context expressions; the `curl -o`/alternate-shell gaps in the pinning check are unrelated and left for a separate change. New regression tests fail on `main` and pass here.

#### Does this PR introduce a user-facing change?

Repositories that previously evaded the DangerousWorkflow check by using index-syntax or re-cased expressions will now be flagged.

```release-note
DangerousWorkflow: detect untrusted script injection and untrusted checkouts written with index-syntax or re-cased GitHub expressions.
```
