### PR TITLE
:sparkles: Pinned-Dependencies supports GitHub self-repository action syntax

### DIFF
--- a/checks/raw/pinned_dependencies.go
+++ b/checks/raw/pinned_dependencies.go
@@ -768,10 +768,7 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 		}
 
 		if job.WorkflowCall != nil && job.WorkflowCall.Uses != nil {
-			//nolint:lll
-			// Check whether this is an action defined in the same repo,
-			// https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#referencing-an-action-in-the-same-repository-where-a-workflow-file-uses-the-action.
-			if !strings.HasPrefix(job.WorkflowCall.Uses.Value, "./") {
+			if !isSameRepositoryAction(job.WorkflowCall.Uses.Value) {
 				dep := newGHActionDependency(job.WorkflowCall.Uses.Value, pathfn, job.WorkflowCall.Uses.Pos.Line)
 				pdata.Dependencies = append(pdata.Dependencies, dep)
 			}
@@ -794,10 +791,7 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 				continue
 			}
 
-			//nolint:lll
-			// Check whether this is an action defined in the same repo,
-			// https://docs.github.com/en/actions/learn-github-actions/finding-and-customizing-actions#referencing-an-action-in-the-same-repository-where-a-workflow-file-uses-the-action.
-			if strings.HasPrefix(execAction.Uses.Value, "./") {
+			if isSameRepositoryAction(execAction.Uses.Value) {
 				continue
 			}
 			dep := newGHActionDependency(execAction.Uses.Value, pathfn, execAction.Uses.Pos.Line)
@@ -806,6 +800,16 @@ var validateGitHubActionWorkflow fileparser.DoWhileTrueOnFileContent = func(
 	}
 
 	return true, nil
+}
+
+// isSameRepositoryAction reports whether actionUses references an action or
+// reusable workflow in the same repository using either the workspace-relative
+// or self-repository syntax.
+// See https://docs.github.com/en/actions/how-tos/write-workflows/choose-what-workflows-do/find-and-customize-actions#adding-an-action-from-the-same-repository.
+//
+//nolint:lll
+func isSameRepositoryAction(actionUses string) bool {
+	return strings.HasPrefix(actionUses, "./") || strings.HasPrefix(actionUses, "$/")
 }
 
 func newGHActionDependency(uses, pathfn string, line int) checker.Dependency {
@@ -831,8 +835,7 @@ func newGHActionDependency(uses, pathfn string, line int) checker.Dependency {
 }
 
 func isActionDependencyPinned(actionUses string) bool {
-	localActionRegex := regexp.MustCompile(`^\..+[^/]`)
-	if localActionRegex.MatchString(actionUses) {
+	if isSameRepositoryAction(actionUses) {
 		return true
 	}
 

--- a/checks/raw/pinned_dependencies_test.go
+++ b/checks/raw/pinned_dependencies_test.go
@@ -60,6 +60,10 @@ func TestGithubWorkflowPinning(t *testing.T) {
 			filename: "./testdata/.github/workflows/workflow-local-action.yaml",
 		},
 		{
+			name:     "Self-repository action workflow",
+			filename: "./testdata/.github/workflows/workflow-self-repository-action.yaml",
+		},
+		{
 			name:     "Non-pinned workflow",
 			filename: "./testdata/.github/workflows/workflow-not-pinned.yaml",
 			warns:    2,
@@ -162,6 +166,11 @@ func TestGithubWorkflowPinningPattern(t *testing.T) {
 		{
 			desc:     "local workflow",
 			uses:     "./.github/uses.yml",
+			ispinned: true,
+		},
+		{
+			desc:     "self-repository action",
+			uses:     "$/.github/actions/setup-dotnet",
 			ispinned: true,
 		},
 		{

--- a/checks/raw/testdata/.github/workflows/workflow-self-repository-action.yaml
+++ b/checks/raw/testdata/.github/workflows/workflow-self-repository-action.yaml
@@ -1,0 +1,25 @@
+# Copyright 2026 OpenSSF Scorecard Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+on:
+  workflow_dispatch:
+
+jobs:
+  self-repository-action:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Use an action from this repository
+        uses: $/.github/actions/setup-dotnet
+
+  self-repository-workflow:
+    uses: $/.github/workflows/reusable-workflow.yml


### PR DESCRIPTION
#### What kind of change does this PR introduce?

(Is it a bug fix, feature, docs update, something else?)

- [x] PR title follows the guidelines defined in our [pull request documentation](https://github.com/ossf/scorecard/blob/main/CONTRIBUTING.md#pr-process)

#### What is the current behavior?

Lack of support for new GitHub action syntaxt `$/your-local-file-with-actions`

#### What is the new behavior (if this is a feature change)?

- [x] Tests for the changes have been added (for bug fixes/features)

#### Which issue(s) this PR fixes

Fixes #5232
Fixes #5216

#### Special notes for your reviewer

#### Does this PR introduce a user-facing change?

```release-note
Pinned-Dependencies supports GitHub self-repository action syntax
```
