### PR TITLE
:bug: Detect curl downloads written with -o or -O

### DIFF
--- a/checks/raw/shell_download_validate.go
+++ b/checks/raw/shell_download_validate.go
@@ -120,6 +120,45 @@ func getWgetOutputFile(cmd []string) (pathfn string, ok bool, err error) {
 	return "", false, nil
 }
 
+// getCurlOutputFile returns the file curl writes to, if any.
+//
+// Unlike wget there is no filename to fall back on: with no output flag curl
+// writes to stdout, so nothing lands on disk to be executed later. curl's short
+// options are case-sensitive and -o and -O mean different things, so they are
+// matched exactly rather than with EqualFold.
+func getCurlOutputFile(cmd []string) (pathfn string, ok bool, err error) {
+	if !isBinaryName("curl", cmd[0]) {
+		return "", false, nil
+	}
+
+	// -o/--output names the file directly.
+	for i := 1; i < len(cmd)-1; i++ {
+		if cmd[i] == "-o" || cmd[i] == "--output" {
+			return cmd[i+1], true, nil
+		}
+	}
+
+	// -O/--remote-name writes to the basename of the URL.
+	for i := 1; i < len(cmd); i++ {
+		if cmd[i] != "-O" && cmd[i] != "--remote-name" {
+			continue
+		}
+		for j := 1; j < len(cmd); j++ {
+			if !strings.HasPrefix(cmd[j], "http") {
+				continue
+			}
+			u, err := url.Parse(cmd[j])
+			if err != nil {
+				return "", false, sce.WithMessage(sce.ErrScorecardInternal, fmt.Sprintf("url.Parse: %v", err))
+			}
+			return path.Base(u.Path), true, nil
+		}
+		return "", false, nil
+	}
+
+	return "", false, nil
+}
+
 func getGsutilOutputFile(cmd []string) (pathfn string, ok bool, err error) {
 	if isBinaryName("gsutil", cmd[0]) {
 		for i := 1; i < len(cmd)-1; i++ {
@@ -174,6 +213,12 @@ func getOutputFile(cmd []string) (pathfn string, ok bool, err error) {
 
 	// Wget.
 	fn, b, err := getWgetOutputFile(cmd)
+	if err != nil || b {
+		return fn, b, err
+	}
+
+	// Curl.
+	fn, b, err = getCurlOutputFile(cmd)
 	if err != nil || b {
 		return fn, b, err
 	}

--- a/checks/raw/shell_download_validate_test.go
+++ b/checks/raw/shell_download_validate_test.go
@@ -705,3 +705,107 @@ func Test_hasUnpinnedURLs(t *testing.T) {
 		})
 	}
 }
+
+func Test_getCurlOutputFile(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		cmd      []string
+		wantFile string
+		wantOK   bool
+	}{
+		{
+			name:     "short output flag",
+			cmd:      []string{"curl", "-o", "d.sh", "https://example.com/install.sh"},
+			wantFile: "d.sh",
+			wantOK:   true,
+		},
+		{
+			name:     "long output flag",
+			cmd:      []string{"curl", "--output", "d.sh", "https://example.com/install.sh"},
+			wantFile: "d.sh",
+			wantOK:   true,
+		},
+		{
+			name:     "output flag after the url",
+			cmd:      []string{"curl", "-sSL", "https://example.com/install.sh", "-o", "d.sh"},
+			wantFile: "d.sh",
+			wantOK:   true,
+		},
+		{
+			name:     "remote name uses the url basename",
+			cmd:      []string{"curl", "-O", "https://example.com/path/install.sh"},
+			wantFile: "install.sh",
+			wantOK:   true,
+		},
+		{
+			name:     "long remote name",
+			cmd:      []string{"curl", "--remote-name", "https://example.com/path/install.sh"},
+			wantFile: "install.sh",
+			wantOK:   true,
+		},
+		{
+			// Without an output flag curl writes to stdout, so nothing lands on disk.
+			name:   "no output flag",
+			cmd:    []string{"curl", "-sSL", "https://example.com/install.sh"},
+			wantOK: false,
+		},
+		{
+			name:   "not curl",
+			cmd:    []string{"wget", "-O", "d.sh", "https://example.com/install.sh"},
+			wantOK: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotFile, gotOK, err := getCurlOutputFile(tt.cmd)
+			if err != nil {
+				t.Fatalf("getCurlOutputFile() error = %v", err)
+			}
+			if gotOK != tt.wantOK {
+				t.Errorf("getCurlOutputFile() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotFile != tt.wantFile {
+				t.Errorf("getCurlOutputFile() file = %q, want %q", gotFile, tt.wantFile)
+			}
+		})
+	}
+}
+
+// A curl download written with -o was never recorded as a fetched file, so the
+// later execution of that file was not flagged, while the wget spelling was.
+func Test_getOutputFile_curl(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		cmd      []string
+		wantFile string
+		wantOK   bool
+	}{
+		{
+			name:     "wget, the spelling that already worked",
+			cmd:      []string{"wget", "-O", "d.sh", "https://example.com/install.sh"},
+			wantFile: "d.sh",
+			wantOK:   true,
+		},
+		{
+			name:     "curl with -o",
+			cmd:      []string{"curl", "-o", "d.sh", "https://example.com/install.sh"},
+			wantFile: "d.sh",
+			wantOK:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			gotFile, gotOK, err := getOutputFile(tt.cmd)
+			if err != nil {
+				t.Fatalf("getOutputFile() error = %v", err)
+			}
+			if gotOK != tt.wantOK || gotFile != tt.wantFile {
+				t.Errorf("getOutputFile() = (%q, %v), want (%q, %v)", gotFile, gotOK, tt.wantFile, tt.wantOK)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix in the Pinned-Dependencies check.

## What is the current behavior?

`getOutputFile` dispatches to `getWgetOutputFile`, `getGsutilOutputFile` and `getAWSOutputFile`. There is no curl handler, even though `curl` is the first entry in `downloadUtils`. curl only works in the download-then-execute path through the `>` redirect branch, so a download written with `-o`, `--output`, `-O` or `--remote-name` is never recorded as a fetched file, and the later execution of that file is not flagged.

Two local repositories differing only in how the download is spelled, each `install.sh` being a fetch of an unpinned URL followed by `bash d.sh`:

```
scorecard (current)   wget -O d.sh URL ; bash d.sh     Aggregate score: 0.0 / 10
scorecard (current)   curl -o d.sh URL ; bash d.sh     Aggregate score: ?          <- nothing found
```

The wget row is the positive control: the check itself works, it just does not see the curl spelling.

## What is the new behavior?

Both are caught:

```
scorecard (this PR)   wget -O d.sh URL ; bash d.sh     Aggregate score: 0.0 / 10
scorecard (this PR)   curl -o d.sh URL ; bash d.sh     Aggregate score: 0.0 / 10
                      dependency not pinned by hash detected -- score normalized to 0
```

`getCurlOutputFile` handles `-o`/`--output` and `-O`/`--remote-name`. It is a separate handler rather than a reuse of the wget one for two reasons worth stating, since they are easy to get wrong:

- `getWgetOutputFile` falls back to deriving a filename from the URL when no `-O` is present. curl with no output flag writes to stdout, so nothing lands on disk, and borrowing that fallback would invent a download that never happened. The new handler returns `false` in that case.
- curl's short options are case-sensitive and `-o` and `-O` mean different things, so they are matched exactly. `getWgetOutputFile` uses `strings.EqualFold`, which would conflate them.

## Which issue(s) this PR fixes

No linked issue.

## Special notes for your reviewer

One known limitation I did not try to cover: bundled short options such as `curl -sSLo d.sh URL` still go undetected, since the flag is not its own argument. That needs argument splitting and felt like a separate change.

Tests added to `checks/raw/shell_download_validate_test.go`: a table for `getCurlOutputFile` covering both output spellings, both remote-name spellings, the flag-after-URL ordering, the no-output-flag case, and a non-curl command; plus a `getOutputFile` test pairing the wget and curl spellings so the asymmetry itself is pinned. `go test ./checks/raw/` passes.
